### PR TITLE
Acquire listenerLock before accessing listenerRegistry

### DIFF
--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -802,7 +802,9 @@ func (s *Netceptor) handleMessageData(md *messageData) error {
 		if handled {
 			return nil
 		}
+		s.listenerLock.RLock()
 		pc, ok := s.listenerRegistry[md.ToService]
+		s.listenerLock.RUnlock()
 		if !ok {
 			return fmt.Errorf("received message for unknown service")
 		}


### PR DESCRIPTION
Fixes a function where we mistakenly access listenerRegistry without first acquiring listenerLock.  See https://github.com/project-receptor/receptor/issues/75.