### PR TITLE
Use the right netceptor in the status function

### DIFF
--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -147,7 +147,7 @@ func (s *Server) controlPing(params string, cfo ControlFuncOperations) (map[stri
 }
 
 func (s *Server) controlStatus(params string, cfo ControlFuncOperations) (map[string]interface{}, error) {
-	status := netceptor.MainInstance.Status()
+	status := s.nc.Status()
 	cfr := make(map[string]interface{})
 	cfr["NodeID"] = status.NodeID
 	cfr["Connections"] = status.Connections


### PR DESCRIPTION
Ran into this when trying to start a control service for my test nodes, turns out this previously could only work for the cli.