### PR TITLE
Change readstring to readstringcontext to prevent possible hangs

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -129,8 +129,7 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 	if err != nil {
 		return fmt.Errorf("write error sending to %s: %s", red.RemoteNode, err)
 	}
-	ctxChild, _ := context.WithTimeout(ctx, 5*time.Second)
-	response, err := utils.ReadStringContext(ctxChild, reader, '\n')
+	response, err := utils.ReadStringContext(ctx, reader, '\n')
 	if err != nil {
 		conn.Close()
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
@@ -157,8 +156,7 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 	if err != nil {
 		return fmt.Errorf("error closing stdin file: %s", err)
 	}
-	ctxChild, _ = context.WithTimeout(ctx, 5*time.Second)
-	response, err = utils.ReadStringContext(ctxChild, reader, '\n')
+	response, err = utils.ReadStringContext(ctx, reader, '\n')
 	if err != nil {
 		conn.Close()
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
@@ -190,8 +188,7 @@ func (rw *remoteUnit) cancelOrReleaseRemoteUnit(ctx context.Context, conn net.Co
 	if err != nil {
 		return fmt.Errorf("write error sending to %s: %s", red.RemoteNode, err)
 	}
-	ctxChild, _ := context.WithTimeout(ctx, 5*time.Second)
-	response, err := utils.ReadStringContext(ctxChild, reader, '\n')
+	response, err := utils.ReadStringContext(ctx, reader, '\n')
 	if err != nil {
 		conn.Close()
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
@@ -234,8 +231,7 @@ func (rw *remoteUnit) monitorRemoteStatus(mw *utils.JobContext, forRelease bool)
 			conn = nil
 			continue
 		}
-		ctxChild, _ := context.WithTimeout(mw, 5*time.Second)
-		status, err := utils.ReadStringContext(ctxChild, reader, '\n')
+		status, err := utils.ReadStringContext(mw, reader, '\n')
 		if err != nil {
 			logger.Debug("Read error reading from %s: %s\n", remoteNode, err)
 			_ = conn.Close()
@@ -319,8 +315,7 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 				logger.Warning("Write error sending to %s: %s\n", remoteNode, err)
 				continue
 			}
-			ctxChild, _ := context.WithTimeout(mw, 5*time.Second)
-			status, err := utils.ReadStringContext(ctxChild, reader, '\n')
+			status, err := utils.ReadStringContext(mw, reader, '\n')
 			if err != nil {
 				logger.Warning("Read error reading from %s: %s\n", remoteNode, err)
 				continue

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -129,8 +129,10 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 	if err != nil {
 		return fmt.Errorf("write error sending to %s: %s", red.RemoteNode, err)
 	}
-	response, err := reader.ReadString('\n')
+	ctxChild, _ := context.WithTimeout(ctx, 5*time.Second)
+	response, err := utils.ReadStringContext(ctxChild, reader, '\n')
 	if err != nil {
+		conn.Close()
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
 	}
 	submitIDRegex := regexp.MustCompile("with ID ([a-zA-Z0-9]+)\\.")
@@ -155,8 +157,10 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 	if err != nil {
 		return fmt.Errorf("error closing stdin file: %s", err)
 	}
-	response, err = reader.ReadString('\n')
+	ctxChild, _ = context.WithTimeout(ctx, 5*time.Second)
+	response, err = utils.ReadStringContext(ctxChild, reader, '\n')
 	if err != nil {
+		conn.Close()
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
 	}
 	resultErrorRegex := regexp.MustCompile("ERROR: (.*)")
@@ -186,8 +190,10 @@ func (rw *remoteUnit) cancelOrReleaseRemoteUnit(ctx context.Context, conn net.Co
 	if err != nil {
 		return fmt.Errorf("write error sending to %s: %s", red.RemoteNode, err)
 	}
-	response, err := reader.ReadString('\n')
+	ctxChild, _ := context.WithTimeout(ctx, 5*time.Second)
+	response, err := utils.ReadStringContext(ctxChild, reader, '\n')
 	if err != nil {
+		conn.Close()
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
 	}
 	if response[:5] == "ERROR" {
@@ -228,7 +234,8 @@ func (rw *remoteUnit) monitorRemoteStatus(mw *utils.JobContext, forRelease bool)
 			conn = nil
 			continue
 		}
-		status, err := reader.ReadString('\n')
+		ctxChild, _ := context.WithTimeout(mw, 5*time.Second)
+		status, err := utils.ReadStringContext(ctxChild, reader, '\n')
 		if err != nil {
 			logger.Debug("Read error reading from %s: %s\n", remoteNode, err)
 			_ = conn.Close()
@@ -312,7 +319,8 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 				logger.Warning("Write error sending to %s: %s\n", remoteNode, err)
 				continue
 			}
-			status, err := reader.ReadString('\n')
+			ctxChild, _ := context.WithTimeout(mw, 5*time.Second)
+			status, err := utils.ReadStringContext(ctxChild, reader, '\n')
 			if err != nil {
 				logger.Warning("Read error reading from %s: %s\n", remoteNode, err)
 				continue


### PR DESCRIPTION
extending https://github.com/project-receptor/receptor/pull/138 to all the other uses of `readstring`