### PR TITLE
Bug fixes in Netceptor

### DIFF
--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -132,7 +132,7 @@ func (s *Server) controlPing(params string, cfo ControlFuncOperations) (map[stri
 			replyChan <- addr
 		}
 	}()
-	_, err = pc.WriteTo([]byte{}, netceptor.NewAddr(params, "ping"))
+	_, err = pc.WriteTo([]byte{}, s.nc.NewAddr(params, "ping"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/netceptor/addr.go
+++ b/pkg/netceptor/addr.go
@@ -4,21 +4,14 @@ import "fmt"
 
 // Addr represents an endpoint address on the Netceptor network
 type Addr struct {
+	network string
 	node    string
 	service string
 }
 
-// NewAddr generates a Receptor network address from a node ID and service name
-func NewAddr(node string, service string) Addr {
-	return Addr{
-		node:    node,
-		service: service,
-	}
-}
-
-// Network returns the network name, which is always just "netceptor"
+// Network returns the network name
 func (a Addr) Network() string {
-	return "netceptor"
+	return a.network
 }
 
 // String formats this address as a string

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -75,6 +75,7 @@ func (nc *PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 	}
 	nCopied := copy(p, m.Data)
 	fromAddr := Addr{
+		network: nc.s.networkName,
 		node:    m.FromNode,
 		service: m.FromService,
 	}
@@ -102,6 +103,7 @@ func (nc *PacketConn) LocalService() string {
 // LocalAddr returns the local address the connection is bound to.
 func (nc *PacketConn) LocalAddr() net.Addr {
 	return Addr{
+		network: nc.s.networkName,
 		node:    nc.s.nodeID,
 		service: nc.localService,
 	}

--- a/pkg/services/tun_proxy.go
+++ b/pkg/services/tun_proxy.go
@@ -129,7 +129,7 @@ func TunProxyService(s *netceptor.Netceptor, tunInterface string, lservice strin
 		logger.Error("Error listening on Receptor network\n")
 		return
 	}
-	raddr := netceptor.NewAddr(node, rservice)
+	raddr := s.NewAddr(node, rservice)
 	go runTunToNetceptor(iface, nconn, raddr)
 	go runNetceptorToTun(nconn, iface, raddr)
 }

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -26,7 +26,7 @@ func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node 
 		return
 	}
 
-	ncAddr := netceptor.NewAddr(node, service)
+	ncAddr := s.NewAddr(node, service)
 
 	for {
 		n, addr, err := uc.ReadFrom(buffer)
@@ -40,7 +40,7 @@ func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node 
 			}
 			logger.Debug("Received new UDP connection from %s\n", raddrStr)
 			connMap[raddrStr] = pc
-			go runNetceptorToUDPInbound(pc, uc, addr, netceptor.NewAddr(node, service))
+			go runNetceptorToUDPInbound(pc, uc, addr, s.NewAddr(node, service))
 		}
 		wn, err := pc.WriteTo(buffer[:n], ncAddr)
 		if err != nil {

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -42,12 +42,17 @@ func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permission
 			logger.Error("Error accepting Unix socket connection: %s\n", err)
 			return
 		}
-		qc, err := s.Dial(node, rservice, tlscfg)
-		if err != nil {
-			logger.Error("Error connecting on Receptor network: %s\n", err)
-			continue
-		}
-		go sockutils.BridgeConns(uc, "unix socket service", qc, "receptor connection")
+		go func() {
+			defer func() {
+				_ = uc.Close()
+			}()
+			qc, err := s.Dial(node, rservice, tlscfg)
+			if err != nil {
+				logger.Error("Error connecting on Receptor network: %s\n", err)
+				return
+			}
+			sockutils.BridgeConns(uc, "unix socket service", qc, "receptor connection")
+		}()
 	}
 }
 

--- a/tests/functional/mesh/mesh.go
+++ b/tests/functional/mesh/mesh.go
@@ -162,14 +162,14 @@ func (n *Node) Ping(node string) (map[string]interface{}, error) {
 
 	sendErrChan := make(chan error)
 	go func() {
-		_, err = pc.WriteTo([]byte{}, netceptor.NewAddr(node, "ping"))
+		_, err = pc.WriteTo([]byte{}, n.NetceptorInstance.NewAddr(node, "ping"))
 		if err != nil {
 			sendErrChan <- err
 			return
 		}
 		select {
 		case <-time.After(100 * time.Millisecond):
-			_, err = pc.WriteTo([]byte{}, netceptor.NewAddr(node, "ping"))
+			_, err = pc.WriteTo([]byte{}, n.NetceptorInstance.NewAddr(node, "ping"))
 			if err != nil {
 				sendErrChan <- err
 				return


### PR DESCRIPTION
This PR:
* Adds a goroutine that starts with each session and listener, to monitor the shutdown context of the overall Netceptor instance as well as the passed-in context, and ensure that the sessions and listeners are closed at the appropriate time.
* Adds the ability for callers to pass in their own context to Listen as well as to Dial.
* Adds a unique network ID to each Netceptor instance, to avoid passing identical Addr objects to go-quic and expecting it to discern that they mean different things.  This requires moving NewAddr from Addr to Netceptor because we need to know the instance before we can generate an address.