### PR TITLE
Make known connection costs available in control socket status

### DIFF
--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -153,6 +153,7 @@ func (s *Server) controlStatus(params string, cfo ControlFuncOperations) (map[st
 	cfr["Connections"] = status.Connections
 	cfr["RoutingTable"] = status.RoutingTable
 	cfr["Advertisements"] = status.Advertisements
+	cfr["KnownConnectionCosts"] = status.KnownConnectionCosts
 	return cfr, nil
 }
 


### PR DESCRIPTION
Following https://github.com/project-receptor/receptor/pull/36, the `KnownConnectionCosts` field should be surfaced in the `status` command on the control socket.