### PR TITLE
Add HopCount field to Netceptor core protocol

### DIFF
--- a/pkg/netceptor/hopcount_test.go
+++ b/pkg/netceptor/hopcount_test.go
@@ -1,0 +1,112 @@
+package netceptor
+
+import (
+	"context"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"log"
+	"strings"
+	"testing"
+	"time"
+)
+
+type logWriter struct {
+	t          *testing.T
+	node1count int
+	node2count int
+}
+
+func (lw *logWriter) Write(p []byte) (n int, err error) {
+	s := strings.Trim(string(p), "\n")
+	if strings.HasPrefix(s, "ERROR") {
+		if !strings.Contains(s, "maximum number of forwarding hops") {
+			lw.t.Fatal(s)
+			return
+		}
+	} else if strings.HasPrefix(s, "TRACE") {
+		if strings.Contains(s, "via node1") {
+			lw.node1count++
+		} else if strings.Contains(s, "via node2") {
+			lw.node2count++
+		}
+	}
+	lw.t.Log(s)
+	return len(p), nil
+}
+
+func TestHopCountLimit(t *testing.T) {
+	lw := &logWriter{
+		t: t,
+	}
+	log.SetOutput(lw)
+	logger.SetShowTrace(true)
+
+	// Create two Netceptor nodes with an in-memory connection
+	b1, b2, err := NewInMemoryBackendPair()
+	if err != nil {
+		t.Fatal(err)
+	}
+	n1 := New(context.Background(), "node1", nil)
+	err = n1.AddBackend(b1, 1.0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2 := New(context.Background(), "node2", nil)
+	err = n2.AddBackend(b2, 1.0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	timeout, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	for {
+		if timeout.Err() != nil {
+			t.Fatal(timeout.Err())
+		}
+		_, ok := n1.Status().RoutingTable["node2"]
+		if ok {
+			_, ok := n2.Status().RoutingTable["node1"]
+			if ok {
+				break
+			}
+		}
+	}
+
+	// Inject a fake node3 that both nodes think the other node has a route to
+	n1.addNameHash("node3")
+	n1.routingTableLock.Lock()
+	n1.routingTable["node3"] = "node2"
+	n1.routingTableLock.Unlock()
+	n2.addNameHash("node3")
+	n2.routingTableLock.Lock()
+	n2.routingTable["node3"] = "node1"
+	n2.routingTableLock.Unlock()
+
+	// Send a message to node3, which should bounce back and forth until max hops is reached
+	pc, err := n1.ListenPacket("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = pc.WriteTo([]byte("hello"), n1.NewAddr("node3", "test"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// If the hop count limit is not working, the connections will never become inactive
+	*b1.lastActivity = time.Now()
+	timeout, _ = context.WithTimeout(context.Background(), 2*time.Second)
+	for time.Now().Sub(*b1.lastActivity) < 250*time.Millisecond {
+		select {
+		case <-timeout.Done():
+			t.Fatal(timeout.Err())
+		case <-time.After(125 * time.Millisecond):
+		}
+	}
+
+	// Make sure we actually succeeded in creating a routing loop
+	if lw.node1count < 10 || lw.node2count < 10 {
+		t.Fatal("test did not create a routing loop")
+	}
+
+	n1.Shutdown()
+	n2.Shutdown()
+	n1.BackendWait()
+	n2.BackendWait()
+}

--- a/pkg/netceptor/inmem.go
+++ b/pkg/netceptor/inmem.go
@@ -1,0 +1,93 @@
+package netceptor
+
+import (
+	"context"
+	"time"
+)
+
+// InMemoryBackend is a simple in-memory channels-based backend, intended for testing.
+type InMemoryBackend struct {
+	peer         *InMemoryBackend
+	sessChan     chan BackendSession
+	lastActivity *time.Time
+}
+
+// NewInMemoryBackendPair instantiates two connected in-memory backends
+func NewInMemoryBackendPair() (*InMemoryBackend, *InMemoryBackend, error) {
+	var lastActivity time.Time
+	b1 := &InMemoryBackend{
+		lastActivity: &lastActivity,
+	}
+	b2 := &InMemoryBackend{
+		lastActivity: &lastActivity,
+	}
+	b1.peer = b2
+	b2.peer = b1
+	return b1, b2, nil
+}
+
+// Start generates a single session for both "sides" when the second call to Start occurs
+func (b *InMemoryBackend) Start(ctx context.Context) (chan BackendSession, error) {
+	b.sessChan = make(chan BackendSession)
+	if b.peer.sessChan != nil {
+		sessionCtx, sessionCancel := context.WithCancel(ctx)
+		chan1 := make(chan []byte)
+		chan2 := make(chan []byte)
+		myIms := &InMemorySession{
+			ctx:          sessionCtx,
+			cancel:       sessionCancel,
+			sendChan:     chan1,
+			recvChan:     chan2,
+			lastActivity: b.lastActivity,
+		}
+		peerIms := &InMemorySession{
+			ctx:          sessionCtx,
+			cancel:       sessionCancel,
+			sendChan:     chan2,
+			recvChan:     chan1,
+			lastActivity: b.lastActivity,
+		}
+		go func() {
+			b.sessChan <- myIms
+		}()
+		go func() {
+			b.peer.sessChan <- peerIms
+		}()
+	}
+	return b.sessChan, nil
+}
+
+// InMemorySession implements BackendSession for in-memory pairs
+type InMemorySession struct {
+	ctx          context.Context
+	cancel       context.CancelFunc
+	sendChan     chan []byte
+	recvChan     chan []byte
+	lastActivity *time.Time
+}
+
+// Send sends data over the session
+func (ims *InMemorySession) Send(data []byte) error {
+	*ims.lastActivity = time.Now()
+	ims.sendChan <- data
+	return nil
+}
+
+// Recv receives data via the session
+func (ims *InMemorySession) Recv(timeout time.Duration) ([]byte, error) {
+	select {
+	case data := <-ims.recvChan:
+		*ims.lastActivity = time.Now()
+		return data, nil
+	case <-time.After(timeout):
+		return nil, &TimeoutError{}
+	case <-ims.ctx.Done():
+		return nil, ims.ctx.Err()
+	}
+}
+
+// Close closes the session
+func (ims *InMemorySession) Close() error {
+	ims.cancel()
+	return nil
+}


### PR DESCRIPTION
This PR adds a HopCount field, to avoid unbounded bandwidth use when there is a routing loop (which the Receptor routing protocol _shouldn't_ allow, but...)   Related: https://github.com/project-receptor/receptor/issues/40.

This requires a change to the `MsgTypeData` packet format.  The initial, one-byte MessageType field is now extended to four bytes, with the first two being the message type and hop count.  Note that the change to the packet format is a breaking change - Receptor binaries compiled before this change will not be able to talk to those compiled after this change.  The 3rd and 4th bytes in the header are reserved for future uses.

Last but not least, this PR also reduces the time for batching routing update requests before actually doing the Dijkstra update.  On close examination of the code, we are never spuriously requesting routing updates - we only make such requests if the routing table has really changed, or a local connection has really come up or gone down.  Also, we have locking in place so if multiple requests are made within less than the time an update takes to complete, they will be serialized and the second update won't start until the first update is complete.  So it is safe to run these updates more aggressively.