### PR TITLE
Do not require --socket when calling --help

### DIFF
--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -13,6 +13,7 @@ from .socket_interface import ReceptorControl
 
 
 class IgnoreRequiredWithHelp(click.Group):
+    # allows user to call --help without needing to provide required=true parameters
     def parse_args(self, ctx, args):
         try:
             return super(IgnoreRequiredWithHelp, self).parse_args(ctx, args)
@@ -25,7 +26,7 @@ class IgnoreRequiredWithHelp(click.Group):
                 param.required = False
             return super(IgnoreRequiredWithHelp, self).parse_args(ctx, args)
 
-            
+
 @click.group(cls=IgnoreRequiredWithHelp)
 @click.pass_context
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -12,7 +12,21 @@ import dateutil.parser
 from .socket_interface import ReceptorControl
 
 
-@click.group()
+class IgnoreRequiredWithHelp(click.Group):
+    def parse_args(self, ctx, args):
+        try:
+            return super(IgnoreRequiredWithHelp, self).parse_args(ctx, args)
+        except click.MissingParameter as exc:
+            if '--help' not in args:
+                raise
+
+            # remove the required params so that help can display
+            for param in self.params:
+                param.required = False
+            return super(IgnoreRequiredWithHelp, self).parse_args(ctx, args)
+
+            
+@click.group(cls=IgnoreRequiredWithHelp)
 @click.pass_context
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")


### PR DESCRIPTION
Overrides the `parse_args()` method of the `click.Group` class. In the presence of --help it will set required parameters to false, avoiding the `Error: missing parameter: socket` message

issue #80 