### PR TITLE
Add remote submission of jobs

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -30,7 +30,7 @@ func (cfg nodeCfg) Prepare() error {
 	netceptor.MainInstance = netceptor.New(cfg.ID, allowedPeers)
 	controlsvc.MainInstance = controlsvc.New(true, netceptor.MainInstance)
 	var err error
-	workceptor.MainInstance, err = workceptor.New(controlsvc.MainInstance, cfg.ID, cfg.DataDir)
+	workceptor.MainInstance, err = workceptor.New(controlsvc.MainInstance, netceptor.MainInstance, cfg.DataDir)
 	if err != nil {
 		return err
 	}

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -647,7 +647,6 @@ func (w *Workceptor) GetResults(unitID string, startPos int64) (chan []byte, err
 		buf := make([]byte, 1024)
 		for {
 			if stdout == nil {
-				time.Sleep(250 * time.Millisecond)
 				stdout, err = os.Open(stdoutFilename)
 				if err != nil {
 					continue
@@ -684,6 +683,9 @@ func (w *Workceptor) GetResults(unitID string, startPos int64) (chan []byte, err
 					debug.Printf("Stdout complete - closing channel\n")
 					return
 				}
+				// We got to the end of the file but stdout isn't complete yet, so we need to wait
+				// until the running process writes more output.
+				time.Sleep(250 * time.Millisecond)
 				continue
 			} else if err != nil {
 				debug.Printf("Error reading stdout: %s\n", err)

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -1,16 +1,22 @@
 package workceptor
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"github.com/fsnotify/fsnotify"
 	"github.com/ghjm/sockceptor/pkg/controlsvc"
 	"github.com/ghjm/sockceptor/pkg/debug"
+	"github.com/ghjm/sockceptor/pkg/netceptor"
 	"github.com/ghjm/sockceptor/pkg/randstr"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"path"
+	"reflect"
+	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -20,6 +26,12 @@ import (
 // NewWorkerFunc is called to initialize a new, empty WorkType object
 type NewWorkerFunc func() WorkType
 
+// Work sleep constants
+const (
+	SuccessWorkSleep = 1 * time.Second // Normal time to wait between checks
+	MaxWorkSleep     = 1 * time.Minute // Max time to ever wait between checks
+)
+
 // Work state constants
 const (
 	WorkStatePending   = 0
@@ -28,10 +40,20 @@ const (
 	WorkStateFailed    = 3
 )
 
+// IsComplete returns true if a given WorkState indicates the job is finished
+func IsComplete(WorkState int) bool {
+	return WorkState == WorkStateSucceeded || WorkState == WorkStateFailed
+}
+
 // StatusInfo describes the status of a unit of work
 type StatusInfo struct {
-	State  int
-	Detail string
+	State        int
+	Detail       string
+	StdoutSize   int64
+	Node         string
+	WorkType     string
+	RemoteUnitID string
+	Params       string
 }
 
 // WorkType represents a unique type of worker
@@ -47,15 +69,15 @@ type workType struct {
 
 // Internal data for a single unit of work
 type workUnit struct {
-	started bool
-	worker  WorkType
-	state   int
-	detail  string
+	started  bool
+	released bool
+	worker   WorkType
+	status   *StatusInfo
 }
 
 // Workceptor is the main object that handles unit-of-work management
 type Workceptor struct {
-	nodeID          string
+	nc              *netceptor.Netceptor
 	dataDir         string
 	workTypes       map[string]*workType
 	activeUnitsLock *sync.RWMutex
@@ -72,6 +94,7 @@ func (si *StatusInfo) Save(filename string) error {
 	if err != nil {
 		return err
 	}
+	jsonBytes = append(jsonBytes, '\n')
 	_, err = file.Write(jsonBytes)
 	if err != nil {
 		return err
@@ -104,12 +127,15 @@ func (si *StatusInfo) Load(filename string) error {
 	return nil
 }
 
-func saveState(unitdir string, state int, detail string) error {
-	si := &StatusInfo{
-		State:  state,
-		Detail: detail,
-	}
-	return si.Save(path.Join(unitdir, "status"))
+// saveState updates the status metadata file in the unitdir
+func saveState(unitdir string, state int, detail string, stdoutSize int64) error {
+	statusFilename := path.Join(unitdir, "status")
+	si := &StatusInfo{}
+	_ = si.Load(statusFilename)
+	si.State = state
+	si.Detail = detail
+	si.StdoutSize = stdoutSize
+	return si.Save(statusFilename)
 }
 
 // WorkStateToString returns a string representation of a WorkState
@@ -129,13 +155,13 @@ func WorkStateToString(workState int) string {
 }
 
 // New constructs a new Workceptor instance
-func New(cs *controlsvc.Server, nodeID string, dataDir string) (*Workceptor, error) {
+func New(cs *controlsvc.Server, nc *netceptor.Netceptor, dataDir string) (*Workceptor, error) {
 	if dataDir == "" {
 		dataDir = path.Join(os.TempDir(), "receptor")
 	}
-	dataDir = path.Join(dataDir, nodeID)
+	dataDir = path.Join(dataDir, nc.NodeID())
 	w := &Workceptor{
-		nodeID:          nodeID,
+		nc:              nc,
 		dataDir:         dataDir,
 		workTypes:       make(map[string]*workType),
 		activeUnitsLock: &sync.RWMutex{},
@@ -145,6 +171,7 @@ func New(cs *controlsvc.Server, nodeID string, dataDir string) (*Workceptor, err
 	if err != nil {
 		return nil, fmt.Errorf("could not add work control function: %s", err)
 	}
+	w.scanForUnits()
 	return w, nil
 }
 
@@ -163,16 +190,17 @@ func (w *Workceptor) RegisterWorker(typeName string, newWorker NewWorkerFunc) er
 	return nil
 }
 
-func (w *Workceptor) updateStatus(filename string, unit *workUnit) {
+// updateLocalStatus updates the status information in a workUnit from disk
+func (w *Workceptor) updateLocalStatus(filename string, unit *workUnit) {
 	si := &StatusInfo{}
 	err := si.Load(filename)
 	if err == nil {
-		unit.state = si.State
-		unit.detail = si.Detail
+		unit.status = si
 	}
 }
 
-func (w *Workceptor) monitorStatus(unitdir string, unit *workUnit) {
+// monitorLocalStatus watches a unit dir and keeps the workUnit up to date with status changes
+func (w *Workceptor) monitorLocalStatus(unitdir string, unit *workUnit) {
 	statusFile := path.Join(unitdir, "status")
 	watcher, err := fsnotify.NewWatcher()
 	if err == nil {
@@ -202,29 +230,186 @@ func (w *Workceptor) monitorStatus(unitdir string, unit *workUnit) {
 		select {
 		case event := <-watcherEvents:
 			if event.Op&fsnotify.Write == fsnotify.Write {
-				w.updateStatus(statusFile, unit)
+				w.updateLocalStatus(statusFile, unit)
 			}
 		case <-time.After(time.Second):
 			newFi, err := os.Stat(statusFile)
 			if err == nil {
 				if fi == nil || fi.ModTime() != newFi.ModTime() {
 					fi = newFi
-					w.updateStatus(statusFile, unit)
+					w.updateLocalStatus(statusFile, unit)
 				}
 			}
 		}
-		if unit.state == WorkStateSucceeded || unit.state == WorkStateFailed {
+		if IsComplete(unit.status.State) {
 			break
 		}
 	}
 }
 
-// PreStartUnit creates a new work unit and generates an identifier for it
-func (w *Workceptor) PreStartUnit(workType string) (string, error) {
-	wT, ok := w.workTypes[workType]
-	if !ok {
-		return "", fmt.Errorf("unknown work type %s", workType)
+// monitorRemoteStatus watches a remote unit on another node and maintains local status
+func (w *Workceptor) monitorRemoteStatus(unit *workUnit, unitID string) {
+	var conn net.Conn
+	var err error
+	var nextDelay = SuccessWorkSleep
+	unitdir := path.Join(w.dataDir, unitID)
+	submitIDRegex := regexp.MustCompile("with ID ([a-zA-Z0-9]+)\\.")
+	for {
+		if conn != nil && !reflect.ValueOf(conn).IsNil() {
+			_ = conn.Close()
+		}
+		time.Sleep(nextDelay)
+		nextDelay = time.Duration(1.5 * float64(nextDelay))
+		if nextDelay > MaxWorkSleep {
+			nextDelay = MaxWorkSleep
+		}
+		if unit.released {
+			return
+		}
+		//TODO: this assumes every work-processing node will have a control service named
+		//     "control." Perhaps we need to hardcode this as something we always start.
+		//     We also need to deal with authenticating this connection, supplying a TLS
+		//     client certificate and CA bundle, etc.
+		conn, err = w.nc.Dial(unit.status.Node, "control", nil)
+		if err != nil {
+			debug.Printf("Connection failed to %s: %s\n", unit.status.Node, err)
+			continue
+		}
+		reader := bufio.NewReader(conn)
+		hello, err := reader.ReadString('\n')
+		if !strings.Contains(hello, unit.status.Node) {
+			debug.Printf("While expecting node ID %s, got message: %s. Exiting.\n", unit.status.Node,
+				strings.TrimRight(hello, "\n"))
+		}
+		if unit.status.RemoteUnitID == "" {
+			_, err = conn.Write([]byte(fmt.Sprintf("work start %s\n", unit.status.WorkType)))
+			if err != nil {
+				debug.Printf("Write error sending to %s: %s\n", unit.status.Node, err)
+				continue
+			}
+			response, err := reader.ReadString('\n')
+			if err != nil {
+				debug.Printf("Read error reading from %s: %s\n", unit.status.Node, err)
+				continue
+			}
+			match := submitIDRegex.FindSubmatch([]byte(response))
+			if match == nil || len(match) != 2 {
+				debug.Printf("Could not parse response: %s\n", strings.TrimRight(response, "\n"))
+				continue
+			}
+			unit.status.RemoteUnitID = string(match[1])
+			err = unit.status.Save(path.Join(unitdir, "status"))
+			if err != nil {
+				debug.Printf("Error saving local status file: %s\n", err)
+				continue
+			}
+			stdin, err := os.Open(path.Join(unitdir, "stdin"))
+			if err != nil {
+				debug.Printf("Error opening stdin file: %s\n", err)
+				continue
+			}
+			_, err = io.Copy(conn, stdin)
+			if err != nil {
+				debug.Printf("Error sending stdin file: %s\n", err)
+				continue
+			}
+			cw, ok := conn.(interface{ CloseWrite() error })
+			if ok {
+				err := cw.CloseWrite()
+				if err != nil {
+					debug.Printf("Error closing write: %s\n", err)
+					continue
+				}
+				response, err = reader.ReadString('\n')
+				if err != nil {
+					debug.Printf("Read error reading from %s: %s\n", unit.status.Node, err)
+					continue
+				}
+				debug.Printf(response)
+			}
+			continue
+		}
+		if !IsComplete(unit.status.State) {
+			// Check if remote job has completed yet
+			_, err = conn.Write([]byte(fmt.Sprintf("work status %s\n", unit.status.RemoteUnitID)))
+			if err != nil {
+				debug.Printf("Write error sending to %s: %s\n", unit.status.Node, err)
+				continue
+			}
+			status, err := reader.ReadString('\n')
+			if err != nil {
+				debug.Printf("Read error reading from %s: %s\n", unit.status.Node, err)
+				continue
+			}
+			if status[:5] == "ERROR" {
+				if strings.Contains(status, "unknown work unit") {
+					debug.Printf("Work unit %s on node %s appears to be gone.\n", unit.status.RemoteUnitID, unit.status.Node)
+					unit.status.State = WorkStateFailed
+					unit.status.Detail = "Remote work unit is gone"
+					_ = unit.status.Save(path.Join(unitdir, "status"))
+					return
+				}
+				debug.Printf("Remote error%s\n", strings.TrimRight(status[5:], "\n"))
+				continue
+			}
+			debug.Printf("%s\n", status)
+			si := StatusInfo{}
+			err = json.Unmarshal([]byte(status), &si)
+			if err != nil {
+				debug.Printf("Error unmarshalling JSON: %s\n", status)
+				continue
+			}
+			unit.status.State = si.State
+			unit.status.Detail = si.Detail
+			unit.status.StdoutSize = si.StdoutSize
+			err = unit.status.Save(path.Join(unitdir, "status"))
+			if err != nil {
+				debug.Printf("Error saving local status file: %s\n", err)
+				continue
+			}
+		}
+		stdoutFilename := path.Join(unitdir, "stdout")
+		stdoutStat, err := os.Stat(stdoutFilename)
+		var stdoutCurSize int64
+		if err != nil {
+			stdoutCurSize = 0
+		} else {
+			stdoutCurSize = stdoutStat.Size()
+		}
+		if IsComplete(unit.status.State) && err == nil && stdoutCurSize >= unit.status.StdoutSize {
+			debug.Printf("Transfer complete, monitor exiting\n")
+			return
+		}
+		if !os.IsExist(err) || stdoutCurSize < unit.status.StdoutSize {
+			_, err = conn.Write([]byte(fmt.Sprintf("work results %s %d\n", unit.status.RemoteUnitID, stdoutCurSize)))
+			if err != nil {
+				debug.Printf("Write error sending to %s: %s\n", unit.status.Node, err)
+				continue
+			}
+			status, err := reader.ReadString('\n')
+			if err != nil {
+				debug.Printf("Read error reading from %s: %s\n", unit.status.Node, err)
+				continue
+			}
+			if !strings.Contains(status, "Streaming results") {
+				debug.Printf("Remote node %s did not stream results\n", unit.status.Node)
+				continue
+			}
+			stdout, err := os.OpenFile(stdoutFilename, os.O_CREATE+os.O_APPEND+os.O_WRONLY, 0600)
+			if err != nil {
+				debug.Printf("Could not open stdout file %s: %s\n", stdoutFilename, err)
+				continue
+			}
+			_, err = io.Copy(stdout, conn)
+			if err != nil {
+				debug.Printf("Error copying to stdout file %s: %s\n", stdoutFilename, err)
+				continue
+			}
+		}
 	}
+}
+
+func (w *Workceptor) generateUnitID() (string, error) {
 	w.activeUnitsLock.Lock()
 	defer w.activeUnitsLock.Unlock()
 	var ident string
@@ -232,20 +417,75 @@ func (w *Workceptor) PreStartUnit(workType string) (string, error) {
 		ident = randstr.RandomString(8)
 		_, ok := w.activeUnits[ident]
 		if !ok {
-			break
+			unitdir := path.Join(w.dataDir, ident)
+			_, err := os.Stat(unitdir)
+			if err == nil {
+				continue
+			}
+			return ident, os.MkdirAll(unitdir, 0700)
 		}
 	}
+}
+
+// PreStartUnit creates a new work unit and generates an identifier for it
+func (w *Workceptor) PreStartUnit(nodeID string, workTypeName string, params string) (string, error) {
+	var wT *workType
+	if nodeID == w.nc.NodeID() {
+		var ok bool
+		wT, ok = w.workTypes[workTypeName]
+		if !ok {
+			return "", fmt.Errorf("unknown work type %s", workTypeName)
+		}
+	}
+	ident, err := w.generateUnitID()
+	if err != nil {
+		return "", err
+	}
+	var worker WorkType
+	if wT != nil {
+		worker = wT.newWorker()
+	}
+	status := &StatusInfo{
+		State:      WorkStatePending,
+		Detail:     "Waiting for Input Data",
+		StdoutSize: 0,
+		Node:       nodeID,
+		WorkType:   workTypeName,
+		Params:     params,
+	}
+	err = status.Save(path.Join(w.dataDir, ident, "status"))
+	if err != nil {
+		return "", err
+	}
+	w.activeUnitsLock.Lock()
+	defer w.activeUnitsLock.Unlock()
 	w.activeUnits[ident] = &workUnit{
-		started: false,
-		worker:  wT.newWorker(),
-		state:   WorkStatePending,
-		detail:  "Waiting for Input Data",
+		started:  false,
+		released: false,
+		worker:   worker,
+		status:   status,
 	}
 	return ident, nil
 }
 
+// startLocalUnit starts running a local unit of work
+func (w *Workceptor) startLocalUnit(unit *workUnit, unitdir string) error {
+	if unit.worker != nil {
+		err := unit.worker.Start(unit.status.Params, unitdir)
+		if err != nil {
+			return fmt.Errorf("error starting work: %s", err)
+		}
+		unit.started = true
+		go w.monitorLocalStatus(unitdir, unit)
+	} else {
+		return fmt.Errorf("tried to start work without worker")
+	}
+	return nil
+}
+
 // StartUnit starts a unit of work
-func (w *Workceptor) StartUnit(unitID string, params string, unitdir string) error {
+func (w *Workceptor) StartUnit(unitID string) error {
+	unitdir := path.Join(w.dataDir, unitID)
 	w.activeUnitsLock.Lock()
 	defer w.activeUnitsLock.Unlock()
 	unit, ok := w.activeUnits[unitID]
@@ -255,16 +495,10 @@ func (w *Workceptor) StartUnit(unitID string, params string, unitdir string) err
 	if unit.started {
 		return fmt.Errorf("work unit %s was already started", unitID)
 	}
-	if unit.worker != nil {
-		err := unit.worker.Start(params, unitdir)
-		if err != nil {
-			return fmt.Errorf("error starting work: %s", err)
-		}
-		unit.started = true
-		go w.monitorStatus(unitdir, unit)
-	} else {
-		return fmt.Errorf("tried to start work without worker")
+	if unit.status.Node == w.nc.NodeID() {
+		return w.startLocalUnit(unit, unitdir)
 	}
+	go w.monitorRemoteStatus(unit, unitID)
 	return nil
 }
 
@@ -282,11 +516,15 @@ func (w *Workceptor) scanForUnits() {
 			if !ok {
 				si := &StatusInfo{}
 				_ = si.Load(path.Join(w.dataDir, fi.Name(), "status"))
-				w.activeUnits[fi.Name()] = &workUnit{
-					started: true, // If we're only finding it now, presumably it was once started
-					worker:  nil,
-					state:   si.State,
-					detail:  si.Detail,
+				unit := &workUnit{
+					started:  true, // If we're finding it now, we don't want to start it again
+					released: false,
+					worker:   nil,
+					status:   si,
+				}
+				w.activeUnits[fi.Name()] = unit
+				if si.Node != "" && si.Node != w.nc.NodeID() {
+					go w.monitorRemoteStatus(unit, fi.Name())
 				}
 			}
 		}
@@ -306,19 +544,36 @@ func (w *Workceptor) ListKnownUnitIDs() []string {
 }
 
 // UnitStatus returns the state of a unit
-func (w *Workceptor) UnitStatus(unitID string) (state int, detail string, err error) {
+func (w *Workceptor) UnitStatus(unitID string) (status *StatusInfo, err error) {
 	w.scanForUnits()
 	w.activeUnitsLock.RLock()
 	unit, ok := w.activeUnits[unitID]
 	w.activeUnitsLock.RUnlock()
 	if !ok {
-		return -1, "", fmt.Errorf("unknown work unit %s", unitID)
+		return nil, fmt.Errorf("unknown work unit %s", unitID)
 	}
-	return unit.state, unit.detail, nil
+	statusCopy := *unit.status
+	return &statusCopy, nil
+}
+
+func (w *Workceptor) unitStatusForCFR(unitID string) (map[string]interface{}, error) {
+	status, err := w.UnitStatus(unitID)
+	if err != nil {
+		return nil, err
+	}
+	retMap := make(map[string]interface{})
+	v := reflect.ValueOf(*status)
+	t := reflect.TypeOf(*status)
+	for i := 0; i < v.NumField(); i++ {
+		retMap[t.Field(i).Name] = v.Field(i).Interface()
+	}
+	retMap["StateName"] = WorkStateToString(status.State)
+	return retMap, nil
 }
 
 // CancelUnit cancels a unit, killing it if it is still running
 func (w *Workceptor) CancelUnit(unitID string) error {
+	//TODO: Handle remote cancellation
 	w.scanForUnits()
 	w.activeUnitsLock.RLock()
 	unit, ok := w.activeUnits[unitID]
@@ -333,25 +588,27 @@ func (w *Workceptor) CancelUnit(unitID string) error {
 			return err
 		}
 	}
-	unit.state = WorkStateFailed
-	unit.detail = "Cancelled"
+	unit.status.State = WorkStateFailed
+	unit.status.Detail = "Cancelled"
 	return nil
 }
 
 // ReleaseUnit releases a unit, canceling it if it is still running
 func (w *Workceptor) ReleaseUnit(unitID string) error {
+	//TODO: Handle remote release
 	err := w.CancelUnit(unitID)
 	if err != nil {
 		return err
 	}
 	w.activeUnitsLock.Lock()
-	_, ok := w.activeUnits[unitID]
+	unit, ok := w.activeUnits[unitID]
 	if !ok {
 		w.activeUnitsLock.Unlock()
 		return fmt.Errorf("unknown work unit %s", unitID)
 	}
 	delete(w.activeUnits, unitID)
 	w.activeUnitsLock.Unlock()
+	unit.released = true
 	err = os.RemoveAll(path.Join(w.dataDir, unitID))
 	if err != nil {
 		return err
@@ -360,7 +617,7 @@ func (w *Workceptor) ReleaseUnit(unitID string) error {
 }
 
 // GetResults returns a live stream of the results of a unit
-func (w *Workceptor) GetResults(unitID string) (chan []byte, error) {
+func (w *Workceptor) GetResults(unitID string, startPos int64) (chan []byte, error) {
 	w.scanForUnits()
 	w.activeUnitsLock.RLock()
 	unit, ok := w.activeUnits[unitID]
@@ -370,19 +627,21 @@ func (w *Workceptor) GetResults(unitID string) (chan []byte, error) {
 	}
 	resultChan := make(chan []byte)
 	go func() {
+		time.Sleep(250 * time.Millisecond)
 		unitdir := path.Join(w.dataDir, unitID)
 		stdoutFilename := path.Join(unitdir, "stdout")
 		var stdout *os.File
 		var err error
-		var filePos int64
+		filePos := startPos
 		buf := make([]byte, 1024)
 		for {
 			if stdout == nil {
 				stdout, err = os.Open(stdoutFilename)
 				if err != nil {
-					// Wait for stdout file to begin to exist
-					time.Sleep(250 * time.Millisecond)
+					continue
 				}
+			}
+			if stdout == nil {
 				continue
 			}
 			newPos, err := stdout.Seek(filePos, 0)
@@ -396,12 +655,23 @@ func (w *Workceptor) GetResults(unitID string) (chan []byte, error) {
 				resultChan <- buf[:n]
 			}
 			if err == io.EOF {
-				if unit.state == WorkStateSucceeded || unit.state == WorkStateFailed {
-					close(resultChan)
-					break
+				err = stdout.Close()
+				if err != nil {
+					debug.Printf("Error closing stdout\n")
+					return
 				}
-				// Don't spin loop the CPU checking and re-checking for EOF
-				time.Sleep(100 * time.Millisecond)
+				stat, err := os.Stat(stdoutFilename)
+				var stdoutSize int64
+				if err != nil {
+					stdoutSize = 0
+				} else {
+					stdoutSize = stat.Size()
+				}
+				if IsComplete(unit.status.State) && stdoutSize >= unit.status.StdoutSize {
+					close(resultChan)
+					debug.Printf("Stdout complete - closing channel\n")
+					return
+				}
 				continue
 			} else if err != nil {
 				debug.Printf("Error reading stdout: %s\n", err)
@@ -419,29 +689,35 @@ func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperation
 	}
 	tokens := strings.Split(params, " ")
 	switch tokens[0] {
-	case "start":
-		if len(tokens) < 2 {
-			return nil, fmt.Errorf("bad command")
+	case "start", "submit":
+		var workType string
+		var workNode string
+		var paramStart int
+		if tokens[0] == "start" {
+			if len(tokens) < 2 {
+				return nil, fmt.Errorf("bad command")
+			}
+			workNode = w.nc.NodeID()
+			workType = tokens[1]
+			paramStart = 2
+		} else {
+			if len(tokens) < 3 {
+				return nil, fmt.Errorf("bad command")
+			}
+			workNode = tokens[1]
+			workType = tokens[2]
+			paramStart = 3
+
 		}
-		workType := tokens[1]
 		params := ""
-		if len(tokens) > 2 {
-			params = strings.Join(tokens[2:], " ")
+		if len(tokens) > paramStart {
+			params = strings.Join(tokens[paramStart:], " ")
 		}
-		ident, err := w.PreStartUnit(workType)
+		ident, err := w.PreStartUnit(workNode, workType, params)
 		if err != nil {
 			return nil, err
 		}
-		unitdir := path.Join(w.dataDir, ident)
-		err = os.MkdirAll(unitdir, 0700)
-		if err != nil {
-			return nil, err
-		}
-		err = saveState(unitdir, WorkStatePending, "Waiting for Input")
-		if err != nil {
-			return nil, err
-		}
-		stdin, err := os.OpenFile(path.Join(unitdir, "stdin"), os.O_CREATE+os.O_WRONLY, 0700)
+		stdin, err := os.OpenFile(path.Join(w.dataDir, ident, "stdin"), os.O_CREATE+os.O_WRONLY, 0600)
 		if err != nil {
 			return nil, err
 		}
@@ -453,40 +729,38 @@ func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperation
 		if err != nil {
 			return nil, err
 		}
-		err = w.StartUnit(ident, params, unitdir)
+		err = w.StartUnit(ident)
 		if err != nil {
 			return nil, err
 		}
 		cfr := make(map[string]interface{})
 		cfr["unitid"] = ident
-		cfr["result"] = "Job Started"
+		if tokens[0] == "start" {
+			cfr["result"] = "Job Started"
+		} else {
+			cfr["result"] = "Job Submitted"
+		}
 		return cfr, nil
 	case "list":
 		unitList := w.ListKnownUnitIDs()
 		cfr := make(map[string]interface{})
 		for i := range unitList {
 			unitID := unitList[i]
-			state, detail, err := w.UnitStatus(unitID)
+			status, err := w.unitStatusForCFR(unitID)
 			if err != nil {
 				return nil, err
 			}
-			sub := make(map[string]interface{})
-			sub["state"] = WorkStateToString(state)
-			sub["detail"] = detail
-			cfr[unitID] = sub
+			cfr[unitID] = status
 		}
 		return cfr, nil
 	case "status":
 		if len(tokens) != 2 {
 			return nil, fmt.Errorf("bad command")
 		}
-		state, detail, err := w.UnitStatus(tokens[1])
+		cfr, err := w.unitStatusForCFR(tokens[1])
 		if err != nil {
 			return nil, err
 		}
-		cfr := make(map[string]interface{})
-		cfr["state"] = WorkStateToString(state)
-		cfr["detail"] = detail
 		return cfr, nil
 	case "release":
 		if len(tokens) != 2 {
@@ -511,11 +785,18 @@ func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperation
 		cfr["cancelled"] = tokens[1]
 		return cfr, nil
 	case "results":
-		// TODO: Take a parameter here to begin streaming results from a byte position
-		if len(tokens) != 2 {
+		if len(tokens) < 2 || len(tokens) > 3 {
 			return nil, fmt.Errorf("bad command")
 		}
-		resultChan, err := w.GetResults(tokens[1])
+		var startPos int64
+		if len(tokens) == 3 {
+			var err error
+			startPos, err = strconv.ParseInt(tokens[2], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("bad command")
+			}
+		}
+		resultChan, err := w.GetResults(tokens[1], startPos)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds a new `work submit` command to the control socket that is similar to `work start` except it takes a nodeID parameter.  The local node will accept stdin from the socket as normal, but instead of running the command, it will open the control socket (which must be named `control`) on the specified node, and use `work start` to run the job.

The local node will then poll for stdout and write it out locally as it becomes available.  Clients subscribed via `work results` will see results in near-real-time.

If the remote node is unreachable at the time the job is submitted (even if it is unknown), the local node will keep retrying until it becomes available.
If the remote node becomes unreachable while a job is running (say, an intermediate node goes down), local subscribers to `work results` will not be closed.  They will just sit there until the remote node comes back up, at which time all the missing stdout will be streamed.

Still to do on this:
* Handle remote `work cancel` and `work release`.
* Specify a TTL so that if the submission can't be sent by a given time, it will be cancelled.
* Decide if every Receptor node should always run a control service named `control`
* Handle TLS parameters for connecting to the remote `control` service