### PR TITLE
Improvements to workceptor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/creack/pty v1.1.11
 	github.com/fsnotify/fsnotify v1.4.7
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/juju/fslock v0.0.0-20160525022230-4d5c94c67b4b
 	github.com/jupp0r/go-priority-queue v0.0.0-20160601094913-ab1073853bde
 	github.com/lucas-clemente/quic-go v0.15.8

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+u
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -59,49 +58,6 @@ func (s *sockControl) ReadFromConn(message string, out io.Writer) error {
 	return nil
 }
 
-func connCheckSyscall(conn syscall.Conn) error {
-	var sysErr error = nil
-	rc, err := conn.SyscallConn()
-	if err != nil {
-		return err
-	}
-	err = rc.Read(func(fd uintptr) bool {
-		var buf []byte = []byte{0}
-		n, _, err := syscall.Recvfrom(int(fd), buf, syscall.MSG_PEEK|syscall.MSG_DONTWAIT)
-		switch {
-		case n == 0 && err == nil:
-			sysErr = io.EOF
-		case err == syscall.EAGAIN || err == syscall.EWOULDBLOCK:
-			sysErr = nil
-		default:
-			sysErr = err
-		}
-		return true
-	})
-	if err != nil {
-		return err
-	}
-	return sysErr
-}
-
-func connCheckNetceptor(conn *netceptor.Conn) error {
-	var buf []byte = []byte{0}
-	_, err := conn.Read(buf)
-	return err
-}
-
-func connCheck(conn net.Conn) error {
-	nc, ok := conn.(*netceptor.Conn)
-	if ok {
-		return connCheckNetceptor(nc)
-	}
-	sc, ok := conn.(syscall.Conn)
-	if ok {
-		return connCheckSyscall(sc)
-	}
-	return nil
-}
-
 func (s *sockControl) WriteToConn(message string, in chan []byte) error {
 	if message != "" {
 		_, err := s.conn.Write([]byte(message))
@@ -109,25 +65,13 @@ func (s *sockControl) WriteToConn(message string, in chan []byte) error {
 			return err
 		}
 	}
-	for {
-		select {
-		case bytes, ok := <-in:
-			if !ok {
-				return nil
-			}
-			_, err := s.conn.Write(bytes)
-			if err != nil {
-				return err
-			}
-		case <-time.After(1 * time.Second):
-			err := connCheck(s.conn)
-			if err == io.EOF {
-				return nil
-			} else if err != nil {
-				return err
-			}
+	for bytes := range in {
+		_, err := s.conn.Write(bytes)
+		if err != nil {
+			return err
 		}
 	}
+	return nil
 }
 
 func (s *sockControl) Close() error {

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -576,8 +576,9 @@ func (s *Netceptor) sendMessage(fromService string, toNode string, toService str
 }
 
 // Returns an unused random service name to use as the equivalent of a TCP/IP ephemeral port number.
-// Caller must already have s.structLock at least read-locked.
 func (s *Netceptor) getEphemeralService() string {
+	s.listenerLock.RLock()
+	defer s.listenerLock.RUnlock()
 	for {
 		service := randstr.RandomString(8)
 		_, ok := s.reservedServices[service]

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -4,6 +4,7 @@ package workceptor
 
 import (
 	"fmt"
+	"github.com/google/shlex"
 	"github.com/project-receptor/receptor/pkg/cmdline"
 	"github.com/project-receptor/receptor/pkg/debug"
 	"os"
@@ -60,7 +61,11 @@ func commandRunner(command string, params string, unitdir string) error {
 	if params == "" {
 		cmd = exec.Command(command)
 	} else {
-		cmd = exec.Command(command, strings.Split(params, " ")...)
+		paramList, err := shlex.Split(params)
+		if err != nil {
+			return err
+		}
+		cmd = exec.Command(command, paramList...)
 	}
 	termChan := make(chan os.Signal)
 	sigKilled := false
@@ -77,7 +82,7 @@ func commandRunner(command string, params string, unitdir string) error {
 		return err
 	}
 	cmd.Stdin = stdin
-	stdout, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0700)
+	stdout, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR will re-structure the remote work monitor to use separate goroutines for tracking status and receiving stdout.  Currently a long-running stdout can block status updates, including a race condition where all stdout has been received, but we don't _know_ it has all been received, because we haven't updated status to realize the job is complete.