### PR TITLE
Rework backend scheme

### DIFF
--- a/example/net.go
+++ b/example/net.go
@@ -16,13 +16,9 @@ import (
 */
 
 func main() {
-	// Create contexts so we can shut down the nodes
-	ctx1, _ := context.WithCancel(context.Background())
-	ctx2, _ := context.WithCancel(context.Background())
-
 	// Create two nodes of the Receptor network-layer protocol (Netceptors).
-	n1 := netceptor.New(ctx1, "node1", nil)
-	n2 := netceptor.New(ctx2, "node2", nil)
+	n1 := netceptor.New(context.Background(), "node1", nil)
+	n2 := netceptor.New(context.Background(), "node2", nil)
 
 	// Start a TCP listener on the first node
 	b1, err := backends.NewTCPListener("localhost:3333", nil)

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -1,0 +1,87 @@
+package backends
+
+import (
+	"context"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"time"
+)
+
+type dialerFunc func(chan struct{}) (netceptor.BackendSession, error)
+
+// dialerSession is a convenience function for backends that use dial/retry logic
+func dialerSession(ctx context.Context, redial bool, redialDelay time.Duration,
+	df dialerFunc) (chan netceptor.BackendSession, error) {
+	sessChan := make(chan netceptor.BackendSession)
+	go func() {
+		defer close(sessChan)
+		for {
+			closeChan := make(chan struct{})
+			sess, err := df(closeChan)
+			if err == nil {
+				sessChan <- sess
+				select {
+				case <-closeChan:
+					// continue
+				case <-ctx.Done():
+					_ = sess.Close()
+					return
+				}
+			}
+			if redial {
+				if err != nil {
+					logger.Warning("Backend connection failed (will retry): %s\n", err)
+				} else {
+					logger.Warning("Backend connection exited (will retry)\n")
+				}
+				select {
+				case <-time.After(redialDelay):
+					continue
+				case <-ctx.Done():
+					return
+				}
+			} else {
+				if err != nil {
+					logger.Error("Backend connection failed: %s\n", err)
+				} else {
+					logger.Error("Backend connection exited\n")
+				}
+				return
+			}
+		}
+	}()
+	return sessChan, nil
+}
+
+type listenFunc func() error
+type acceptFunc func() (netceptor.BackendSession, error)
+type listenerCancelFunc func()
+
+// listenerSession is a convenience function for backends that use listen/accept logic
+func listenerSession(ctx context.Context, lf listenFunc, af acceptFunc, lcf listenerCancelFunc) (chan netceptor.BackendSession, error) {
+	err := lf()
+	if err != nil {
+		return nil, err
+	}
+	sessChan := make(chan netceptor.BackendSession)
+	go func() {
+		defer func() {
+			lcf()
+			close(sessChan)
+		}()
+		for {
+			c, err := af()
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			if err != nil {
+				logger.Error("Error accepting connection: %s\n", err)
+				return
+			}
+			sessChan <- c
+		}
+	}()
+	return sessChan, nil
+}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -59,7 +59,7 @@ func Log(level int, format string, v ...interface{}) {
 	var prefix string
 	for k, v := range logLevelMap {
 		if v == level {
-			prefix = strings.ToUpper(k)
+			prefix = fmt.Sprintf("%s ", strings.ToUpper(k))
 			break
 		}
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -5,6 +5,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/cmdline"
 	"log"
 	"os"
+	"strings"
 )
 
 var logLevel int
@@ -31,7 +32,7 @@ func SetShowTrace(trace bool) {
 // level string
 func GetLogLevelByName(logName string) (int, error) {
 	var err error
-	if val, hasKey := LogLevelMap[logName]; hasKey {
+	if val, hasKey := LogLevelMap[strings.ToLower(logName)]; hasKey {
 		return val, nil
 	}
 	err = fmt.Errorf("%s is not a valid log level name", logName)
@@ -46,10 +47,10 @@ func GetLogLevel() int {
 // LogLevelMap maps strings to log level int
 // allows for --LogLevel Debug at command line
 var LogLevelMap = map[string]int{
-	"Error":   errorLevel,
-	"Warning": warningLevel,
-	"Info":    infoLevel,
-	"Debug":   debugLevel,
+	"error":   errorLevel,
+	"warning": warningLevel,
+	"info":    infoLevel,
+	"debug":   debugLevel,
 }
 
 // Error reports unexpected behavior, likely to result in termination

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -237,11 +237,6 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64) error {
 	return nil
 }
 
-// DoneBackend signals to the wait group that the backend is done
-func (s *Netceptor) DoneBackend() {
-	s.backendWaitGroup.Done()
-}
-
 // BackendWait waits for the backend wait group
 func (s *Netceptor) BackendWait() {
 	s.backendWaitGroup.Wait()

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -622,15 +622,14 @@ func (s *Netceptor) getEphemeralService() string {
 	}
 }
 
-// Prints the routing table.  Only used for debugging.
+// Prints the routing table.
 // The caller must already hold at least a read lock on known connections and routing.
 func (s *Netceptor) printRoutingTable() {
-	debugLevel, _ := logger.GetLogLevelByName("Debug")
-	curLevel := logger.GetLogLevel()
-	if curLevel < debugLevel {
+	logLevel, _ := logger.GetLogLevelByName("Info")
+	if logger.GetLogLevel() < logLevel {
 		return
 	}
-	logger.Debug("Known Connections:\n")
+	logger.Log(logLevel, "Known Connections:\n")
 	for conn := range s.knownConnectionCosts {
 		sb := &strings.Builder{}
 		_, _ = fmt.Fprintf(sb, "   %s: ", conn)
@@ -638,11 +637,11 @@ func (s *Netceptor) printRoutingTable() {
 			_, _ = fmt.Fprintf(sb, "%s(%.2f) ", peer, s.knownConnectionCosts[conn][peer])
 		}
 		_, _ = fmt.Fprintf(sb, "\n")
-		logger.Debug(sb.String())
+		logger.Log(logLevel, sb.String())
 	}
-	logger.Debug("Routing Table:\n")
+	logger.Log(logLevel, "Routing Table:\n")
 	for node := range s.routingTable {
-		logger.Debug("   %s via %s\n", node, s.routingTable[node])
+		logger.Log(logLevel, "   %s via %s\n", node, s.routingTable[node])
 	}
 }
 

--- a/pkg/tickrunner/tickrunner.go
+++ b/pkg/tickrunner/tickrunner.go
@@ -1,6 +1,7 @@
 package tickrunner
 
 import (
+	"context"
 	"time"
 )
 
@@ -8,8 +9,7 @@ import (
 // If many requests come in close to the same time, only run the task once.
 // Callers can ask for the task to be run within a given amount of time, which
 // overrides defaltReqDelay. Sending a zero to the channel runs it immediately.
-func Run(f func(), periodicInterval time.Duration, defaultReqDelay time.Duration,
-	shutdownChan chan bool) chan time.Duration {
+func Run(ctx context.Context, f func(), periodicInterval time.Duration, defaultReqDelay time.Duration) chan time.Duration {
 	runChan := make(chan time.Duration)
 	go func() {
 		nextRunTime := time.Now().Add(periodicInterval)
@@ -28,7 +28,7 @@ func Run(f func(), periodicInterval time.Duration, defaultReqDelay time.Duration
 				if proposedTime.Before(nextRunTime) {
 					nextRunTime = proposedTime
 				}
-			case <-shutdownChan:
+			case <-ctx.Done():
 				return
 			}
 		}

--- a/tests/functional/mesh/mesh.go
+++ b/tests/functional/mesh/mesh.go
@@ -57,7 +57,7 @@ func handleError(err error, fatal bool) {
 
 // NewNode builds a node with the name passed as the argument
 func NewNode(name string) Node {
-	n1 := netceptor.New(name, nil)
+	n1 := netceptor.New(context.Background(), name, nil)
 	return Node{
 		NetceptorInstance: n1,
 	}
@@ -71,7 +71,7 @@ func (n *Node) TCPListen(address string, cost float64) error {
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	n.NetceptorInstance.RunBackend(b1, cost, handleError)
+	err = n.NetceptorInstance.AddBackend(b1, cost)
 	return err
 }
 
@@ -82,7 +82,7 @@ func (n *Node) TCPDial(address string, cost float64) error {
 	if err != nil {
 		return err
 	}
-	n.NetceptorInstance.RunBackend(b1, cost, handleError)
+	err = n.NetceptorInstance.AddBackend(b1, cost)
 	return err
 }
 
@@ -94,7 +94,7 @@ func (n *Node) UDPListen(address string, cost float64) error {
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	n.NetceptorInstance.RunBackend(b1, cost, handleError)
+	err = n.NetceptorInstance.AddBackend(b1, cost)
 	return err
 }
 
@@ -105,7 +105,7 @@ func (n *Node) UDPDial(address string, cost float64) error {
 	if err != nil {
 		return err
 	}
-	n.NetceptorInstance.RunBackend(b1, cost, handleError)
+	err = n.NetceptorInstance.AddBackend(b1, cost)
 	return err
 }
 
@@ -118,7 +118,7 @@ func (n *Node) WebsocketListen(address string, cost float64) error {
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	n.NetceptorInstance.RunBackend(b1, cost, handleError)
+	err = n.NetceptorInstance.AddBackend(b1, cost)
 	return err
 }
 
@@ -130,7 +130,7 @@ func (n *Node) WebsocketDial(address string, cost float64) error {
 	if err != nil {
 		return err
 	}
-	n.NetceptorInstance.RunBackend(b1, cost, handleError)
+	err = n.NetceptorInstance.AddBackend(b1, cost)
 	return err
 }
 


### PR DESCRIPTION
This PR makes the following changes:

- Instead of `RunBackend` calling `backend.Start()` which then calls back a `BackendSessionFunc`, backends register with a simplified `AddBackend` call, allowing more logic to be abstracted in the framework rather than requiring implementation in each backend.
- Utility functions are added for the common use cases of a Dial/redial and Listen/Accept backend types.
- Netceptor is restructured to use Go contexts instead of the shutdown channels slice, allowing for cleaner and more reliable shutdown, as well as being more idiomatic to Go.
- The logger is updated to treat log levels case insensitively, so users can run `--log-level debug` (lower case D) without error.

See https://github.com/project-receptor/receptor/issues/28