### PR TITLE
Fix blocking situations that were preventing clean shutdown

### DIFF
--- a/example/net.go
+++ b/example/net.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/project-receptor/receptor/pkg/backends"
+	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"io"
 	"net"
@@ -16,6 +17,9 @@ import (
 */
 
 func main() {
+	// Suppress log output.  Remove this if you want to see log information.
+	logger.QuietMode()
+
 	// Create two nodes of the Receptor network-layer protocol (Netceptors).
 	n1 := netceptor.New(context.Background(), "node1", nil)
 	n2 := netceptor.New(context.Background(), "node2", nil)

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -36,7 +36,7 @@ func NewUDPDialer(address string, redial bool) (*UDPDialer, error) {
 // Start runs the given session function over this backend service
 func (b *UDPDialer) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, b.redial, 5*time.Second,
-		func(ctx context.Context, closeChan chan struct{}) (netceptor.BackendSession, error) {
+		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
 			dialer := net.Dialer{}
 			conn, err := dialer.DialContext(ctx, "udp", b.address)
 			if err != nil {

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -48,7 +48,7 @@ func NewWebsocketDialer(address string, tlscfg *tls.Config, extraHeader string, 
 // Start runs the given session function over this backend service
 func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, b.redial, 5*time.Second,
-		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
+		func(ctx context.Context, closeChan chan struct{}) (netceptor.BackendSession, error) {
 			dialer := websocket.Dialer{
 				TLSClientConfig: b.tlscfg,
 				Proxy:           http.ProxyFromEnvironment,
@@ -59,7 +59,7 @@ func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSess
 				header.Add(http.CanonicalHeaderKey(extraHeaderParts[0]), extraHeaderParts[1])
 			}
 			header.Add(http.CanonicalHeaderKey("origin"), b.origin)
-			conn, _, err := dialer.Dial(b.address, header)
+			conn, _, err := dialer.DialContext(ctx, b.address, header)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -48,7 +48,7 @@ func NewWebsocketDialer(address string, tlscfg *tls.Config, extraHeader string, 
 // Start runs the given session function over this backend service
 func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, b.redial, 5*time.Second,
-		func(ctx context.Context, closeChan chan struct{}) (netceptor.BackendSession, error) {
+		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
 			dialer := websocket.Dialer{
 				TLSClientConfig: b.tlscfg,
 				Proxy:           http.ProxyFromEnvironment,

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -19,6 +19,11 @@ const (
 	DebugLevel
 )
 
+// QuietMode turns off all log output
+func QuietMode() {
+	logLevel = 0
+}
+
 // SetLogLevel is a helper function for setting logLevel int
 func SetLogLevel(level int) {
 	logLevel = level

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -889,7 +889,6 @@ func (ci *connInfo) protoWriter(sess BackendSession) {
 				ci.CancelFunc()
 				return
 			}
-		default:
 		}
 
 	}


### PR DESCRIPTION
This PR adds the following fixes:

- Use a context in backend `Listen()` and `Dial()` calls, with a particular goal of having `Accept()` be released on context cancel
- Use contexts instead of `ErrorChan` to end back-end sessions, so they exit if the whole Netceptor exits without extra logic
- Do not send to `updateRoutingTableChan` and `sendRouteFloodChan` if we are shutting down, because those goroutines may have already exited