### PR TITLE
Add automerge github action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,32 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.8.4"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "mergeit"
+          MERGE_REMOVE_LABELS: "mergeit"
+          MERGE_METHOD: "rebase"
+          UPDATE_LABELS: "mergeit"
+          UPDATE_METHOD: "rebase"


### PR DESCRIPTION
This allows us to set a label of "mergeit" which will auto-merge the PR once approvals and checks are all in place.

I am using rebase rather than squash because (a) I dislike merge commits, (b) I like preserving history, and (c) I don't like the auto generated commit messages that would result from auto-squashing.