### PR TITLE
Fix race condition

### DIFF
--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -714,7 +714,10 @@ func (s *Netceptor) handleRoutingUpdate(ri *routingUpdate, recvConn string) {
 		_ = s.addNameHash(ri.NodeID)
 	}
 	s.knownNodeInfo[ri.NodeID] = ni
-	s.knownConnectionCosts[ri.NodeID] = ri.Connections
+	s.knownConnectionCosts[ri.NodeID] = make(map[string]float64)
+	for k, v := range ri.Connections {
+		s.knownConnectionCosts[ri.NodeID][k] = v
+	}
 	for conn := range s.knownConnectionCosts {
 		if conn == s.nodeID {
 			continue


### PR DESCRIPTION
I found this when running my tests, 1 in every 20 or so tests would fail with a panic due to a concurrent map iteration and map write. I think what's happening is while the `ri` is being serialized, another advertisement comes (maybe specifically from this node?) which changes `ri.Connections`. In any case this seems to fix the bug and is probably what we should be doing regardless