### PR TITLE
Unlock Unix socket on proxy service exit

### DIFF
--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -21,6 +21,7 @@ func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permission
 		logger.Debug("Could not acquire lock on socket file: %s\n", err)
 		return
 	}
+	defer lock.Unlock()
 	err = os.RemoveAll(filename)
 	if err != nil {
 		logger.Debug("Could not overwrite socket file: %s\n", err)


### PR DESCRIPTION
We shouldn't leave the lock file locked if we exit the function.