### PR TITLE
Update control socket path and set RECEPTORCTL_SOCKET

### DIFF
--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -11,6 +11,8 @@ RUN dnf -y install dumb-init receptor receptorctl && \
 
 RUN rm -rf /receptor-RPMs/ /etc/yum.repos.d/receptor.repo
 
+ENV RECEPTORCTL_SOCKET=/tmp/receptor.sock
+
 EXPOSE 7323
 
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/packaging/container/receptor.conf
+++ b/packaging/container/receptor.conf
@@ -1,7 +1,7 @@
 ---
 - control-service:
     service: control
-    filename: /var/run/receptor.sock
+    filename: /tmp/receptor.sock
 
 - tcp-listener:
     port: 7323


### PR DESCRIPTION
This changes the control socket path to `/tmp/receptor.sock` because this is writable whether or not the container is running as root.  With this change, the container runs fine in OpenShift as unprivileged.  The PR also sets `RECEPTORCTL_SOCKET` so that if you `oc rsh` into the container (or `podman exec bash` locally), you can run things like `receptorctl status` and have it just work.