### PR TITLE
Don't allow AcceptStream failures to block Accept

### DIFF
--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -10,18 +10,17 @@ import (
 	"net"
 	"os"
 	"runtime"
-	"syscall"
 )
 
 // UnixProxyServiceInbound listens on a Unix socket and forwards connections over the Receptor network
 func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permissions os.FileMode,
 	node string, rservice string, tlscfg *tls.Config) error {
-	uli, lockFd, err := sockutils.UnixSocketListen(filename, permissions)
+	uli, lock, err := sockutils.UnixSocketListen(filename, permissions)
 	if err != nil {
 		return fmt.Errorf("error opening Unix socket: %s", err)
 	}
 	go func() {
-		defer syscall.Close(lockFd)
+		defer lock.Unlock()
 		for {
 			uc, err := uli.Accept()
 			if err != nil {

--- a/pkg/sockutils/flock.go
+++ b/pkg/sockutils/flock.go
@@ -1,0 +1,38 @@
+//+build !windows
+
+package sockutils
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// ErrLocked is returned when the flock is already held
+var ErrLocked = fmt.Errorf("fslock is already locked")
+
+// FLock represents a file lock
+type FLock struct {
+	fd int
+}
+
+// TryFLock non-blockingly attempts to acquire a lock on the file
+func TryFLock(filename string) (*FLock, error) {
+	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0600)
+	if err != nil {
+		return nil, err
+	}
+	err = syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == syscall.EWOULDBLOCK {
+		err = ErrLocked
+	}
+	if err != nil {
+		_ = syscall.Close(fd)
+		return nil, err
+	}
+	return &FLock{fd: fd}, nil
+}
+
+// Unlock unlocks the file lock
+func (lock *FLock) Unlock() error {
+	return syscall.Close(lock.fd)
+}

--- a/pkg/sockutils/flock_windows.go
+++ b/pkg/sockutils/flock_windows.go
@@ -1,0 +1,24 @@
+//+build windows
+
+package sockutils
+
+import (
+	"fmt"
+)
+
+// ErrLocked is returned when the flock is already held
+var ErrLocked = fmt.Errorf("fslock is already locked")
+
+// FLock represents a Unix file lock, but is not usable on Windows
+type FLock struct {
+}
+
+// TryFLock is not implemented on Windows
+func TryFLock(filename string) (*FLock, error) {
+	return nil, fmt.Errorf("file locks not implemented on Windows")
+}
+
+// Unlock is not implemented on Windows
+func (lock *FLock) Unlock() error {
+	return fmt.Errorf("file locks not implemented on Windows")
+}

--- a/pkg/sockutils/unixsock.go
+++ b/pkg/sockutils/unixsock.go
@@ -1,0 +1,55 @@
+//+build !windows
+
+package sockutils
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"syscall"
+)
+
+// errLocked is returned when the flock is already held
+var errLocked = fmt.Errorf("fslock is already locked")
+
+// tryFLock non-blockingly attempts to acquire a lock on the file
+func tryFLock(filename string) (int, error) {
+	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0600)
+	if err != nil {
+		return 0, err
+	}
+	err = syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == syscall.EWOULDBLOCK {
+		err = errLocked
+	}
+	if err != nil {
+		_ = syscall.Close(fd)
+		return 0, err
+	}
+	return fd, nil
+}
+
+// UnixSocketListen listens on a Unix socket, handling file locking and permissions
+func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, int, error) {
+	lockFd, err := tryFLock(filename + ".lock")
+	if err != nil {
+		return nil, -1, fmt.Errorf("could not acquire lock on socket file: %s", err)
+	}
+	err = os.RemoveAll(filename)
+	if err != nil {
+		_ = syscall.Close(lockFd)
+		return nil, -1, fmt.Errorf("could not overwrite socket file: %s", err)
+	}
+	uli, err := net.Listen("unix", filename)
+	if err != nil {
+		_ = syscall.Close(lockFd)
+		return nil, -1, fmt.Errorf("could not listen on socket file: %s", err)
+	}
+	err = os.Chmod(filename, permissions)
+	if err != nil {
+		_ = uli.Close()
+		_ = syscall.Close(lockFd)
+		return nil, -1, fmt.Errorf("error setting socket file permissions: %s", err)
+	}
+	return uli, lockFd, nil
+}

--- a/pkg/sockutils/unixsock.go
+++ b/pkg/sockutils/unixsock.go
@@ -6,50 +6,29 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"syscall"
 )
 
-// errLocked is returned when the flock is already held
-var errLocked = fmt.Errorf("fslock is already locked")
-
-// tryFLock non-blockingly attempts to acquire a lock on the file
-func tryFLock(filename string) (int, error) {
-	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0600)
-	if err != nil {
-		return 0, err
-	}
-	err = syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
-	if err == syscall.EWOULDBLOCK {
-		err = errLocked
-	}
-	if err != nil {
-		_ = syscall.Close(fd)
-		return 0, err
-	}
-	return fd, nil
-}
-
 // UnixSocketListen listens on a Unix socket, handling file locking and permissions
-func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, int, error) {
-	lockFd, err := tryFLock(filename + ".lock")
+func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, *FLock, error) {
+	lock, err := TryFLock(filename + ".lock")
 	if err != nil {
-		return nil, -1, fmt.Errorf("could not acquire lock on socket file: %s", err)
+		return nil, nil, fmt.Errorf("could not acquire lock on socket file: %s", err)
 	}
 	err = os.RemoveAll(filename)
 	if err != nil {
-		_ = syscall.Close(lockFd)
-		return nil, -1, fmt.Errorf("could not overwrite socket file: %s", err)
+		_ = lock.Unlock()
+		return nil, nil, fmt.Errorf("could not overwrite socket file: %s", err)
 	}
 	uli, err := net.Listen("unix", filename)
 	if err != nil {
-		_ = syscall.Close(lockFd)
-		return nil, -1, fmt.Errorf("could not listen on socket file: %s", err)
+		_ = lock.Unlock()
+		return nil, nil, fmt.Errorf("could not listen on socket file: %s", err)
 	}
 	err = os.Chmod(filename, permissions)
 	if err != nil {
 		_ = uli.Close()
-		_ = syscall.Close(lockFd)
-		return nil, -1, fmt.Errorf("error setting socket file permissions: %s", err)
+		_ = lock.Unlock()
+		return nil, nil, fmt.Errorf("error setting socket file permissions: %s", err)
 	}
-	return uli, lockFd, nil
+	return uli, lock, nil
 }

--- a/pkg/sockutils/unixsock_windows.go
+++ b/pkg/sockutils/unixsock_windows.go
@@ -1,0 +1,14 @@
+//+build windows
+
+package sockutils
+
+import (
+	"fmt"
+	"net"
+	"os"
+)
+
+// UnixSocketListen is not available on Windows
+func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, int, error) {
+	return nil, -1, fmt.Errorf("Unix sockets not available on Windows")
+}

--- a/pkg/sockutils/unixsock_windows.go
+++ b/pkg/sockutils/unixsock_windows.go
@@ -9,6 +9,6 @@ import (
 )
 
 // UnixSocketListen is not available on Windows
-func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, int, error) {
-	return nil, -1, fmt.Errorf("Unix sockets not available on Windows")
+func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, *FLock, error) {
+	return nil, nil, fmt.Errorf("Unix sockets not available on Windows")
 }


### PR DESCRIPTION
The current implementation has a single loop that does an Accept and then an AcceptStream.  If someone connects but fails to open a stream, the AcceptStream will block forever, preventing any future connections.

This PR makes Listen start an accept loop, that sends connections to the main Accept function through a channel.  The loop runs AcceptStream in a separate goroutine, so it does not block the main Accept loop.