### PR TITLE
Revert close behavior of unix proxy because closing here is premature

### DIFF
--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -44,9 +44,6 @@ func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permission
 			return
 		}
 		go func() {
-			defer func() {
-				_ = uc.Close()
-			}()
 			qc, err := s.Dial(node, rservice, tlscfg)
 			if err != nil {
 				logger.Error("Error connecting on Receptor network: %s\n", err)


### PR DESCRIPTION
The workceptor control service plugin expects the bridge to remain half-open after the other end closes, so we can send a final acknowledgement after receiving EOF on the incoming stdin.  As a result, we shouldn't call `close` in this function after all.