### PR TITLE
Move CI tasks to Makefile target so you can easily run them locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,4 +9,12 @@ format:
 
 fmt: format
 
-.PHONY: lint format fmt
+ci:
+	echo "Running pre-commit" && \
+	pre-commit run --all-files && \
+	echo "Running Go builds" && \
+	go build cmd/*.go && \
+	go build example/*.go && \
+	echo "All done"
+
+.PHONY: lint format fmt ci

--- a/build/ci/Dockerfile
+++ b/build/ci/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 RUN dnf -y update && \
   dnf -y install epel-release && \
-  dnf -y install git golang python3 python3-pip python3-pip-wheel && \
+  dnf -y install git golang python3 python3-pip python3-pip-wheel make && \
   dnf clean all
 RUN pip3 install pre-commit
 RUN go get -u golang.org/x/lint/golint

--- a/build/ci/entrypoint.sh
+++ b/build/ci/entrypoint.sh
@@ -1,8 +1,3 @@
 #!/bin/sh
 export PATH=/root/go/bin:$PATH
-echo "Running pre-commit" && \
-  pre-commit run --all-files && \
-  echo "Running Go builds" && \
-  go build cmd/*.go && \
-  go build example/*.go && \
-  echo "All done"
+make ci


### PR DESCRIPTION
This moves the CI tests to a Makefile target for ease of running the same test suite locally.  I meant to do this in https://github.com/project-receptor/receptor/pull/33 but forgot.