### PR TITLE
Run more tests in parallel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build-all:
 	go build example/*.go
 
 test:
-	go test ./... -p 1 -count=1
+	go test ./... -p 1 -parallel=16 -count=1
 
 ci: pre-commit build-all test
 	echo "All done"


### PR DESCRIPTION
by default `go test` will run up to GOMAXPROCS tests in parallel, in github actions i think that's only 1, however our tests are pretty light on cpu load so really we should be fine running many many more tests in parallel, seems like 4 - 16 is probably fine.