### PR TITLE
Add unreachable handling for netceptor.Conn

### DIFF
--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"io"
 	"strings"
 )
@@ -21,7 +20,7 @@ func bridgeHalf(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2N
 	defer func() {
 		done <- true
 	}()
-	buf := make([]byte, netceptor.MTU)
+	buf := make([]byte, 65536)
 	shouldClose := false
 	for {
 		n, err := c1.Read(buf)

--- a/pkg/utils/broker.go
+++ b/pkg/utils/broker.go
@@ -1,0 +1,67 @@
+package utils
+
+import "context"
+
+// Broker code adapted from https://stackoverflow.com/questions/36417199/how-to-broadcast-message-using-channel
+// which is licensed under Creative Commons CC BY-SA 4.0.
+
+// Broker implements a simple pub-sub broadcast system
+type Broker struct {
+	ctx       context.Context
+	publishCh chan interface{}
+	subCh     chan chan interface{}
+	unsubCh   chan chan interface{}
+}
+
+// NewBroker allocates a new Broker object
+func NewBroker(ctx context.Context) *Broker {
+	b := &Broker{
+		ctx:       ctx,
+		publishCh: make(chan interface{}),
+		subCh:     make(chan chan interface{}),
+		unsubCh:   make(chan chan interface{}),
+	}
+	go b.start()
+	return b
+}
+
+// start starts the broker goroutine
+func (b *Broker) start() {
+	subs := map[chan interface{}]struct{}{}
+	for {
+		select {
+		case <-b.ctx.Done():
+			return
+		case msgCh := <-b.subCh:
+			subs[msgCh] = struct{}{}
+		case msgCh := <-b.unsubCh:
+			delete(subs, msgCh)
+		case msg := <-b.publishCh:
+			for msgCh := range subs {
+				// msgCh is buffered, use non-blocking send to protect the broker:
+				select {
+				case msgCh <- msg:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// Subscribe registers to receive messages from the broker
+func (b *Broker) Subscribe() chan interface{} {
+	msgCh := make(chan interface{}, 1)
+	b.subCh <- msgCh
+	return msgCh
+}
+
+// Unsubscribe de-registers a message receiver
+func (b *Broker) Unsubscribe(msgCh chan interface{}) {
+	b.unsubCh <- msgCh
+	close(msgCh)
+}
+
+// Publish sends a message to all subscribers
+func (b *Broker) Publish(msg interface{}) {
+	b.publishCh <- msg
+}

--- a/pkg/utils/cancel_with_err_context.go
+++ b/pkg/utils/cancel_with_err_context.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// CancelWithErrFunc is like a regular context.CancelFunc, but you can specify an error to return.
+type CancelWithErrFunc func(err error)
+
+// CancelWithErrContext is a context that can be cancelled with a specific error return.
+type CancelWithErrContext struct {
+	parentCtx context.Context
+	errChan   chan error
+	doneChan  chan struct{}
+	closeOnce sync.Once
+	err       error
+}
+
+// ContextWithCancelWithErr returns a context and a CancelWithErrFunc. This functions like a normal
+// context cancel function, except you can specify what error should be returned.
+func ContextWithCancelWithErr(parent context.Context) (*CancelWithErrContext, CancelWithErrFunc) {
+	cwe := &CancelWithErrContext{
+		parentCtx: parent,
+		errChan:   make(chan error),
+		doneChan:  make(chan struct{}),
+		closeOnce: sync.Once{},
+	}
+	go func() {
+		for {
+			select {
+			case <-parent.Done():
+				cwe.closeDoneChan()
+				return
+			case err := <-cwe.errChan:
+				cwe.err = err
+				if err != nil {
+					cwe.closeDoneChan()
+					return
+				}
+			}
+		}
+	}()
+	return cwe, func(err error) {
+		cwe.err = err
+		cwe.closeDoneChan()
+	}
+}
+
+func (cwe *CancelWithErrContext) closeDoneChan() {
+	cwe.closeOnce.Do(func() {
+		close(cwe.doneChan)
+	})
+}
+
+// Done implements Context.Done()
+func (cwe *CancelWithErrContext) Done() <-chan struct{} {
+	return cwe.doneChan
+}
+
+// Err implements Context.Err()
+func (cwe *CancelWithErrContext) Err() error {
+	if cwe.err != nil {
+		return cwe.err
+	}
+	return cwe.parentCtx.Err()
+}
+
+// Deadline implements Context.Deadline()
+func (cwe *CancelWithErrContext) Deadline() (time time.Time, ok bool) {
+	return cwe.parentCtx.Deadline()
+}
+
+// Value implements Context.Value()
+func (cwe *CancelWithErrContext) Value(key interface{}) interface{} {
+	return cwe.parentCtx.Value(key)
+}


### PR DESCRIPTION
This PR adds a new reserved service called "unreach" which is sent a message when a node receives a message to an unreachable service.  This allows the originating side to detect and return an appropriate error message when the requested service doesn't exist on the remote side, or when a local listener tries to send reply traffic to a peer that has been closed.

Related https://github.com/project-receptor/receptor/issues/13.