### PR TITLE
Allow user to define a cost per remote node

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -47,7 +47,7 @@ func (cfg nullBackendCfg) Start(ctx context.Context) (chan netceptor.BackendSess
 
 // Run runs the action, in this case adding a null backend to keep the wait group alive
 func (cfg nullBackendCfg) Run() error {
-	err := netceptor.MainInstance.AddBackend(&nullBackendCfg{}, 1.0)
+	err := netceptor.MainInstance.AddBackend(&nullBackendCfg{}, 1.0, make(map[string]float64))
 	if err != nil {
 		return err
 	}

--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -47,7 +47,7 @@ func (cfg nullBackendCfg) Start(ctx context.Context) (chan netceptor.BackendSess
 
 // Run runs the action, in this case adding a null backend to keep the wait group alive
 func (cfg nullBackendCfg) Run() error {
-	err := netceptor.MainInstance.AddBackend(&nullBackendCfg{}, 1.0, make(map[string]float64))
+	err := netceptor.MainInstance.AddBackend(&nullBackendCfg{}, 1.0, nil)
 	if err != nil {
 		return err
 	}

--- a/example/net.go
+++ b/example/net.go
@@ -30,7 +30,7 @@ func main() {
 		fmt.Printf("Error listening on TCP: %s\n", err)
 		os.Exit(1)
 	}
-	err = n1.AddBackend(b1, 1.0)
+	err = n1.AddBackend(b1, 1.0, nil)
 	if err != nil {
 		fmt.Printf("Error starting backend: %s\n", err)
 		os.Exit(1)
@@ -42,7 +42,7 @@ func main() {
 		fmt.Printf("Error dialing on TCP: %s\n", err)
 		os.Exit(1)
 	}
-	err = n2.AddBackend(b2, 1.0)
+	err = n2.AddBackend(b2, 1.0, nil)
 
 	// Start an echo server on node 1
 	l1, err := n1.Listen("echo", nil)

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -203,6 +203,7 @@ type TCPListenerCfg struct {
 	Port     int     `description:"Local TCP port to listen on" barevalue:"yes" required:"yes"`
 	TLS      string  `description:"Name of TLS server config"`
 	Cost     float64 `description:"Connection cost (weight)" default:"1.0"`
+	NodeCostMap map[string]float64 `description:"Connection cost (weight) for specific node"`
 }
 
 // Prepare verifies the parameters are correct
@@ -225,7 +226,7 @@ func (cfg TCPListenerCfg) Run() error {
 		logger.Error("Error creating listener %s: %s\n", address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost)
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCostMap)
 	if err != nil {
 		return err
 	}
@@ -264,7 +265,7 @@ func (cfg TCPDialerCfg) Run() error {
 		logger.Error("Error creating peer %s: %s\n", cfg.Address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost)
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, make(map[string]float64))
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -199,17 +199,22 @@ func (ns *TCPSession) Close() error {
 
 // TCPListenerCfg is the cmdline configuration object for a TCP listener
 type TCPListenerCfg struct {
-	BindAddr string  `description:"Local address to bind to" default:"0.0.0.0"`
-	Port     int     `description:"Local TCP port to listen on" barevalue:"yes" required:"yes"`
-	TLS      string  `description:"Name of TLS server config"`
-	Cost     float64 `description:"Connection cost (weight)" default:"1.0"`
-	NodeCostMap map[string]float64 `description:"Connection cost (weight) for specific node"`
+	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
+	Port     int                `description:"Local TCP port to listen on" barevalue:"yes" required:"yes"`
+	TLS      string             `description:"Name of TLS server config"`
+	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
+	NodeCost map[string]float64 `description:"Connection cost (weight) for each node"`
 }
 
 // Prepare verifies the parameters are correct
 func (cfg TCPListenerCfg) Prepare() error {
 	if cfg.Cost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
+	}
+	for node, cost := range cfg.NodeCost {
+		if cost <= 0.0 {
+			return fmt.Errorf("connection cost must be positive for %s", node)
+		}
 	}
 	return nil
 }
@@ -226,7 +231,7 @@ func (cfg TCPListenerCfg) Run() error {
 		logger.Error("Error creating listener %s: %s\n", address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCostMap)
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCost)
 	if err != nil {
 		return err
 	}
@@ -265,7 +270,7 @@ func (cfg TCPDialerCfg) Run() error {
 		logger.Error("Error creating peer %s: %s\n", cfg.Address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, make(map[string]float64))
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -256,7 +256,7 @@ func (cfg UDPListenerCfg) Run() error {
 		logger.Error("Error creating listener %s: %s\n", address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost)
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, make(map[string]float64))
 	if err != nil {
 		logger.Error("Error creating backend for %s: %s\n", address, err)
 		return err
@@ -287,7 +287,7 @@ func (cfg UDPDialerCfg) Run() error {
 		logger.Error("Error creating peer %s: %s\n", cfg.Address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost)
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, make(map[string]float64))
 	if err != nil {
 		logger.Error("Error creating backend for %s: %s\n", cfg.Address, err)
 		return err

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -239,7 +239,7 @@ func (cfg WebsocketListenerCfg) Run() error {
 		logger.Error("Error creating listener %s: %s\n", address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost)
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, make(map[string]float64))
 	if err != nil {
 		return err
 	}
@@ -290,7 +290,7 @@ func (cfg WebsocketDialerCfg) Run() error {
 		logger.Error("Error creating peer %s: %s\n", cfg.Address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost)
+	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, make(map[string]float64))
 	if err != nil {
 		return err
 	}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -261,7 +261,7 @@ func (s *Netceptor) NodeID() string {
 }
 
 // AddBackend adds a backend to the Netceptor system
-func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, costPerNode map[string]float64) error {
+func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCostMap map[string]float64) error {
 	sessChan, err := backend.Start(s.context)
 	if err != nil {
 		return err
@@ -276,7 +276,7 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, costPerN
 				if ok {
 					s.backendWaitGroup.Add(1)
 					go func() {
-						err := s.runProtocol(sess, connectionCost, costPerNode)
+						err := s.runProtocol(sess, connectionCost, nodeCostMap)
 						s.backendWaitGroup.Done()
 						if err != nil {
 							logger.Error("Backend error: %s\n", err)
@@ -991,7 +991,7 @@ func (s *Netceptor) sendAndLogConnectionRejection(remoteNodeID string, ci *connI
 }
 
 // Main Netceptor protocol loop
-func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, costPerNode map[string]float64) error {
+func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nodeCostMap map[string]float64) error {
 	if connectionCost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
 	}
@@ -1106,7 +1106,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, cos
 						return s.sendAndLogConnectionRejection(remoteNodeID, ci, "it is not in the accepted connections list")
 					}
 
-					remoteNodeCost, ok := costPerNode[remoteNodeID]
+					remoteNodeCost, ok := nodeCostMap[remoteNodeID]
 					if ok {
 						ci.Cost = remoteNodeCost
 						connectionCost = remoteNodeCost

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -261,7 +261,7 @@ func (s *Netceptor) NodeID() string {
 }
 
 // AddBackend adds a backend to the Netceptor system
-func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCostMap map[string]float64) error {
+func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost map[string]float64) error {
 	sessChan, err := backend.Start(s.context)
 	if err != nil {
 		return err
@@ -276,7 +276,7 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost
 				if ok {
 					s.backendWaitGroup.Add(1)
 					go func() {
-						err := s.runProtocol(sess, connectionCost, nodeCostMap)
+						err := s.runProtocol(sess, connectionCost, nodeCost)
 						s.backendWaitGroup.Done()
 						if err != nil {
 							logger.Error("Backend error: %s\n", err)
@@ -991,7 +991,7 @@ func (s *Netceptor) sendAndLogConnectionRejection(remoteNodeID string, ci *connI
 }
 
 // Main Netceptor protocol loop
-func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nodeCostMap map[string]float64) error {
+func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nodeCost map[string]float64) error {
 	if connectionCost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
 	}
@@ -1106,7 +1106,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 						return s.sendAndLogConnectionRejection(remoteNodeID, ci, "it is not in the accepted connections list")
 					}
 
-					remoteNodeCost, ok := nodeCostMap[remoteNodeID]
+					remoteNodeCost, ok := nodeCost[remoteNodeID]
 					if ok {
 						ci.Cost = remoteNodeCost
 						connectionCost = remoteNodeCost

--- a/tests/functional/mesh/mesh.go
+++ b/tests/functional/mesh/mesh.go
@@ -76,7 +76,7 @@ func (n *Node) TCPListen(address string, cost float64, tlsCfg *tls.Config) error
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost)
+	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
 	return err
 }
 
@@ -87,7 +87,7 @@ func (n *Node) TCPDial(address string, cost float64, tlsCfg *tls.Config) error {
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost)
+	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
 	return err
 }
 
@@ -99,7 +99,7 @@ func (n *Node) UDPListen(address string, cost float64) error {
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost)
+	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
 	return err
 }
 
@@ -110,7 +110,7 @@ func (n *Node) UDPDial(address string, cost float64) error {
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost)
+	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
 	return err
 }
 
@@ -123,7 +123,7 @@ func (n *Node) WebsocketListen(address string, cost float64, tlsCfg *tls.Config)
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost)
+	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
 	return err
 }
 
@@ -135,7 +135,7 @@ func (n *Node) WebsocketDial(address string, cost float64, tlsCfg *tls.Config) e
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost)
+	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
 	return err
 }
 


### PR DESCRIPTION
This commit will allow users to specify a map of nodes and costs.

```yaml
- tcp-listener:
    port: 2222
    cost: 1.0
    nodecost:
        bar: 1.5
        fish: 2.0
```

or from command line

`./receptor --node foo --tcp-listener nodecost='{"bar":1.5,"fish":2.0}'`

Nodes must still agree on cost.

If `nodecost[bar]` is not defined, then it uses the value of `cost`.

issue #31 