### PR TITLE
Add support for retrieving local address when running on an ephemeral port

### DIFF
--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -122,6 +122,14 @@ func NewUDPListener(address string) (*UDPListener, error) {
 	return &ul, nil
 }
 
+// LocalAddr returns the local address the listener is listening on
+func (b *UDPListener) LocalAddr() net.Addr {
+	if b.conn == nil {
+		return nil
+	}
+	return b.conn.LocalAddr()
+}
+
 // Start runs the given session function over the UDPListener backend
 func (b *UDPListener) Start(bsf netceptor.BackendSessFunc, errf netceptor.ErrorFunc) {
 	go func() {


### PR DESCRIPTION
If you don't pass a port number as part of the address, the `net.Listener` and `net.ListenUDP` will listen on an ephemeral port.  This PR provides the ability for a caller to retrieve the resulting address, including port number.

The `net/http` library does not, as far as I can tell, offer the ability to listen on an ephemeral port.  If no port is specified, it listens on port 80.