### PR TITLE
Receptorctl

### DIFF
--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -139,7 +139,7 @@ func (s *Server) controlPing(params string, cfo ControlFuncOperations) (map[stri
 	cfr := make(map[string]interface{})
 	select {
 	case addr := <-replyChan:
-		cfr["Result"] = fmt.Sprintf("Reply from %s in %s\n", addr.String(), time.Since(startTime))
+		cfr["Result"] = fmt.Sprintf("Reply from %s in %s", addr.String(), time.Since(startTime))
 	case <-time.After(10 * time.Second):
 		cfr["Result"] = "Timeout waiting for ping response"
 	}

--- a/receptorctl/.gitignore
+++ b/receptorctl/.gitignore
@@ -1,0 +1,104 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+.mypy_cache
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+report.xml
+report.pylama
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# IPython Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/
+
+# Spyder project settings
+.spyderproject
+
+# Rope project settings
+.ropeproject
+
+# vim
+*.swp
+
+# mac OS
+*.DS_Store
+
+# pytest
+*.pytest_cache
+
+# PyCharm
+.idea/

--- a/receptorctl/README.md
+++ b/receptorctl/README.md
@@ -1,0 +1,1 @@
+Receptorctl is a front-end CLI and importable Python library that interacts with Receptor over its control socket interface.

--- a/receptorctl/receptorctl/__init__.py
+++ b/receptorctl/receptorctl/__init__.py
@@ -1,0 +1,2 @@
+from .cli import run
+from .socket_interface import ReceptorControl

--- a/receptorctl/receptorctl/__main__.py
+++ b/receptorctl/receptorctl/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from .cli import run
+
+run()

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -1,0 +1,91 @@
+import sys
+import os
+import time
+import select
+import fcntl
+import tty
+import termios
+import click
+from .socket_interface import ReceptorControl
+
+
+@click.group()
+@click.pass_context
+@click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True)
+def cli(ctx, socket):
+    rc = ReceptorControl()
+    rc.connect(socket)
+    ctx.obj = dict()
+    ctx.obj['rc'] = rc
+
+
+@cli.command()
+@click.pass_context
+def status(ctx):
+    rc = ctx.obj['rc']
+    rc.print_status()
+
+
+@cli.command()
+@click.pass_context
+@click.argument('node')
+@click.option('--count', default=4)
+@click.option('--delay', default=1.0)
+def ping(ctx, node, count, delay):
+    rc = ctx.obj['rc']
+    for i in range(count):
+        success, detail = rc.ping(node)
+        if success:
+            print(detail)
+        else:
+            print("FAILED:", detail)
+        if i < count-1:
+            time.sleep(delay)
+
+
+@cli.command()
+@click.pass_context
+@click.argument('node')
+@click.argument('service')
+@click.option('--raw', '-r', default=False, is_flag=True, help="Set terminal to raw mode")
+def connect(ctx, node, service, raw):
+    rc = ctx.obj['rc']
+    rc.connect_to_service(node, service)
+
+    stdin_tattrs = termios.tcgetattr(sys.stdin)
+    stdin_fcntl = fcntl.fcntl(sys.stdin, fcntl.F_GETFL)
+    fcntl.fcntl(sys.stdin, fcntl.F_SETFL, stdin_fcntl | os.O_NONBLOCK)
+    if raw and sys.stdin.isatty():
+        tty.setraw(sys.stdin.fileno(), termios.TCSAFLUSH)
+        new_term = termios.tcgetattr(sys.stdin)
+        new_term[3] = new_term[3] & ~termios.ISIG
+        termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, new_term)
+
+    try:
+        while True:
+            r, _, _ = select.select([rc.socket, sys.stdin], [], [])
+            for readable in r:
+                if readable is rc.socket:
+                    data = rc.socket.recv(4096)
+                    if not data:
+                        return
+                    sys.stdout.write(data.decode())
+                    sys.stdout.flush()
+                else:
+                    data = sys.stdin.read()
+                    if not data:
+                        return
+                    rc.socket.send(data.encode())
+    finally:
+        termios.tcsetattr(sys.stdin, termios.TCSAFLUSH, stdin_tattrs)
+
+
+def run():
+    try:
+        cli.main(sys.argv[1:], standalone_mode=False)
+    except click.exceptions.Abort:
+        pass
+    except Exception as e:
+        print("Error:", e)
+        sys.exit(1)
+    sys.exit(0)

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -1,0 +1,141 @@
+import sys
+import os
+import re
+import socket
+import json
+import time
+import dateutil.parser
+from pprint import pprint
+
+
+class ReceptorControl:
+    def __init__(self):
+        self.socket = None
+        self.sockfile = None
+        self.remote_node = None
+
+    def readstr(self):
+        return self.sockfile.readline().strip()
+
+    def writestr(self, str):
+        self.sockfile.write(str)
+        self.sockfile.flush()
+
+    def handshake(self):
+        m = re.compile("Receptor Control, node (.+)").fullmatch(self.readstr())
+        if not m:
+            raise RuntimeError("Failed to handshake with Receptor socket")
+        self.remote_node = m[1]
+
+    def read_and_parse_json(self):
+        text = self.readstr()
+        if str.startswith(text, "ERROR:"):
+            raise RuntimeError(text[7:])
+        data = json.loads(text)
+        return data
+
+    def simple_command(self, command):
+        self.writestr(f"{command}\n")
+        return self.read_and_parse_json()
+
+    def connect(self, address):
+        if self.socket is not None:
+            raise ValueError("Already connected")
+        m = re.compile("tcp:(//)?([a-zA-Z0-9-]+):([0-9]+)|(unix:(//)?)?([^:]+)").fullmatch(address)
+        if m:
+            if m[6]:
+                path = os.path.expanduser(m[6])
+                if not os.path.exists(path):
+                    raise ValueError(f"Socket path does not exist: {path}")
+                self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                self.socket.connect(path)
+                self.sockfile = self.socket.makefile('rw')
+                self.handshake()
+                return
+            elif m[2] and m[3]:
+                host = m[2]
+                port = m[3]
+                print(f"TCP socket, host {host} port {port}")
+                self.handshake()
+                return
+        raise ValueError(f"Invalid socket address {address}")
+
+    def close(self):
+        if self.sockfile is not None:
+            self.sockfile.close()
+            self.sockfile = None
+
+        if self.socket is not None:
+            self.socket.close()
+            self.socket = None
+
+    def print_status(self):
+        status = self.simple_command("status")
+        node_id = status.pop('NodeID')
+        print(f"Node ID: {node_id}")
+
+        longest_node = 12
+
+        connections = status.pop('Connections', None)
+        if connections:
+            for conn in connections:
+                l = len(conn['NodeID'])
+                if l > longest_node:
+                    longest_node = l
+
+        costs = status.pop('KnownConnectionCosts', None)
+        if costs:
+            for node in costs:
+                if len(node) > longest_node:
+                    longest_node = len(node)
+
+        if connections:
+            for conn in connections:
+                l = len(conn['NodeID'])
+                if l > longest_node:
+                    longest_node = l
+            print()
+            print(f"{'Connection':<{longest_node}} Cost")
+            for conn in connections:
+                print(f"{conn['NodeID']:<{longest_node}} {conn['Cost']}")
+
+        if costs:
+            print()
+            print(f"{'Known Node':<{longest_node}} Known Connections")
+            for node in costs:
+                print(f"{node:<{longest_node}} ", end="")
+                pprint(costs[node])
+
+        routes = status.pop('RoutingTable', None)
+        if routes:
+            print()
+            print(f"{'Route':<{longest_node}} Via")
+            for node in routes:
+                print(f"{node:<{longest_node}} {routes[node]}")
+
+        ads = status.pop('Advertisements', None)
+        if ads:
+            print()
+            print(f"{'Node':<{longest_node}} Service   Last Seen            Tags")
+            for ad in ads:
+                time = dateutil.parser.parse(ad['Time'])
+                print(f"{ad['NodeID']:<{longest_node}} {ad['Service']:<8}  {time:%Y-%m-%d %H:%M:%S}  ", end="")
+                pprint(ad['Tags'])
+
+        if status:
+            print("Additional data returned from Receptor:")
+            pprint(status)
+
+    def ping(self, node):
+        try:
+            result = self.simple_command(f"ping {node}")
+            success = str.startswith(result['Result'], "Reply")
+            return success, result['Result']
+        except RuntimeError as e:
+            return False, e
+
+    def connect_to_service(self, node, service):
+        self.writestr(f"connect {node} {service}\n")
+        text = self.readstr()
+        if not str.startswith(text, "Connecting"):
+            raise RuntimeError(text)

--- a/receptorctl/setup.py
+++ b/receptorctl/setup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+from setuptools import setup, find_packages
+
+with open('README.md', 'r') as f:
+    long_description = f.read()
+
+setup(
+    name="receptorctl",
+    version="0.0.1",
+    author='Red Hat Ansible',
+    url="https://github.com/project-receptor/receptor/receptorctl",
+    license='Apache',
+    packages=find_packages(),
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    install_requires=[
+        "setuptools",
+        "python-dateutil",
+    ],
+    zip_safe=False,
+    entry_points={
+        'console_scripts': [
+              'receptorctl=receptorctl:run'
+          ]
+    },
+    classifiers=[
+        "Programming Language :: Python :: 3",
+    ],
+)


### PR DESCRIPTION
Add a new Python module and CLI called receptorctl, that functions as a front-end to the Receptor control socket.  Currently this implements the three built-in control service commands: status, ping and connect.