### PR TITLE
Fix status file locking race condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,31 +2,34 @@ receptor: $(shell find pkg -type f -name '*.go') cmd/receptor.go
 	go build cmd/receptor.go
 
 lint:
-	golint cmd/... pkg/... example/...
+	@golint cmd/... pkg/... example/...
 
 format:
-	find cmd/ pkg/ -type f -name '*.go' -exec go fmt {} \;
+	@find cmd/ pkg/ -type f -name '*.go' -exec go fmt {} \;
 
 fmt: format
 
 pre-commit:
-	echo "Running pre-commit" && \
-	pre-commit run --all-files
+	@pre-commit run --all-files
 
 build-all:
-	echo "Running Go builds" && \
-	go build cmd/*.go && \
+	@echo "Running Go builds..." && go build cmd/*.go && \
 	GOOS=windows go build -o receptor.exe cmd/receptor.go && \
 	GOOS=darwin go build -o receptor.app cmd/receptor.go && \
 	go build example/*.go
 
-test:
-	go test ./... -p 1 -parallel=16 -count=1
+test: receptor
+	@go test ./... -p 1 -parallel=16 -count=1
+
+testloop: receptor
+	@i=1; while echo "------ $$i" && \
+	  go test ./... -p 1 -parallel=16 -count=1; do \
+	  i=$$((i+1)); done
 
 ci: pre-commit build-all test
-	echo "All done"
+	@echo "All done"
 
 clean:
-	rm receptor receptor.exe receptor.app
+	@rm -fv receptor receptor.exe receptor.app
 
-.PHONY: lint format fmt ci pre-commit build-all test clean
+.PHONY: lint format fmt ci pre-commit build-all test clean testloop

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -51,11 +51,7 @@ func commandRunner(command string, params string, unitdir string) error {
 	status := StatusFileData{}
 	status.ExtraData = &commandExtraData{}
 	statusFilename := path.Join(unitdir, "status")
-	err := status.Load(statusFilename)
-	if err != nil {
-		return err
-	}
-	err = status.UpdateBasicStatus(statusFilename, WorkStatePending, "Not started yet", 0)
+	err := status.UpdateBasicStatus(statusFilename, WorkStatePending, "Not started yet", 0)
 	if err != nil {
 		logger.Error("Error updating status file %s: %s", statusFilename, err)
 	}

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -17,7 +17,7 @@ func newCommandWorker() WorkUnit {
 }
 
 func TestWorkceptorJson(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("/tmp", "receptor-test-*")
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "receptor-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -1,0 +1,84 @@
+package workceptor
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStatusFileLock(t *testing.T) {
+
+	numWriterThreads := 8
+	numReaderThreads := 8
+	baseWaitTime := 200 * time.Millisecond
+
+	tmpdir, err := ioutil.TempDir(os.TempDir(), "receptor-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpdir)
+	statusFilename := path.Join(tmpdir, "status")
+	startTime := time.Now()
+	var totalWaitTime time.Duration
+	wg := sync.WaitGroup{}
+	wg.Add(numWriterThreads)
+	for i := 0; i < numWriterThreads; i++ {
+		waitTime := time.Duration(i) * baseWaitTime
+		totalWaitTime = totalWaitTime + waitTime
+		go func(iter int, waitTime time.Duration) {
+			sfd := StatusFileData{}
+			err = sfd.UpdateFullStatus(statusFilename, func(status *StatusFileData) {
+				time.Sleep(waitTime)
+				status.State = iter
+				status.StdoutSize = int64(iter)
+				status.Detail = fmt.Sprintf("%d", iter)
+			})
+			wg.Done()
+		}(i, waitTime)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	wg2 := sync.WaitGroup{}
+	wg2.Add(numReaderThreads)
+	for i := 0; i < numReaderThreads; i++ {
+		go func() {
+			sfd := StatusFileData{}
+			fileHasExisted := false
+			for {
+				if ctx.Err() != nil {
+					wg2.Done()
+					return
+				}
+				err := sfd.Load(statusFilename)
+				if os.IsNotExist(err) && !fileHasExisted {
+					continue
+				}
+				fileHasExisted = true
+				if err != nil {
+					t.Fatal(fmt.Sprintf("Error loading status file: %s", err))
+				}
+				detailIter, err := strconv.Atoi(sfd.Detail)
+				if err != nil {
+					t.Fatal(fmt.Sprintf("Error converting status detail to int: %s", err))
+				}
+				if detailIter >= 0 {
+					if int64(sfd.State) != sfd.StdoutSize || sfd.State != detailIter {
+						t.Fatal(fmt.Sprintf("Mismatched data in struct"))
+					}
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	cancel()
+	totalTime := time.Now().Sub(startTime)
+	if totalTime < totalWaitTime {
+		t.Fatal("File locks apparently not locking")
+	}
+	wg2.Wait()
+}


### PR DESCRIPTION
There is an unavoidable race condition (or at least I can't think of a way to avoid it) when creating and locking a new file using POSIX advisory file locking.  Because there is no atomic "create and lock" operation, it is possible for one thread to create the file and then find it already locked by another thread.  When this happens between a Workceptor status file save and load operation, the load sees an empty file, resulting in a JSON decoding error.

~~To fix this, this PR adds logic to the load operation to check whether the file we just opened is empty.  If we are experiencing the race condition, that means there is another thread immediately waiting to write to the file as soon as it gains the lock.  So we release the lock once, wait a short time, and then try to re-open the file.  If the file is still empty at this second attempt, we conclude that there really is an empty file in the directory, which is an error condition.~~