### PR TITLE
Add more workceptor tests

### DIFF
--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -254,8 +254,8 @@ func (r *ReceptorControl) WorkRelease(unitID string) error {
 }
 
 // GetWorkStatus returns JSON of status file for a given unitID
-func (r *ReceptorControl) GetWorkStatus(unitID string) (workceptor.StatusFileData, error) {
-	status := workceptor.StatusFileData{}
+func (r *ReceptorControl) GetWorkStatus(unitID string) (*workceptor.StatusFileData, error) {
+	status := &workceptor.StatusFileData{}
 	_, err := r.WriteStr(fmt.Sprintf("work status %s\n", unitID))
 	if err != nil {
 		return status, err
@@ -264,7 +264,7 @@ func (r *ReceptorControl) GetWorkStatus(unitID string) (workceptor.StatusFileDat
 	if err != nil {
 		return status, err
 	}
-	err = json.Unmarshal(jsonData, &status)
+	err = json.Unmarshal(jsonData, status)
 	if err != nil {
 		return status, err
 	}

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/workceptor"
 	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 	"net"
 	"regexp"
@@ -15,13 +16,15 @@ import (
 
 // ReceptorControl Connects to a control socket and provides basic commands
 type ReceptorControl struct {
-	socketConn *net.UnixConn
+	socketConn     *net.UnixConn
+	socketFilename string
 }
 
 // New Returns an empty ReceptorControl
 func New() *ReceptorControl {
 	return &ReceptorControl{
-		socketConn: nil,
+		socketConn:     nil,
+		socketFilename: "",
 	}
 }
 
@@ -42,6 +45,20 @@ func (r *ReceptorControl) Connect(filename string) error {
 	err = r.handshake()
 	if err != nil {
 		return err
+	}
+	r.socketFilename = filename
+	return nil
+}
+
+// Reconnect to unix socket
+func (r *ReceptorControl) Reconnect() error {
+	if r.socketFilename != "" {
+		err := r.Connect(r.socketFilename)
+		if err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("Could not reconnect, no socketFilename")
 	}
 	return nil
 }
@@ -179,13 +196,14 @@ func (r *ReceptorControl) getWorkSubmitResponse() (string, error) {
 		return "", err
 	}
 	r.Close() // since write is closed, we should close the whole socket
+	r.Reconnect()
 	unitID := fmt.Sprintf("%v", response["unitid"])
 	return unitID, nil
 }
 
 // WorkSubmit begins work on remote node
-func (r *ReceptorControl) WorkSubmit(node, serviceName string) (string, error) {
-	_, err := r.WriteStr(fmt.Sprintf("work submit %s %s\n", node, serviceName))
+func (r *ReceptorControl) WorkSubmit(node, workType string) (string, error) {
+	_, err := r.WriteStr(fmt.Sprintf("work submit %s %s\n", node, workType))
 	if err != nil {
 		return "", err
 	}
@@ -197,8 +215,8 @@ func (r *ReceptorControl) WorkSubmit(node, serviceName string) (string, error) {
 }
 
 // WorkStart begins work on local node
-func (r *ReceptorControl) WorkStart(workID string) (string, error) {
-	_, err := r.WriteStr(fmt.Sprintf("work start %s\n", workID))
+func (r *ReceptorControl) WorkStart(workType string) (string, error) {
+	_, err := r.WriteStr(fmt.Sprintf("work start %s\n", workType))
 	if err != nil {
 		return "", err
 	}
@@ -210,8 +228,8 @@ func (r *ReceptorControl) WorkStart(workID string) (string, error) {
 }
 
 // WorkCancel cancels work
-func (r *ReceptorControl) WorkCancel(workID string) error {
-	_, err := r.WriteStr(fmt.Sprintf("work cancel %s\n", workID))
+func (r *ReceptorControl) WorkCancel(unitID string) error {
+	_, err := r.WriteStr(fmt.Sprintf("work cancel %s\n", unitID))
 	if err != nil {
 		return err
 	}
@@ -223,8 +241,8 @@ func (r *ReceptorControl) WorkCancel(workID string) error {
 }
 
 // WorkRelease cancels and deletes work
-func (r *ReceptorControl) WorkRelease(workID string) error {
-	_, err := r.WriteStr(fmt.Sprintf("work release %s\n", workID))
+func (r *ReceptorControl) WorkRelease(unitID string) error {
+	_, err := r.WriteStr(fmt.Sprintf("work release %s\n", unitID))
 	if err != nil {
 		return err
 	}
@@ -235,8 +253,9 @@ func (r *ReceptorControl) WorkRelease(workID string) error {
 	return nil
 }
 
-func (r *ReceptorControl) getWorkStatus(workID string) (map[string]interface{}, error) {
-	_, err := r.WriteStr(fmt.Sprintf("work status %s\n", workID))
+// GetWorkStatus returns JSON of status file for a given unitID
+func (r *ReceptorControl) GetWorkStatus(unitID string) (map[string]interface{}, error) {
+	_, err := r.WriteStr(fmt.Sprintf("work status %s\n", unitID))
 	if err != nil {
 		return nil, err
 	}
@@ -261,26 +280,55 @@ func (r *ReceptorControl) getWorkList() (map[string]interface{}, error) {
 }
 
 func assertWithTimeout(ctx context.Context, check func() bool) bool {
-	return utils.CheckUntilTimeout(ctx, 250*time.Millisecond, check)
+	return utils.CheckUntilTimeout(ctx, 500*time.Millisecond, check)
+}
+
+func (r *ReceptorControl) assertWorkState(ctx context.Context, unitID string, state int) bool {
+	check := func() bool {
+		workStatus, _ := r.GetWorkStatus(unitID)
+		return int(workStatus["State"].(float64)) == state
+	}
+	return assertWithTimeout(ctx, check)
 }
 
 //AssertWorkRunning waits until work status is running
-func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, workID string) error {
-	check := func() bool {
-		workStatus, _ := r.getWorkStatus(workID)
-		return workStatus["StateName"] == "Running"
+func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, unitID string) error {
+	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateRunning) {
+		return fmt.Errorf("Failed to assert %s is running or ctx timed out", unitID)
 	}
-	if !assertWithTimeout(ctx, check) {
-		return fmt.Errorf("Failed to assert %s is running", workID)
+	return nil
+}
+
+// AssertWorkPending waits until status is pending
+func (r *ReceptorControl) AssertWorkPending(ctx context.Context, unitID string) error {
+	if !r.assertWorkState(ctx, unitID, workceptor.WorkStatePending) {
+		return fmt.Errorf("Failed to assert %s is pending or ctx timed out", unitID)
+	}
+	return nil
+}
+
+// AssertWorkSucceeded waits until status is successful
+func (r *ReceptorControl) AssertWorkSucceeded(ctx context.Context, unitID string) error {
+	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateSucceeded) {
+		return fmt.Errorf("Failed to assert %s succeeded or ctx timed out", unitID)
+	}
+	return nil
+}
+
+// AssertWorkFailed waits until status is failed
+func (r *ReceptorControl) AssertWorkFailed(ctx context.Context, unitID string) error {
+	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateFailed) {
+		return fmt.Errorf("Failed to assert %s failed or ctx timed out", unitID)
 	}
 	return nil
 }
 
 //AssertWorkCancelled waits until work status is cancelled
-func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, workID string) error {
+func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, unitID string) error {
 	check := func() bool {
-		workStatus, _ := r.getWorkStatus(workID)
-		if workStatus["StateName"] != "Failed" && workStatus["StateName"] != "Succeeded" {
+		workStatus, _ := r.GetWorkStatus(unitID)
+		state := int(workStatus["State"].(float64))
+		if state != workceptor.WorkStateFailed {
 			return false
 		}
 		detailIf, ok := workStatus["Detail"]
@@ -306,26 +354,55 @@ func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, workID string
 		return false
 	}
 	if !assertWithTimeout(ctx, check) {
-		return fmt.Errorf("Failed to assert %s is cancelled", workID)
+		return fmt.Errorf("Failed to assert %s is cancelled or ctx timed out", unitID)
 	}
 	return nil
 }
 
 // AssertWorkReleased asserts that work is not in work list
-func (r *ReceptorControl) AssertWorkReleased(ctx context.Context, workID string) error {
+func (r *ReceptorControl) AssertWorkReleased(ctx context.Context, unitID string) error {
 	check := func() bool {
 		workList, err := r.getWorkList()
 		if err != nil {
 			return false
 		}
-		_, ok := workList[workID] // workID should not be in list
+		_, ok := workList[unitID] // unitID should not be in list
 		if ok {
 			return false
 		}
 		return true
 	}
 	if !assertWithTimeout(ctx, check) {
-		return fmt.Errorf("Failed to assert %s is released", workID)
+		return fmt.Errorf("Failed to assert %s is released or ctx timed out", unitID)
+	}
+
+	return nil
+}
+
+func (r *ReceptorControl) getWorkResults(unitID string, readSize int) ([]byte, error) {
+	r.WriteStr(fmt.Sprintf("work results %s\n", unitID))
+	r.ReadStr() // flush "Streaming results for.." line"
+	buf := make([]byte, readSize)
+	n, err := r.socketConn.Read(buf)
+	if err != nil {
+		return nil, err
+	}
+	if n != readSize {
+		return nil, fmt.Errorf("did not read correct size")
+	}
+	r.Close()
+	r.Reconnect()
+	return buf, nil
+}
+
+// AssertWorkResults makes sure results match expected byte array
+func (r *ReceptorControl) AssertWorkResults(unitID string, expectedResults []byte) error {
+	workResults, err := r.getWorkResults(unitID, len(expectedResults))
+	if err != nil {
+		return err
+	}
+	if string(expectedResults) != string(workResults) {
+		return fmt.Errorf("work results did not match expected results")
 	}
 	return nil
 }

--- a/tests/functional/mesh/climesh.go
+++ b/tests/functional/mesh/climesh.go
@@ -172,7 +172,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData) (*CLIMesh, error) {
 	baseDir := filepath.Join(os.TempDir(), "receptor-testing")
 	// Ignore the error, if the dir already exists thats fine
 	os.Mkdir(baseDir, 0755)
-	tempdir, err := ioutil.TempDir(baseDir, "mesh-*")
+	tempdir, err := ioutil.TempDir(baseDir, "mesh-")
 	if err != nil {
 		return nil, err
 	}
@@ -185,7 +185,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData) (*CLIMesh, error) {
 	// there's something to dial into
 	for k := range MeshDefinition.Nodes {
 		node := NewCLINode(k)
-		tempdir, err = ioutil.TempDir(mesh.dir, k+"-*")
+		tempdir, err = ioutil.TempDir(mesh.dir, k+"-")
 		if err != nil {
 			return nil, err
 		}

--- a/tests/functional/mesh/libmesh.go
+++ b/tests/functional/mesh/libmesh.go
@@ -206,7 +206,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData) (*LibMesh, error) {
 	baseDir := filepath.Join(os.TempDir(), "receptor-testing")
 	// Ignore the error, if the dir already exists thats fine
 	os.Mkdir(baseDir, 0755)
-	tempdir, err := ioutil.TempDir(baseDir, "mesh-*")
+	tempdir, err := ioutil.TempDir(baseDir, "mesh-")
 	if err != nil {
 		return nil, err
 	}
@@ -217,7 +217,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData) (*LibMesh, error) {
 	// there's something to dial into
 	for k := range MeshDefinition.Nodes {
 		node := NewLibNode(k)
-		node.dir, err = ioutil.TempDir(mesh.dir, k+"-*")
+		node.dir, err = ioutil.TempDir(mesh.dir, k+"-")
 		if err != nil {
 			return nil, err
 		}

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -730,6 +730,7 @@ func TestWork(t *testing.T) {
 		nodes := mesh.Nodes()
 
 		nodes["node3"].Shutdown()
+		nodes["node3"].WaitForShutdown()
 		unitID, err := controller.WorkSubmit("node3", "echosleepshort")
 		if err != nil {
 			t.Fatal(err)
@@ -766,6 +767,7 @@ func TestWork(t *testing.T) {
 			t.Fatal(err)
 		}
 		nodes["node2"].Shutdown()
+		nodes["node2"].WaitForShutdown()
 		nodes["node2"].Start()
 		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
 		err = controller.AssertWorkSucceeded(ctx, unitID)

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -677,12 +677,16 @@ func TestWork(t *testing.T) {
 		}
 	}
 
-	t.Run("cancel then release remote work", func(t *testing.T) {
-		t.Parallel()
-		controller, mesh, _ := workInit()
+	tearDown := func(controller *receptorcontrol.ReceptorControl, mesh *CLIMesh) {
 		defer mesh.WaitForShutdown()
 		defer mesh.Destroy()
 		defer controller.Close()
+	}
+
+	t.Run("cancel then release remote work", func(t *testing.T) {
+		t.Parallel()
+		controller, mesh, _ := workInit()
+		defer tearDown(controller, mesh)
 		nodes := mesh.Nodes()
 
 		unitID, err := controller.WorkSubmit("node3", "echosleeplong")
@@ -722,9 +726,7 @@ func TestWork(t *testing.T) {
 	t.Run("work submit while remote node is down", func(t *testing.T) {
 		t.Parallel()
 		controller, mesh, _ := workInit()
-		defer mesh.WaitForShutdown()
-		defer mesh.Destroy()
-		defer controller.Close()
+		defer tearDown(controller, mesh)
 		nodes := mesh.Nodes()
 
 		nodes["node3"].Shutdown()
@@ -745,9 +747,7 @@ func TestWork(t *testing.T) {
 	t.Run("work streaming resumes when relay node restarts", func(t *testing.T) {
 		t.Parallel()
 		controller, mesh, expectedResults := workInit()
-		defer mesh.WaitForShutdown()
-		defer mesh.Destroy()
-		defer controller.Close()
+		defer tearDown(controller, mesh)
 		nodes := mesh.Nodes()
 
 		unitID, err := controller.WorkSubmit("node3", "echosleeplong")

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -591,7 +591,7 @@ func TestWork(t *testing.T) {
 		"params":   "-c \"for i in {1..5}; do echo $i;done\"",
 	}
 	expectedResults := []byte("1\n2\n3\n4\n5\n")
-	// Generate a mesh with 2 nodes
+	// Generate a mesh with 3 nodes
 	data.Nodes["node2"] = &YamlNode{
 		Connections: map[string]YamlConnection{},
 		Nodedef: []interface{}{
@@ -672,7 +672,7 @@ func TestWork(t *testing.T) {
 			}
 			return false
 		}
-		if !utils.CheckUntilTimeout(ctx, 500*time.Millisecond, check) {
+		if !utils.CheckUntilTimeout(ctx, 3000*time.Millisecond, check) {
 			t.Errorf("file size not correct for %s", stdoutFilename)
 		}
 	}
@@ -682,13 +682,13 @@ func TestWork(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
 		err = controller.AssertWorkRunning(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		controller.WorkCancel(unitID)
-		ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
 		err = controller.AssertWorkCancelled(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
@@ -700,7 +700,7 @@ func TestWork(t *testing.T) {
 			t.Fatal(err)
 		}
 		controller.WorkRelease(unitID)
-		ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
 		err = controller.AssertWorkReleased(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
@@ -709,31 +709,13 @@ func TestWork(t *testing.T) {
 		assertFilesReleased(nodes["node3"].Dir(), "node3", remoteUnitID)
 	})
 
-	t.Run("get results from remote work", func(t *testing.T) {
-		unitID, err := controller.WorkSubmit("node3", "echosleepshort")
-		if err != nil {
-			t.Fatal(err)
-		}
-		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
-		err = controller.AssertWorkSucceeded(ctx, unitID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
-		assertStdoutFizeSize(ctx, nodes["node1"].Dir(), "node1", unitID, 10)
-		err = controller.AssertWorkResults(unitID, expectedResults)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
 	t.Run("work submit while remote node is down", func(t *testing.T) {
 		nodes["node3"].Shutdown()
 		unitID, err := controller.WorkSubmit("node3", "echosleepshort")
 		if err != nil {
 			t.Fatal(err)
 		}
-		ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
 		err = controller.AssertWorkPending(ctx, unitID)
 		nodes["node3"].Start()
 		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -694,8 +694,7 @@ func TestWork(t *testing.T) {
 			t.Fatal(err)
 		}
 		workStatus, err := controller.GetWorkStatus(unitID)
-		extraData := workStatus["ExtraData"].(map[string]interface{})
-		remoteUnitID := extraData["RemoteUnitID"].(string)
+		remoteUnitID := workStatus.ExtraData.(map[string]interface{})["RemoteUnitID"].(string)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
`TestWork` sets up a 3 node linear mesh
Node1  ---- Node2 ---- Node3   (node 1 can only reach node3 via node 2)

This PR includes 3 sub-tests
1. `Node1` starts work on `Node3`, then cancels and releases it.
2. Shutdown remote `Node3`. `Node1` starts work on `Node3`, bring `Node3` back online and make sure the job is successful on `Node1`.
3. `Node1` starts work on `Node3`. `Node2` goes down (the relay node), then comes back online. Make sure job on `Node1` is successful. It also tests that `Node1` receives partial work results before `Node2` goes down, then has the full results at the end.

Notes:
We have no way of indicating from the API that work has been successfully copied from stdout on the remote node to stdout on the controller node. 
`assertStdoutFizeSize()` is a method I wrote that will check the local stdout to make sure it has the data we expect, before calling `AssertWorkResults()`.

This change also adds a `Reconnect()` method for `receptorcontrol`. In some cases we needed to close the socket, so this allows us to reconnect without recreating a new receptorcontrol object

