### PR TITLE
Cancel and release extend to remote units of work

### DIFF
--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -326,15 +326,12 @@ func (w *Workceptor) monitorRemoteStatus(ctx context.Context, cancel context.Can
 			logger.Error("Error saving local status file: %s\n", err)
 			return
 		}
-
 		if IsComplete(state) {
 			return
 		}
-
 		if released {
 			return
 		}
-
 		if sleepOrDone(ctx.Done(), 1*time.Second) {
 			return
 		}
@@ -365,7 +362,6 @@ func (w *Workceptor) monitorRemoteStdout(ctx context.Context, cancel context.Can
 				return
 			}
 		}
-
 		diskStdoutSize := fileSizeOrZero(stdoutFilename)
 		unit.lock.RLock()
 		remoteStdoutSize := unit.status.StdoutSize
@@ -416,7 +412,6 @@ func (w *Workceptor) monitorRemoteStdout(ctx context.Context, cancel context.Can
 			_, err = io.Copy(stdout, conn)
 			close(doneChan)
 
-
 			unit.lock.RLock()
 			released := unit.released
 			unit.lock.RUnlock()
@@ -447,7 +442,6 @@ func (w *Workceptor) monitorRemoteUnit(unit *workUnit, unitID string) {
 	workType := unit.status.WorkType
 	unit.monitoringRemote = true
 	unit.lock.Unlock()
-
 	for {
 		if conn != nil && !reflect.ValueOf(conn).IsNil() {
 			_ = conn.Close()
@@ -457,14 +451,12 @@ func (w *Workceptor) monitorRemoteUnit(unit *workUnit, unitID string) {
 		if nextDelay > MaxWorkSleep {
 			nextDelay = MaxWorkSleep
 		}
-
 		unit.lock.RLock()
 		released := unit.released
 		unit.lock.RUnlock()
 		if released {
 			return
 		}
-
 		conn, reader, err := w.connectToRemote(remoteNodeID)
 		if err != nil {
 			logger.Error("Connection failed to %s: %s\n", remoteNodeID, err)
@@ -732,12 +724,10 @@ func (w *Workceptor) cancelRemote(remoteNodeID, remoteUnitID string, unit *workU
 		if released {
 			return nil
 		}
-
 		conn, _, err := w.connectToRemote(remoteNodeID)
 		if err != nil {
 			logger.Error("Connection failed to %s: %s\n", remoteNodeID, err)
 		}
-
 		if conn != nil {
 			_, err = conn.Write([]byte(fmt.Sprintf("work cancel %s\n", remoteUnitID)))
 			if err != nil {
@@ -749,16 +739,13 @@ func (w *Workceptor) cancelRemote(remoteNodeID, remoteUnitID string, unit *workU
 			conn.Close()
 		}
 		time.Sleep(retryInterval)
-
 		// backoff scheme, increase retryInterval
 		retryInterval = time.Duration(1.5 * float64(retryInterval))
 		if retryInterval > MaxWorkSleep {
 			retryInterval = MaxWorkSleep
 		}
 	}
-
 	retryInterval = 500 * time.Millisecond
-
 	var state int
 	for {
 		// check that unit still exists, could have been released
@@ -768,14 +755,12 @@ func (w *Workceptor) cancelRemote(remoteNodeID, remoteUnitID string, unit *workU
 		if released {
 			return nil
 		}
-
 		unit.lock.RLock()
 		state = unit.status.State
 		unit.lock.RUnlock()
 		if IsComplete(state) {
 			return nil
 		}
-
 		time.Sleep(retryInterval)
 	}
 }
@@ -869,7 +854,6 @@ func (w *Workceptor) ReleaseUnit(unitID string) error {
 	w.activeUnitsLock.Lock()
 	delete(w.activeUnits, unitID)
 	w.activeUnitsLock.Unlock()
-
 	err = os.RemoveAll(path.Join(w.dataDir, unitID))
 	if err != nil {
 		return err

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -662,7 +662,7 @@ func (w *Workceptor) scanForUnits() {
 				}
 				w.activeUnits[fi.Name()] = unit
 				if si.Node != "" && si.Node != w.nc.NodeID() {
-					if si.LocalCancel && si.State == WorkStateRunning {
+					if si.LocalCancel && !IsComplete(si.State) {
 						remoteNodeID := si.Node
 						remoteUnitID := si.RemoteUnitID
 						go w.cancelRemote(remoteNodeID, remoteUnitID, unit)

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -71,12 +71,12 @@ type workType struct {
 
 // Internal data for a single unit of work
 type workUnit struct {
-	lock         *sync.RWMutex
-	started      bool
-	released     bool
-	waitRemote   *sync.WaitGroup
-	worker       WorkType
-	status       *StatusInfo
+	lock       *sync.RWMutex
+	started    bool
+	released   bool
+	waitRemote *sync.WaitGroup
+	worker     WorkType
+	status     *StatusInfo
 }
 
 // Workceptor is the main object that handles unit-of-work management
@@ -574,12 +574,12 @@ func (w *Workceptor) PreStartUnit(nodeID string, workTypeName string, params str
 	w.activeUnitsLock.Lock()
 	defer w.activeUnitsLock.Unlock()
 	w.activeUnits[ident] = &workUnit{
-		lock:     &sync.RWMutex{},
-		started:  false,
-		released: false,
+		lock:       &sync.RWMutex{},
+		started:    false,
+		released:   false,
 		waitRemote: &sync.WaitGroup{},
-		worker:   worker,
-		status:   status,
+		worker:     worker,
+		status:     status,
 	}
 	return ident, nil
 }
@@ -643,12 +643,12 @@ func (w *Workceptor) scanForUnits() {
 				statusFilename := path.Join(w.dataDir, fi.Name(), "status")
 				_ = si.Load(statusFilename)
 				unit := &workUnit{
-					lock:     &sync.RWMutex{},
-					started:  true, // If we're finding it now, we don't want to start it again
-					released: false,
+					lock:       &sync.RWMutex{},
+					started:    true, // If we're finding it now, we don't want to start it again
+					released:   false,
 					waitRemote: &sync.WaitGroup{},
-					worker:   nil,
-					status:   si,
+					worker:     nil,
+					status:     si,
 				}
 				if unit.status.State == WorkStatePending {
 					unit.status.State = WorkStateFailed
@@ -792,7 +792,7 @@ func (w *Workceptor) CancelUnit(unitID string) (bool, error) {
 		unit.lock.Unlock()
 		firstAttemptSuccess := make(chan bool)
 		go w.cancelRemote(nodeID, remoteUnitID, unit, firstAttemptSuccess)
-		if !<- firstAttemptSuccess {
+		if !<-firstAttemptSuccess {
 			isPending = true
 		}
 	} else {

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -805,7 +805,7 @@ func (w *Workceptor) CancelUnit(unitID string) (bool, error) {
 	err := unit.status.Save(path.Join(unitdir, "status"))
 	unit.lock.RUnlock()
 	if err != nil {
-		return isPending, fmt.Errorf("Error saving local status file: %s\n", err)
+		return isPending, fmt.Errorf("saving local status file: %s", err)
 	}
 	return isPending, nil
 }

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -756,6 +756,7 @@ func (w *Workceptor) cancelRemote(remoteNodeID, remoteUnitID string, unit *workU
 			continue
 		}
 		if response[:5] == "ERROR" {
+			logger.Warning("Error cancelling remote unit: %s\n", response[6:])
 			conn.Close()
 			continue
 		} else {

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -963,6 +963,7 @@ func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan str
 				stdoutSize := fileSizeOrZero(stdoutFilename)
 				if IsComplete(unit.status.State) && stdoutSize >= unit.status.StdoutSize {
 					close(resultChan)
+					logger.Info("Stdout complete - closing channel\n")
 					return
 				}
 				continue


### PR DESCRIPTION
issue #54

`cancelRemote()` uses a goroutine that connects to the remote node and issues a `work cancel` command. This goroutine will not timeout, but will terminate after a successful cancel or a release.

`ReleaseUnit()` will make a one-time attempt to connect to remote and issue a `work release` command. Regardless if it is successful, it will go ahead and delete local files.

Cancel and Release are robust to when nodes are down. If either the control node or remote node go down before the cancellation takes place, it will cancel the work when the nodes come back online.