### PR TITLE
Add traceroute and reorganize controlsvc

### DIFF
--- a/pkg/controlsvc/connect.go
+++ b/pkg/controlsvc/connect.go
@@ -1,0 +1,85 @@
+package controlsvc
+
+import (
+	"fmt"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"strings"
+)
+
+type connectCommandType struct{}
+type connectCommand struct {
+	targetNode    string
+	targetService string
+	tlsConfigName string
+}
+
+func (t *connectCommandType) InitFromString(params string) (ControlCommand, error) {
+	tokens := strings.Split(params, " ")
+	if len(tokens) < 2 {
+		return nil, fmt.Errorf("no connect target")
+	}
+	if len(tokens) > 3 {
+		return nil, fmt.Errorf("too many parameters")
+	}
+	var tlsConfigName string
+	if len(tokens) == 3 {
+		tlsConfigName = tokens[2]
+	}
+	c := &connectCommand{
+		targetNode:    tokens[0],
+		targetService: tokens[1],
+		tlsConfigName: tlsConfigName,
+	}
+	return c, nil
+}
+
+func (t *connectCommandType) InitFromJSON(config map[string]interface{}) (ControlCommand, error) {
+	targetNode, ok := config["node"]
+	if !ok {
+		return nil, fmt.Errorf("no connect target node")
+	}
+	targetNodeStr, ok := targetNode.(string)
+	if !ok {
+		return nil, fmt.Errorf("connect target node must be string")
+	}
+	targetService, ok := config["service"]
+	if !ok {
+		return nil, fmt.Errorf("no connect target service")
+	}
+	targetServiceStr, ok := targetService.(string)
+	if !ok {
+		return nil, fmt.Errorf("connect target service must be string")
+	}
+	var tlsConfigStr string
+	tlsConfig, ok := config["tls"]
+	if ok {
+		tlsConfigStr, ok = tlsConfig.(string)
+		if !ok {
+			return nil, fmt.Errorf("connect tls name must be string")
+		}
+	} else {
+		tlsConfigStr = ""
+	}
+	c := &connectCommand{
+		targetNode:    targetNodeStr,
+		targetService: targetServiceStr,
+		tlsConfigName: tlsConfigStr,
+	}
+	return c, nil
+}
+
+func (c *connectCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+	tlscfg, err := nc.GetClientTLSConfig(c.tlsConfigName, c.targetNode)
+	if err != nil {
+		return nil, err
+	}
+	rc, err := nc.Dial(c.targetNode, c.targetService, tlscfg)
+	if err != nil {
+		return nil, err
+	}
+	err = cfo.BridgeConn("Connecting\n", rc, "connected service")
+	if err != nil {
+		return nil, err
+	}
+	return nil, nil
+}

--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -1,0 +1,126 @@
+package controlsvc
+
+import (
+	"fmt"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"strings"
+	"time"
+)
+
+type pingCommandType struct{}
+type pingCommand struct {
+	target string
+}
+
+func (t *pingCommandType) InitFromString(params string) (ControlCommand, error) {
+	if params == "" {
+		return nil, fmt.Errorf("no ping target")
+	}
+	c := &pingCommand{
+		target: params,
+	}
+	return c, nil
+}
+
+func (t *pingCommandType) InitFromJSON(config map[string]interface{}) (ControlCommand, error) {
+	target, ok := config["target"]
+	if !ok {
+		return nil, fmt.Errorf("no ping target")
+	}
+	targetStr, ok := target.(string)
+	if !ok {
+		return nil, fmt.Errorf("ping target must be string")
+	}
+	c := &pingCommand{
+		target: targetStr,
+	}
+	return c, nil
+}
+
+// ping is the internal implementation of sending a single ping packet and waiting for a reply or error
+func ping(nc *netceptor.Netceptor, target string, hopsToLive byte) (time.Duration, string, error) {
+	doneChan := make(chan struct{})
+	pc, err := nc.ListenPacket("")
+	if err != nil {
+		return 0, "", err
+	}
+	defer func() {
+		close(doneChan)
+		_ = pc.Close()
+	}()
+	pc.SetHopsToLive(hopsToLive)
+	msgCh := pc.SubscribeUnreachable()
+	type errorResult struct {
+		err      error
+		fromNode string
+	}
+	errorChan := make(chan errorResult)
+	go func() {
+		for {
+			select {
+			case <-doneChan:
+				pc.UnsubscribeUnreachable(msgCh)
+				return
+			case msg := <-msgCh:
+				errMsg, ok := msg["Problem"]
+				if !ok {
+					errMsg = "unknown error"
+				}
+				fromNode, ok := msg["ReceivedFromNode"]
+				if !ok {
+					fromNode = ""
+				}
+				errorChan <- errorResult{
+					err:      fmt.Errorf(errMsg),
+					fromNode: fromNode,
+				}
+			}
+		}
+	}()
+	startTime := time.Now()
+	replyChan := make(chan string)
+	go func() {
+		buf := make([]byte, 8)
+		_, addr, err := pc.ReadFrom(buf)
+		fromNode := ""
+		if addr != nil {
+			fromNode = addr.String()
+			fromNode = strings.TrimSuffix(fromNode, ":ping")
+		}
+		if err == nil {
+			replyChan <- fromNode
+		} else {
+			errorChan <- errorResult{
+				err:      err,
+				fromNode: fromNode,
+			}
+		}
+	}()
+	_, err = pc.WriteTo([]byte{}, nc.NewAddr(target, "ping"))
+	if err != nil {
+		return time.Since(startTime), nc.NodeID(), err
+	}
+	select {
+	case errRes := <-errorChan:
+		return time.Since(startTime), errRes.fromNode, errRes.err
+	case remote := <-replyChan:
+		return time.Since(startTime), remote, nil
+	case <-time.After(10 * time.Second):
+		return time.Since(startTime), "", fmt.Errorf("timeout")
+	}
+}
+
+func (c *pingCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+	pingTime, pingRemote, err := ping(nc, c.target, netceptor.MaxForwardingHops)
+	cfr := make(map[string]interface{})
+	if err == nil {
+		cfr["Success"] = true
+		cfr["From"] = pingRemote
+		cfr["Time"] = pingTime
+		cfr["TimeStr"] = fmt.Sprintf("%s", pingTime)
+	} else {
+		cfr["Success"] = false
+		cfr["Error"] = err.Error()
+	}
+	return cfr, nil
+}

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -1,0 +1,33 @@
+package controlsvc
+
+import (
+	"fmt"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+)
+
+type statusCommandType struct{}
+type statusCommand struct{}
+
+func (t *statusCommandType) InitFromString(params string) (ControlCommand, error) {
+	if params != "" {
+		return nil, fmt.Errorf("status command does not take parameters")
+	}
+	c := &statusCommand{}
+	return c, nil
+}
+
+func (t *statusCommandType) InitFromJSON(config map[string]interface{}) (ControlCommand, error) {
+	c := &statusCommand{}
+	return c, nil
+}
+
+func (c *statusCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+	status := nc.Status()
+	cfr := make(map[string]interface{})
+	cfr["NodeID"] = status.NodeID
+	cfr["Connections"] = status.Connections
+	cfr["RoutingTable"] = status.RoutingTable
+	cfr["Advertisements"] = status.Advertisements
+	cfr["KnownConnectionCosts"] = status.KnownConnectionCosts
+	return cfr, nil
+}

--- a/pkg/controlsvc/traceroute.go
+++ b/pkg/controlsvc/traceroute.go
@@ -1,0 +1,56 @@
+package controlsvc
+
+import (
+	"fmt"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"strconv"
+)
+
+type tracerouteCommandType struct{}
+type tracerouteCommand struct {
+	target string
+}
+
+func (t *tracerouteCommandType) InitFromString(params string) (ControlCommand, error) {
+	if params == "" {
+		return nil, fmt.Errorf("no traceroute target")
+	}
+	c := &tracerouteCommand{
+		target: params,
+	}
+	return c, nil
+}
+
+func (t *tracerouteCommandType) InitFromJSON(config map[string]interface{}) (ControlCommand, error) {
+	target, ok := config["target"]
+	if !ok {
+		return nil, fmt.Errorf("no traceroute target")
+	}
+	targetStr, ok := target.(string)
+	if !ok {
+		return nil, fmt.Errorf("traceroute target must be string")
+	}
+	c := &tracerouteCommand{
+		target: targetStr,
+	}
+	return c, nil
+}
+
+func (c *tracerouteCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+	cfr := make(map[string]interface{})
+	for i := 0; i <= netceptor.MaxForwardingHops; i++ {
+		thisResult := make(map[string]interface{})
+		pingTime, pingRemote, err := ping(nc, c.target, byte(i))
+		thisResult["From"] = pingRemote
+		thisResult["Time"] = pingTime
+		thisResult["TimeStr"] = fmt.Sprintf("%s", pingTime)
+		if err != nil && err.Error() != netceptor.ProblemExpiredInTransit {
+			thisResult["Error"] = err.Error()
+		}
+		cfr[strconv.Itoa(i)] = thisResult
+		if err == nil || err.Error() != netceptor.ProblemExpiredInTransit {
+			break
+		}
+	}
+	return cfr, nil
+}

--- a/pkg/netceptor/hopcount_test.go
+++ b/pkg/netceptor/hopcount_test.go
@@ -107,7 +107,14 @@ func TestHopCountLimit(t *testing.T) {
 
 	// If the hop count limit is not working, the connections will never become inactive
 	timeout, _ = context.WithTimeout(context.Background(), 2*time.Second)
-	for time.Now().Sub(n1.connections["node2"].lastReceivedData) < 250*time.Millisecond {
+	for {
+		c, ok := n1.connections["node2"]
+		if !ok {
+			t.Fatal("node2 disappeared from node1's connections")
+		}
+		if time.Since(c.lastReceivedData) > 250*time.Millisecond {
+			break
+		}
 		select {
 		case <-timeout.Done():
 			t.Fatal(timeout.Err())

--- a/pkg/utils/broker.go
+++ b/pkg/utils/broker.go
@@ -1,6 +1,9 @@
 package utils
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // Broker code adapted from https://stackoverflow.com/questions/36417199/how-to-broadcast-message-using-channel
 // which is licensed under Creative Commons CC BY-SA 4.0.
@@ -8,18 +11,18 @@ import "context"
 // Broker implements a simple pub-sub broadcast system
 type Broker struct {
 	ctx       context.Context
-	publishCh chan interface{}
-	subCh     chan chan interface{}
-	unsubCh   chan chan interface{}
+	publishCh chan map[string]string
+	subCh     chan chan map[string]string
+	unsubCh   chan chan map[string]string
 }
 
 // NewBroker allocates a new Broker object
 func NewBroker(ctx context.Context) *Broker {
 	b := &Broker{
 		ctx:       ctx,
-		publishCh: make(chan interface{}),
-		subCh:     make(chan chan interface{}),
-		unsubCh:   make(chan chan interface{}),
+		publishCh: make(chan map[string]string),
+		subCh:     make(chan chan map[string]string),
+		unsubCh:   make(chan chan map[string]string),
 	}
 	go b.start()
 	return b
@@ -27,7 +30,7 @@ func NewBroker(ctx context.Context) *Broker {
 
 // start starts the broker goroutine
 func (b *Broker) start() {
-	subs := map[chan interface{}]struct{}{}
+	subs := map[chan map[string]string]struct{}{}
 	for {
 		select {
 		case <-b.ctx.Done():
@@ -49,19 +52,29 @@ func (b *Broker) start() {
 }
 
 // Subscribe registers to receive messages from the broker
-func (b *Broker) Subscribe() chan interface{} {
-	msgCh := make(chan interface{}, 1)
-	b.subCh <- msgCh
-	return msgCh
+func (b *Broker) Subscribe() chan map[string]string {
+	if b == nil || b.ctx == nil {
+		fmt.Printf("foo\n")
+	}
+	if b.ctx.Err() == nil {
+		msgCh := make(chan map[string]string, 1)
+		b.subCh <- msgCh
+		return msgCh
+	}
+	return nil
 }
 
 // Unsubscribe de-registers a message receiver
-func (b *Broker) Unsubscribe(msgCh chan interface{}) {
-	b.unsubCh <- msgCh
+func (b *Broker) Unsubscribe(msgCh chan map[string]string) {
+	if b.ctx.Err() == nil {
+		b.unsubCh <- msgCh
+	}
 	close(msgCh)
 }
 
 // Publish sends a message to all subscribers
-func (b *Broker) Publish(msg interface{}) {
-	b.publishCh <- msg
+func (b *Broker) Publish(msg map[string]string) {
+	if b.ctx.Err() == nil {
+		b.publishCh <- msg
+	}
 }

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -74,14 +74,6 @@ class ReceptorControl:
                 pass
             self.socket = None
 
-    def ping(self, node):
-        try:
-            result = self.simple_command(f"ping {node}")
-            success = str.startswith(result['Result'], "Reply")
-            return success, result['Result']
-        except RuntimeError as e:
-            return False, e
-
     def connect_to_service(self, node, service):
         self.writestr(f"connect {node} {service}\n")
         text = self.readstr()

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -145,24 +145,20 @@ func (r *ReceptorControl) ReadAndParseJSON() (map[string]interface{}, error) {
 }
 
 // Ping pings the specified node
-func (r *ReceptorControl) Ping(node string) (map[string]string, error) {
+func (r *ReceptorControl) Ping(node string) (string, error) {
 	_, err := r.WriteStr(fmt.Sprintf("ping %s\n", node))
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	jsonData, err := r.ReadAndParseJSON()
 	if err != nil {
-		return nil, err
+		return "", err
 	}
-	pingData := make(map[string]string)
-	// Convert to map[string]string
-	for k, v := range jsonData {
-		pingData[k] = v.(string)
+	success := jsonData["Success"].(bool)
+	if !success {
+		return "", errors.New(jsonData["Error"].(string))
 	}
-	if strings.HasPrefix(pingData["Result"], "Reply") != true {
-		return nil, errors.New(pingData["Result"])
-	}
-	return pingData, nil
+	return fmt.Sprintf("Reply from %s in %s", jsonData["From"].(string), jsonData["TimeStr"].(string)), nil
 }
 
 // Status retrieves the status of the current node


### PR DESCRIPTION
This pull request reorganizes the controlsvc package to move each command's implementation out to a separate file, and adds a new controlsvc traceroute command.

Traceroute works by sending pings with increasing maximum HopsToLive values.  When we get expired in transit errors, we know that the sending node was the Xth hop on the route.  Any success, or error other than expired in transit, terminates the process.

The structure of the control service requires the results to be send as a single JSON object, which means we can't return partial results.  As a result the entire traceroute has to run to completion before any results are seen.  This should only be a practical issue in a very large and slow Receptor network.