### PR TITLE
Add CancelRead to netceptor.Conn and use it in Workceptor

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -247,6 +247,11 @@ func (c *Conn) Read(b []byte) (n int, err error) {
 	return c.qs.Read(b)
 }
 
+// CancelRead cancels a pending read operation
+func (c *Conn) CancelRead() {
+	c.qs.CancelRead(499)
+}
+
 // Write writes data to the connection
 func (c *Conn) Write(b []byte) (n int, err error) {
 	return c.qs.Write(b)


### PR DESCRIPTION
The semantics of `netceptor.Conn.Close()` are that it closes the writer side of the connection but not the reader.  This mirrors the semantics of TCP, where "close" means, essentially, "send a FIN" - and obviously you can't call a function on hostA that causes hostB to send a FIN because that would be spooky action at a distance.

We probably want these semantics to stay the way they are, but Workceptor needs a way to cancel its stdout `io.Copy()` process when we become aware that a unit of work is cancelled or released.  Luckily, go-quic implements a `CancelRead()` function for just this purpose.  So what this PR does is add a `netceptor.Conn.CancelRead()` that can be called by Workceptor to unblock the `io.Copy()`.  HTTP status code 499 is used because it kinda sorta means "closed by user."