### PR TITLE
Packaging updates to CI runner image

### DIFF
--- a/packaging/ci-image/Dockerfile
+++ b/packaging/ci-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:32
 RUN dnf -y update && \
-  dnf -y install git golang python3 python3-pip make jq && \
+  dnf -y install git golang python3 python3-pip make jq iproute openssl && \
   dnf clean all
 RUN pip3 install pre-commit
 

--- a/packaging/ci-image/Dockerfile
+++ b/packaging/ci-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:32
 RUN dnf -y update && \
-  dnf -y install git golang python3 python3-pip python3-pip-wheel make && \
+  dnf -y install git golang python3 python3-pip make && \
   dnf clean all
 RUN pip3 install pre-commit
 

--- a/packaging/ci-image/Dockerfile
+++ b/packaging/ci-image/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:32
 RUN dnf -y update && \
-  dnf -y install git golang python3 python3-pip make && \
+  dnf -y install git golang python3 python3-pip make jq && \
   dnf clean all
 RUN pip3 install pre-commit
 


### PR DESCRIPTION
The python3-pip-wheel package doesn't exist in Fedora 32.  (This previously worked because we were using CentOS 8.)