### PR TITLE
Python worker no longer includes any platform-specific code

### DIFF
--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -1,5 +1,3 @@
-//+build linux
-
 package workceptor
 
 import (


### PR DESCRIPTION
So there's no reason to make its build be platform specific.