### PR TITLE
Make a Go build cache in the CI runner image

### DIFF
--- a/build/ci-image/Dockerfile
+++ b/build/ci-image/Dockerfile
@@ -5,5 +5,9 @@ RUN dnf -y update && \
   dnf clean all
 RUN pip3 install pre-commit
 RUN go get -u golang.org/x/lint/golint
+
+# Warm up the Go build cache
+RUN git clone https://github.com/project-receptor/receptor && cd receptor && make build-all && cd .. && rm -rf receptor
+
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR runs a `go build` from the devel branch of the main repo in the CI runner container build process.  This creates a warmed-up go build cache, with dependencies already downloaded and compiled.  CI builds of PRs that don't change dependencies will be much faster.  If a PR does change dependencies, then they will just get rebuilt, the same as if you were rebuilding them locally without deleting your Go build cache.