### PR TITLE
Use timeouts in BackendSession Recv method to fix leaking goroutine

### DIFF
--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -161,7 +161,7 @@ func newWebsocketSession(conn *websocket.Conn, closeChan chan struct{}) *Websock
 	return ws
 }
 
-//
+// recvChannelizer receives messages and pushes them to a channel.
 func (ns *WebsocketSession) recvChannelizer() {
 	for {
 		_, data, err := ns.conn.ReadMessage()

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -38,18 +38,33 @@ var MainInstance *Netceptor
 // indicates whether the error is fatal (i.e. the associated process is going to exit).
 type ErrorFunc func(error, bool)
 
+// ErrTimeout is returned for an expired deadline.
+var ErrTimeout error = &TimeoutError{}
+
+// TimeoutError is returned for an expired deadline.
+type TimeoutError struct{}
+
+// Error returns a string describing the error.
+func (e *TimeoutError) Error() string { return "i/o timeout" }
+
+// Timeout returns true if this error was a timeout.
+func (e *TimeoutError) Timeout() bool { return true }
+
+// Temporary returns true if a retry is likely a good idea.
+func (e *TimeoutError) Temporary() bool { return true }
+
 // Backend is the interface for back-ends that the Receptor network can run over
 type Backend interface {
 	Start(context.Context) (chan BackendSession, error)
 }
 
-// BackendSession is the interface for a single session of a back-end
+// BackendSession is the interface for a single session of a back-end.
 // Backends must be DATAGRAM ORIENTED, meaning that Recv() must return
 // whole packets sent by Send(). If the underlying protocol is stream
 // oriented, then the backend must deal with any required buffering.
 type BackendSession interface {
 	Send([]byte) error
-	Recv() ([]byte, error)
+	Recv(time.Duration) ([]byte, error) // Must return netceptor.ErrTimeout if the timeout is exceeded
 	Close() error
 }
 
@@ -855,11 +870,14 @@ func (s *Netceptor) handleServiceAdvertisement(data []byte, receivedFrom string)
 // Goroutine to send data from the backend to the connection's ReadChan
 func (ci *connInfo) protoReader(sess BackendSession) {
 	for {
-		buf, err := sess.Recv()
+		buf, err := sess.Recv(1 * time.Second)
 		select {
 		case <-ci.Context.Done():
 			return
 		default:
+		}
+		if err == ErrTimeout {
+			continue
 		}
 		if err != nil {
 			if err != io.EOF {

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -6,21 +6,6 @@ import (
 	"time"
 )
 
-// ErrTimeout is returned for an expired deadline.
-var ErrTimeout error = &TimeoutError{}
-
-// TimeoutError is returned for an expired deadline.
-type TimeoutError struct{}
-
-// Error returns a string describing the error.
-func (e *TimeoutError) Error() string { return "i/o timeout" }
-
-// Timeout returns true if this error was a timeout.
-func (e *TimeoutError) Timeout() bool { return true }
-
-// Temporary returns true if a retry is likely a good idea.
-func (e *TimeoutError) Temporary() bool { return true }
-
 // PacketConn implements the net.PacketConn interface via the Receptor network
 type PacketConn struct {
 	s             *Netceptor


### PR DESCRIPTION
The goroutine leak in issue https://github.com/project-receptor/receptor/issues/62 is caused by `BackendSession.Recv()` being a blocking call, so the `protoReader` goroutine never exits.  This PR adds a timeout value to `Recv()` so that `protoReader` has a chance to periodically check if the context is done.

The timeout implementation in the websockets backend cannot use `SetReadDeadLine` like the other backends do, because of https://github.com/gorilla/websocket/issues/474.  After a timeout error occurs, the websocket connection is no longer usable and must be closed.  So instead, we start a goroutine called `recvChannelizer` which pushes messages to a channel, and exits after any error.  The websockets backend `Recv()` message then provides "soft" timeouts using a select on this channel or the timeout.