### PR TITLE
Command service improvements

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -26,10 +26,18 @@ type nodeCfg struct {
 func (cfg nodeCfg) Prepare() error {
 	var err error
 	if cfg.ID == "" {
-		cfg.ID, err = os.Hostname()
+		host, err := os.Hostname()
 		if err != nil {
 			return err
 		}
+		lchost := strings.ToLower(host)
+		if lchost == "localhost" || lchost[:10] == "localhost." {
+			return fmt.Errorf("no node ID specified and local host name is localhost")
+		}
+		cfg.ID = host
+	}
+	if strings.ToLower(cfg.ID) == "localhost" {
+		return fmt.Errorf("node ID \"localhost\" is reserved")
 	}
 	var allowedPeers []string
 	if cfg.AllowedPeers != "" {

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -231,7 +231,7 @@ func (cfg TCPListenerCfg) Prepare() error {
 // Run runs the action
 func (cfg TCPListenerCfg) Run() error {
 	address := fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.Port)
-	tlscfg, err := netceptor.GetServerTLSConfig(cfg.TLS)
+	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,7 @@ func (cfg TCPDialerCfg) Run() error {
 	if err != nil {
 		return err
 	}
-	tlscfg, err := netceptor.GetClientTLSConfig(cfg.TLS, host)
+	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, host)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -236,7 +236,7 @@ func (cfg WebsocketListenerCfg) Prepare() error {
 // Run runs the action
 func (cfg WebsocketListenerCfg) Run() error {
 	address := fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.Port)
-	tlscfg, err := netceptor.GetServerTLSConfig(cfg.TLS)
+	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {
 		return err
 	}
@@ -287,7 +287,7 @@ func (cfg WebsocketDialerCfg) Run() error {
 	if u.Scheme == "wss" && tlsCfgName == "" {
 		tlsCfgName = "default"
 	}
-	tlscfg, err := netceptor.GetClientTLSConfig(tlsCfgName, u.Hostname())
+	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(tlsCfgName, u.Hostname())
 	if err != nil {
 		return err
 	}

--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -494,8 +494,10 @@ func loadConfigFromFile(filename string) ([]*cfgObjInfo, error) {
 	return cfgObjs, nil
 }
 
-// ParseAndRun parses the command line configuration and runs the selected actions.
-func ParseAndRun(args []string) {
+// ParseAndRun parses the command line configuration and runs the selected actions.  Phases is a list of function
+// names that will be called on each config objects.  If some objects need to be configured before others, use
+// multiple phases.  Each phase is run against all objects before moving to the next phase.
+func ParseAndRun(args []string, phases []string) {
 	var accumulator *cfgObjInfo
 	var commandType reflect.Type
 	var requiredParams map[string]bool
@@ -745,12 +747,7 @@ func ParseAndRun(args []string) {
 	}
 
 	// Run phases
-
-	// Prepare implementations must not refer to anything instantiated by any other object since
-	// the other object's resources may not be initialized yet. Prepare should not return until
-	// this object is ready to be accessed/used by other objects.
-	runMethod("Prepare")
-
-	// Run implementations can assume that everyone else's Prepare has already run.
-	runMethod("Run")
+	for i := range phases {
+		runMethod(phases[i])
+	}
 }

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -541,8 +541,11 @@ func (s *Netceptor) flood(message []byte, excludeConn string) {
 // All-zero seed for deterministic highwayhash
 var zerokey = make([]byte, 32)
 
-// Adds a name to the hash lookup table
+// Hash a name and add it to the lookup table
 func (s *Netceptor) addNameHash(name string) uint64 {
+	if strings.EqualFold(name, "localhost") {
+		name = s.nodeID
+	}
 	h, _ := highwayhash.New64(zerokey)
 	_, _ = h.Write([]byte(name))
 	hv := h.Sum64()
@@ -649,6 +652,9 @@ func (s *Netceptor) forwardMessage(md *messageData) error {
 func (s *Netceptor) sendMessage(fromService string, toNode string, toService string, data []byte) error {
 	if len(fromService) > 8 || len(toService) > 8 {
 		return fmt.Errorf("service name too long")
+	}
+	if strings.EqualFold(toNode, "localhost") {
+		toNode = s.nodeID
 	}
 	md := &messageData{
 		FromNode:    s.nodeID,

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -60,7 +60,7 @@ type CommandSvcCfg struct {
 // Run runs the action
 func (cfg CommandSvcCfg) Run() error {
 	logger.Info("Running command service %s\n", cfg)
-	tlscfg, err := netceptor.GetServerTLSConfig(cfg.TLS)
+	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -85,11 +85,11 @@ type TCPProxyInboundCfg struct {
 // Run runs the action
 func (cfg TCPProxyInboundCfg) Run() error {
 	logger.Debug("Running TCP inbound proxy service %v\n", cfg)
-	tlsClientCfg, err := netceptor.GetClientTLSConfig(cfg.TLSClient, cfg.RemoteNode)
+	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, cfg.RemoteNode)
 	if err != nil {
 		return err
 	}
-	tlsServerCfg, err := netceptor.GetServerTLSConfig(cfg.TLSServer)
+	tlsServerCfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLSServer)
 	if err != nil {
 		return err
 	}
@@ -108,7 +108,7 @@ type TCPProxyOutboundCfg struct {
 // Run runs the action
 func (cfg TCPProxyOutboundCfg) Run() error {
 	logger.Debug("Running TCP inbound proxy service %s\n", cfg)
-	tlsServerCfg, err := netceptor.GetServerTLSConfig(cfg.TLSServer)
+	tlsServerCfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLSServer)
 	if err != nil {
 		return err
 	}
@@ -116,7 +116,7 @@ func (cfg TCPProxyOutboundCfg) Run() error {
 	if err != nil {
 		return err
 	}
-	tlsClientCfg, err := netceptor.GetClientTLSConfig(cfg.TLSClient, host)
+	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, host)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -80,7 +80,7 @@ type UnixProxyInboundCfg struct {
 // Run runs the action
 func (cfg UnixProxyInboundCfg) Run() error {
 	logger.Debug("Running Unix socket inbound proxy service %v\n", cfg)
-	tlscfg, err := netceptor.GetClientTLSConfig(cfg.TLS, cfg.RemoteNode)
+	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, cfg.RemoteNode)
 	if err != nil {
 		return err
 	}
@@ -98,7 +98,7 @@ type UnixProxyOutboundCfg struct {
 // Run runs the action
 func (cfg UnixProxyOutboundCfg) Run() error {
 	logger.Debug("Running Unix socket inbound proxy service %s\n", cfg)
-	tlscfg, err := netceptor.GetServerTLSConfig(cfg.TLS)
+	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {
 		return err
 	}

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -16,26 +16,16 @@ func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperation
 	}
 	tokens := strings.Split(params, " ")
 	switch tokens[0] {
-	case "start", "submit":
+	case "submit":
 		var workType string
 		var workNode string
 		var paramStart int
-		if tokens[0] == "start" {
-			if len(tokens) < 2 {
-				return nil, fmt.Errorf("bad command")
-			}
-			workNode = w.nc.NodeID()
-			workType = tokens[1]
-			paramStart = 2
-		} else {
-			if len(tokens) < 3 {
-				return nil, fmt.Errorf("bad command")
-			}
-			workNode = tokens[1]
-			workType = tokens[2]
-			paramStart = 3
-
+		if len(tokens) < 3 {
+			return nil, fmt.Errorf("bad command")
 		}
+		workNode = tokens[1]
+		workType = tokens[2]
+		paramStart = 3
 		if workType == "remote" {
 			return nil, fmt.Errorf("bad command")
 		}
@@ -45,8 +35,7 @@ func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperation
 		}
 		var worker WorkUnit
 		var err error
-		// foocontroller: work submit foo workType should be run locally
-		if tokens[0] == "start" || workNode == w.nc.NodeID() {
+		if workNode == w.nc.NodeID() || strings.EqualFold(workNode, "localhost") {
 			worker, err = w.AllocateUnit(workType, params)
 		} else {
 			worker, err = w.AllocateRemoteUnit(workNode, workType, params)

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -3,42 +3,178 @@ package workceptor
 import (
 	"fmt"
 	"github.com/project-receptor/receptor/pkg/controlsvc"
+	"github.com/project-receptor/receptor/pkg/netceptor"
 	"os"
 	"path"
 	"strconv"
 	"strings"
 )
 
-// Worker function called by the control service to process a "work" command
-func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperations) (map[string]interface{}, error) {
-	if len(params) == 0 {
-		return nil, fmt.Errorf("bad command")
-	}
+type workceptorCommandType struct {
+	w *Workceptor
+}
+
+type workceptorCommand struct {
+	w          *Workceptor
+	subcommand string
+	params     map[string]interface{}
+}
+
+func (t *workceptorCommandType) InitFromString(params string) (controlsvc.ControlCommand, error) {
 	tokens := strings.Split(params, " ")
-	switch tokens[0] {
+	if len(tokens) == 0 {
+		return nil, fmt.Errorf("no work subcommand")
+	}
+	c := &workceptorCommand{
+		w:          t.w,
+		subcommand: strings.ToLower(tokens[0]),
+		params:     make(map[string]interface{}),
+	}
+	switch c.subcommand {
 	case "submit":
-		var workType string
-		var workNode string
-		var paramStart int
 		if len(tokens) < 3 {
-			return nil, fmt.Errorf("bad command")
+			return nil, fmt.Errorf("work submit requires a target node and work type")
 		}
-		workNode = tokens[1]
-		workType = tokens[2]
-		paramStart = 3
-		if workType == "remote" {
-			return nil, fmt.Errorf("bad command")
+		c.params["node"] = tokens[1]
+		c.params["worktype"] = tokens[2]
+		if len(tokens) > 3 {
+			c.params["params"] = strings.Join(tokens[3:], " ")
+		} else {
+			c.params["params"] = ""
 		}
-		params := ""
-		if len(tokens) > paramStart {
-			params = strings.Join(tokens[paramStart:], " ")
+	case "list":
+		if len(tokens) > 1 {
+			return nil, fmt.Errorf("work list does not take parameters")
+		}
+	case "status", "cancel", "release", "force-release":
+		if len(tokens) < 2 {
+			return nil, fmt.Errorf("work %s requires a unit ID", c.subcommand)
+		}
+		if len(tokens) > 2 {
+			return nil, fmt.Errorf("work %s does not take parameters after the unit ID", c.subcommand)
+		}
+		c.params["unitid"] = tokens[1]
+	case "results":
+		if len(tokens) < 2 {
+			return nil, fmt.Errorf("work results requires a unit ID")
+		}
+		if len(tokens) > 3 {
+			return nil, fmt.Errorf("work results only takes a unit ID and optional start position")
+		}
+		c.params["unitid"] = tokens[1]
+		if len(tokens) > 2 {
+			var err error
+			c.params["startpos"], err = strconv.ParseInt(tokens[2], 10, 64)
+			if err != nil {
+				return nil, fmt.Errorf("error converting start position to integer: %s", err)
+			}
+		} else {
+			c.params["startpos"] = int64(0)
+		}
+	}
+	return c, nil
+}
+
+// strFromMap extracts a string from a map[string]interface{}, handling errors
+func strFromMap(config map[string]interface{}, name string) (string, error) {
+	value, ok := config[name]
+	if !ok {
+		return "", fmt.Errorf("field %s missing", name)
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return "", fmt.Errorf("field %s must be a string", name)
+	}
+	return valueStr, nil
+}
+
+// intFromMap extracts an int64 from a map[string]interface{}, handling errors
+func intFromMap(config map[string]interface{}, name string) (int64, error) {
+	value, ok := config[name]
+	if !ok {
+		return 0, fmt.Errorf("field %s missing", name)
+	}
+	valueInt, ok := value.(int64)
+	if ok {
+		return valueInt, nil
+	}
+	valueFloat, ok := value.(float64)
+	if ok {
+		return int64(valueFloat), nil
+	}
+	valueStr, ok := value.(string)
+	if ok {
+		valueInt, err := strconv.ParseInt(valueStr, 10, 64)
+		if err != nil {
+			return valueInt, nil
+		}
+	}
+	return 0, fmt.Errorf("field %s value %s is not convertible to an int", name, value)
+}
+
+func (t *workceptorCommandType) InitFromJSON(config map[string]interface{}) (controlsvc.ControlCommand, error) {
+	subCmd, err := strFromMap(config, "subcommand")
+	if err != nil {
+		return nil, err
+	}
+	c := &workceptorCommand{
+		w:          t.w,
+		subcommand: strings.ToLower(subCmd),
+		params:     make(map[string]interface{}),
+	}
+	switch c.subcommand {
+	case "submit":
+		c.params["node"], err = strFromMap(config, "node")
+		if err != nil {
+			return nil, err
+		}
+		c.params["worktype"], err = strFromMap(config, "worktype")
+		if err != nil {
+			return nil, err
+		}
+		c.params["params"], err = strFromMap(config, "params")
+		if err != nil {
+			return nil, err
+		}
+	case "status", "cancel", "release", "force-release":
+		c.params["unitid"], err = strFromMap(config, "unitid")
+		if err != nil {
+			return nil, err
+		}
+	case "results":
+		c.params["unitid"], err = strFromMap(config, "unitid")
+		if err != nil {
+			return nil, err
+		}
+		c.params["startpos"], err = intFromMap(config, "startpos")
+		if err != nil {
+			return nil, err
+		}
+	}
+	return c, nil
+}
+
+// Worker function called by the control service to process a "work" command
+func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.ControlFuncOperations) (map[string]interface{}, error) {
+	switch c.subcommand {
+	case "submit":
+		workNode, err := strFromMap(c.params, "node")
+		if err != nil {
+			return nil, err
+		}
+		workType, err := strFromMap(c.params, "worktype")
+		if err != nil {
+			return nil, err
+		}
+		params, err := strFromMap(c.params, "params")
+		if err != nil {
+			return nil, err
 		}
 		var worker WorkUnit
-		var err error
-		if workNode == w.nc.NodeID() || strings.EqualFold(workNode, "localhost") {
-			worker, err = w.AllocateUnit(workType, params)
+		if workNode == nc.NodeID() || strings.EqualFold(workNode, "localhost") {
+			worker, err = c.w.AllocateUnit(workType, params)
 		} else {
-			worker, err = w.AllocateRemoteUnit(workNode, workType, params)
+			worker, err = c.w.AllocateRemoteUnit(workNode, workType, params)
 		}
 		if err != nil {
 			return nil, err
@@ -73,11 +209,11 @@ func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperation
 		}
 		return cfr, nil
 	case "list":
-		unitList := w.ListKnownUnitIDs()
+		unitList := c.w.ListKnownUnitIDs()
 		cfr := make(map[string]interface{})
 		for i := range unitList {
 			unitID := unitList[i]
-			status, err := w.unitStatusForCFR(unitID)
+			status, err := c.w.unitStatusForCFR(unitID)
 			if err != nil {
 				return nil, err
 			}
@@ -85,68 +221,67 @@ func (w *Workceptor) workFunc(params string, cfo controlsvc.ControlFuncOperation
 		}
 		return cfr, nil
 	case "status":
-		if len(tokens) != 2 {
-			return nil, fmt.Errorf("bad command")
+		unitid, err := strFromMap(c.params, "unitid")
+		if err != nil {
+			return nil, err
 		}
-		cfr, err := w.unitStatusForCFR(tokens[1])
+		cfr, err := c.w.unitStatusForCFR(unitid)
 		if err != nil {
 			return nil, err
 		}
 		return cfr, nil
 	case "cancel", "release", "force-release":
-		if len(tokens) != 2 {
-			return nil, fmt.Errorf("bad command")
+		unitid, err := strFromMap(c.params, "unitid")
+		if err != nil {
+			return nil, err
 		}
 		cfr := make(map[string]interface{})
 		var pendingMsg string
 		var completeMsg string
-		if tokens[0] == "cancel" {
+		if c.subcommand == "cancel" {
 			pendingMsg = "cancel pending"
 			completeMsg = "cancelled"
 		} else {
 			pendingMsg = "release pending"
 			completeMsg = "released"
 		}
-		unit, err := w.findUnit(tokens[1])
+		unit, err := c.w.findUnit(unitid)
 		if err != nil {
-			cfr["already gone"] = tokens[1]
+			cfr["already gone"] = unitid
 		} else {
-			if tokens[0] == "cancel" {
+			if c.subcommand == "cancel" {
 				err = unit.Cancel()
 			} else {
-				err = unit.Release(tokens[0] == "force-release")
+				err = unit.Release(c.subcommand == "force-release")
 			}
 			if err != nil && !IsPending(err) {
 				return nil, err
 			}
 			if IsPending(err) {
-				cfr[pendingMsg] = tokens[1]
+				cfr[pendingMsg] = unitid
 			} else {
-				cfr[completeMsg] = tokens[1]
+				cfr[completeMsg] = unitid
 			}
 		}
 		return cfr, nil
 	case "results":
-		if len(tokens) < 2 || len(tokens) > 3 {
-			return nil, fmt.Errorf("bad command")
+		unitid, err := strFromMap(c.params, "unitid")
+		if err != nil {
+			return nil, err
 		}
-		var startPos int64
-		if len(tokens) == 3 {
-			var err error
-			startPos, err = strconv.ParseInt(tokens[2], 10, 64)
-			if err != nil {
-				return nil, fmt.Errorf("bad command")
-			}
+		startPos, err := intFromMap(c.params, "startpos")
+		if err != nil {
+			return nil, err
 		}
 		doneChan := make(chan struct{})
 		defer func() {
 			doneChan <- struct{}{}
 		}()
-		resultChan, err := w.GetResults(tokens[1], startPos, doneChan)
+		resultChan, err := c.w.GetResults(unitid, startPos, doneChan)
 		if err != nil {
 			return nil, err
 		}
-		err = cfo.WriteToConn(fmt.Sprintf("Streaming results for work unit %s\n", tokens[1]), resultChan)
+		err = cfo.WriteToConn(fmt.Sprintf("Streaming results for work unit %s\n", unitid), resultChan)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -2,7 +2,6 @@ package workceptor
 
 import (
 	"context"
-	"github.com/project-receptor/receptor/pkg/controlsvc"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"io/ioutil"
 	"os"
@@ -23,8 +22,7 @@ func TestWorkceptorJson(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpdir)
 	nc := netceptor.New(nil, "test", nil)
-	cs := controlsvc.New(false, nc)
-	w, err := New(context.Background(), cs, nc, tmpdir)
+	w, err := New(context.Background(), nc, tmpdir)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -130,7 +130,7 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 	}
 	defer doClose()
 	red := rw.Status().ExtraData.(*remoteExtraData)
-	_, err := conn.Write([]byte(fmt.Sprintf("work start %s\n", red.RemoteWorkType)))
+	_, err := conn.Write([]byte(fmt.Sprintf("work submit localhost %s\n", red.RemoteWorkType)))
 	if err != nil {
 		return fmt.Errorf("write error sending to %s: %s", red.RemoteNode, err)
 	}

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -90,9 +90,8 @@ class ReceptorControl:
 
     def submit_work(self, node, worktype, params, payload):
         if node is None:
-            command = f"work start {worktype} {params}\n"
-        else:
-            command = f"work submit {node} {worktype} {params}\n"
+            node = "localhost"
+        command = f"work submit {node} {worktype} {params}\n"
         self.writestr(command)
         text = self.readstr()
         m = re.compile("Work unit created with ID (.+). Send stdin data and EOF.").fullmatch(text)

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -216,15 +216,7 @@ func (r *ReceptorControl) WorkSubmit(node, workType string) (string, error) {
 
 // WorkStart begins work on local node
 func (r *ReceptorControl) WorkStart(workType string) (string, error) {
-	_, err := r.WriteStr(fmt.Sprintf("work start %s\n", workType))
-	if err != nil {
-		return "", err
-	}
-	unitID, err := r.getWorkSubmitResponse()
-	if err != nil {
-		return "", err
-	}
-	return unitID, nil
+	return r.WorkSubmit("localhost", workType)
 }
 
 // WorkCancel cancels work

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -749,7 +749,10 @@ func TestWork(t *testing.T) {
 		}
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 		err = controller.AssertWorkPending(ctx, unitID)
-		nodes["node3"].Start()
+		err = nodes["node3"].Start()
+		if err != nil {
+			t.Fatal(err)
+		}
 		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
 		err = controller.AssertWorkSucceeded(ctx, unitID)
 		if err != nil {


### PR DESCRIPTION
* Combine the very similar `work start` and `work submit` commands into a single `work submit` command.
* Introduce a `localhost` name, so you can do `work submit localhost <worktype>` (and other things like `ping localhost`).
* Add the possibility of sending control service commands as JSON, to allow some commands to take larger or more complex parameters than are feasible as a simple command line (such as, for example, Kubernetes credentials).