### PR TITLE
Add functional test for cancelling remote work

### DIFF
--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -172,7 +172,10 @@ func (r *ReceptorControl) WorkSubmit(node, serviceName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	r.ReadStr()
+	_, err = r.ReadStr() // flush response
+	if err != nil {
+		return "", err
+	}
 	r.CloseWrite()
 	response, err := r.ReadAndParseJSON()
 	if err != nil {

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -270,7 +270,6 @@ func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, workID string) 
 	}
 	if !assertWithTimeout(ctx, check) {
 		workStatus, _ := r.getWorkStatus(workID)
-		fmt.Println(workStatus)
 		return fmt.Errorf("Failed to assert %s is running", workID)
 	}
 	return nil

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -183,6 +183,7 @@ func (r *ReceptorControl) WorkSubmit(node, serviceName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	r.Close()
 	unitID := fmt.Sprintf("%v", response["unitid"])
 	return unitID, nil
 }
@@ -269,7 +270,6 @@ func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, workID string) 
 		return workStatus["StateName"] == "Running"
 	}
 	if !assertWithTimeout(ctx, check) {
-		workStatus, _ := r.getWorkStatus(workID)
 		return fmt.Errorf("Failed to assert %s is running", workID)
 	}
 	return nil

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -116,14 +116,12 @@ func (r *ReceptorControl) ReadAndParseJSON() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	jsonData := make(map[string]interface{})
 
 	err = json.Unmarshal(data, &jsonData)
 	if err != nil {
 		return nil, err
 	}
-
 	return jsonData, nil
 }
 

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -575,6 +575,90 @@ func TestCosts(t *testing.T) {
 
 }
 
+func TestWorkCancel(t *testing.T) {
+	t.Parallel()
+	// Setup our mesh yaml data
+	data := YamlData{}
+	data.Nodes = make(map[string]*YamlNode)
+	workCommand := map[interface{}]interface{}{
+		"service": "echosleep",
+		"command": "bash",
+		"params":  "-c \"for i in {1..5}; do echo $i; sleep 2;done\"",
+	}
+	// Generate a mesh with 2 nodes
+	data.Nodes["node1"] = &YamlNode{
+		Connections: map[string]YamlConnection{},
+		Nodedef: []interface{}{
+			map[interface{}]interface{}{
+				"tcp-listener": map[interface{}]interface{}{
+					"cost": 4.5,
+					"nodecost": map[interface{}]interface{}{
+						"node2": 2.6,
+					},
+				},
+			},
+		},
+	}
+	data.Nodes["node2"] = &YamlNode{
+		Connections: map[string]YamlConnection{
+			"node1": YamlConnection{
+				Index: 0,
+			},
+		},
+		Nodedef: []interface{}{
+			map[interface{}]interface{}{
+				"work-command": workCommand,
+			},
+		},
+	}
+
+	mesh, err := NewCLIMeshFromYaml(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mesh.WaitForShutdown()
+	defer mesh.Shutdown()
+
+	err = mesh.WaitForReady(60000)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	nodes := mesh.Nodes()
+
+	controller := receptorcontrol.New()
+	err = controller.Connect(nodes["node1"].ControlSocket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	workID, err := controller.WorkSubmit("node2", "echosleep")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// controller closes after a work submit, so must reopen
+	controller = receptorcontrol.New()
+	err = controller.Connect(nodes["node1"].ControlSocket())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = controller.AssertWorkRunning(workID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.WorkCancel(workID)
+	err = controller.AssertWorkCancelled(workID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.WorkRelease(workID)
+	err = controller.AssertWorkReleased(workID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller.Close()
+
+}
+
 func benchmarkLinearMeshStartup(totalNodes int, b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		// Setup our mesh yaml data

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -642,12 +642,14 @@ func TestWorkCancel(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = controller.AssertWorkRunning(workID)
+	ctx, _ = context.WithTimeout(context.Background(), 20*time.Second)
+	err = controller.AssertWorkRunning(ctx, workID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	controller.WorkCancel(workID)
-	err = controller.AssertWorkCancelled(workID)
+	ctx, _ = context.WithTimeout(context.Background(), 20*time.Second)
+	err = controller.AssertWorkCancelled(ctx, workID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -619,7 +619,8 @@ func TestWorkCancel(t *testing.T) {
 	defer mesh.WaitForShutdown()
 	defer mesh.Shutdown()
 
-	err = mesh.WaitForReady(60000)
+	ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+	err = mesh.WaitForReady(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Uses a 2-node mesh. `node1` starts work on `node2`. Issues a cancel, then a release.

We confirm that work is properly cancelled by issuing a `work status {workid}` command and asserting that `Detail` is `Cancelled` and `StateName` is `Failed`

We confirm that work is properly released by issue a `work list` command and asserting that workid is not in the list.