### PR TITLE
Readstring uses context instead of timeout

### DIFF
--- a/pkg/utils/readstring_context.go
+++ b/pkg/utils/readstring_context.go
@@ -28,6 +28,6 @@ func ReadStringContext(ctx context.Context, reader *bufio.Reader, delim byte) (s
 	case res := <-result:
 		return res.str, res.err
 	case <-ctx.Done():
-		return "", fmt.Errorf("ctx timeout")
+		return "", ctx.Err()
 	}
 }

--- a/pkg/utils/readstring_context.go
+++ b/pkg/utils/readstring_context.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"bufio"
 	"context"
-	"fmt"
 )
 
 type readStringResult = struct {

--- a/pkg/utils/readstring_context.go
+++ b/pkg/utils/readstring_context.go
@@ -11,7 +11,7 @@ type readStringResult = struct {
 	err error
 }
 
-// ReadStringContext calls bufio.Reader.ReadString() but enforces a context.  Note that if the
+// ReadStringContext calls bufio.Reader.ReadString() but uses a context.  Note that if the
 // ctx.Done() fires, the ReadString() call is still active, and bufio is not re-entrant, so it is
 // important for callers to error out of further use of the bufio.  Also, the goroutine will not
 // exit until the bufio's underlying connection is closed.

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -52,11 +52,14 @@ func (rw *remoteUnit) connectToRemote(ctx context.Context) (net.Conn, *bufio.Rea
 		return nil, nil, err
 	}
 	reader := bufio.NewReader(conn)
-	hello, err := utils.ReadStringWithTimeout(reader, '\n', 5*time.Second)
+	ctxChild, _ := context.WithTimeout(ctx, 5*time.Second)
+	hello, err := utils.ReadStringContext(ctxChild, reader, '\n')
 	if err != nil {
+		conn.Close()
 		return nil, nil, err
 	}
 	if !strings.Contains(hello, node) {
+		conn.Close()
 		return nil, nil, fmt.Errorf("while expecting node ID %s, got message: %s", node,
 			strings.TrimRight(hello, "\n"))
 	}


### PR DESCRIPTION
Also caller closes `conn` in case of context timeout.