### PR TITLE
Fix log level not being set using bare parameter

### DIFF
--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -712,7 +712,7 @@ func ParseAndRun(args []string, phases []string) {
 			lcname := strings.ToLower(f.Name)
 			hasBeenSet := false
 			for i := range cfgObj.fieldsSet {
-				if cfgObj.fieldsSet[i] == lcname {
+				if strings.ToLower(cfgObj.fieldsSet[i]) == lcname {
 					hasBeenSet = true
 					break
 				}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -110,7 +110,7 @@ type loglevelCfg struct {
 	Level string `description:"Log level: Error, Warning, Info or Debug" barevalue:"yes" default:"error"`
 }
 
-func (cfg loglevelCfg) Prepare() error {
+func (cfg loglevelCfg) Init() error {
 	var err error
 	val, err := GetLogLevelByName(cfg.Level)
 	if err != nil {


### PR DESCRIPTION
This PR fixes an issue where `--log-level level=Debug` worked but `--log-level Debug` didn't.  See https://github.com/project-receptor/receptor/issues/157.

Also, moved log initialization to the recently-added Init startup phase, so that the logger is configured and able to catch messages as early as possible.