### PR TITLE
Fix Shutdown test flake

### DIFF
--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -131,7 +131,7 @@ func TestMeshShutdown(t *testing.T) {
 
 			// Check that the connections are closed
 			pid := os.Getpid()
-			pidString := strconv.Itoa(pid)
+			pidString := "pid=" + strconv.Itoa(pid)
 			done := false
 			var out bytes.Buffer
 			for timeout := 2 * time.Second; timeout > 0 && !done; {


### PR DESCRIPTION
If there's an open port with the same number as our pid, our shutdown tests will fail incorrectly, I thought i had already added this string prefix to prevent that but I must have lost that in my reworking of my PR somehow. This is unlikely to break things when running in the container because we'll probably be the only process, but I ran into this running tests locally.