### PR TITLE
Fix complex type names in cmdline help

### DIFF
--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -212,7 +212,7 @@ type TCPListenerCfg struct {
 	Port     int                `description:"Local TCP port to listen on" barevalue:"yes" required:"yes"`
 	TLS      string             `description:"Name of TLS server config"`
 	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
-	NodeCost map[string]float64 `description:"Connection cost (weight) for each node"`
+	NodeCost map[string]float64 `description:"Per-node costs"`
 }
 
 // Prepare verifies the parameters are correct

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -248,7 +248,7 @@ type UDPListenerCfg struct {
 	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
 	Port     int                `description:"Local UDP port to listen on" barevalue:"yes" required:"yes"`
 	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
-	NodeCost map[string]float64 `description:"Connection cost (weight) for each node"`
+	NodeCost map[string]float64 `description:"Per-node costs"`
 }
 
 // Prepare verifies the parameters are correct

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -217,7 +217,7 @@ type WebsocketListenerCfg struct {
 	Port     int                `description:"Local TCP port to run http server on" barevalue:"yes" required:"yes"`
 	TLS      string             `description:"Name of TLS server config"`
 	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
-	NodeCost map[string]float64 `description:"Connection cost (weight) for each node"`
+	NodeCost map[string]float64 `description:"Per-node costs"`
 }
 
 // Prepare verifies the parameters are correct

--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -46,6 +46,21 @@ func AddConfigType(name string, description string, configType interface{}, requ
 	})
 }
 
+func printableTypeName(typ reflect.Type) string {
+	if typ.String() == "interface {}" {
+		return fmt.Sprintf("JSON data")
+	} else if typ.String() == "map[string]interface {}" {
+		return fmt.Sprintf("JSON dict with string keys")
+	} else if typ.Kind() == reflect.Map {
+		return fmt.Sprintf("JSON dict of %s to %s", printableTypeName(typ.Key()), printableTypeName(typ.Elem()))
+	} else if typ.Kind() == reflect.Slice {
+		return fmt.Sprintf("JSON list of %s", printableTypeName(typ.Elem()))
+	} else if typ.String() == "interface {}" {
+		return "anything"
+	}
+	return typ.String()
+}
+
 func printCmdHelp(ct param) {
 	if ct.Hidden {
 		return
@@ -57,7 +72,7 @@ func printCmdHelp(ct param) {
 	fmt.Printf("\n")
 	for i := 0; i < ct.Type.NumField(); i++ {
 		fmt.Printf("      %s=<%s>: %s", strings.ToLower(ct.Type.Field(i).Name),
-			ct.Type.Field(i).Type.Name(),
+			printableTypeName(ct.Type.Field(i).Type),
 			ct.Type.Field(i).Tag.Get("description"))
 		extras := make([]string, 0)
 		req, err := betterParseBool(ct.Type.Field(i).Tag.Get("required"))

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -107,7 +107,7 @@ func Trace(format string, v ...interface{}) {
 }
 
 type loglevelCfg struct {
-	Level string `description:"Log level to enable Error, Warning, Info, Debug" barevalue:"yes" required:"yes"`
+	Level string `description:"Log level: Error, Warning, Info or Debug" barevalue:"yes" required:"yes"`
 }
 
 func (cfg loglevelCfg) Prepare() error {

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -391,10 +391,10 @@ func (kw *kubeUnit) Release(force bool) error {
 // WorkKubeCfg is the cmdline configuration object for a Kubernetes worker plugin
 type WorkKubeCfg struct {
 	WorkType   string `required:"true" description:"Name for this worker type"`
-	KubeConfig string `description:"Kubeconfig file (defaults to in-cluster or environment)"`
+	KubeConfig string `description:"Kubeconfig file (default: in-cluster or environment)"`
 	Namespace  string `required:"true" description:"Kubernetes namespace to create pods in"`
 	Image      string `required:"true" description:"Container image to use for the worker pod"`
-	Command    string `description:"Command to run in the container (defaults to entrypoint)"`
+	Command    string `description:"Command to run in the container (default: entrypoint)"`
 }
 
 // newWorker is a factory to produce worker instances

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -42,8 +42,8 @@ func (pw *pythonUnit) Start() error {
 type WorkPythonCfg struct {
 	WorkType string                 `required:"true" description:"Name for this worker type"`
 	Plugin   string                 `required:"true" description:"Python module name of the worker plugin"`
-	Function string                 `required:"true" description:"Receptor-exported function within the module"`
-	Config   map[string]interface{} `description:"Plugin-specific configuration settings"`
+	Function string                 `required:"true" description:"Receptor-exported function to call"`
+	Config   map[string]interface{} `description:"Plugin-specific configuration"`
 }
 
 // newWorker is a factory to produce worker instances


### PR DESCRIPTION
Also tweaks some packages' help text so Receptor's help all fits in an 80 character terminal window.  Related #95.