### PR TITLE
Allow configuring build functionality with build tags

### DIFF
--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -1,3 +1,6 @@
+// +build !no_tcp_backend
+// +build !no_backends
+
 package backends
 
 import (

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -1,3 +1,6 @@
+// +build !no_udp_backend
+// +build !no_backends
+
 package backends
 
 import (

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -1,3 +1,6 @@
+// +build !no_websocket_backend
+// +build !no_backends
+
 package backends
 
 import (

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -1,3 +1,5 @@
+// +build !no_controlsvc
+
 package controlsvc
 
 import (
@@ -16,25 +18,6 @@ import (
 	"strings"
 	"sync"
 )
-
-// ControlCommandType is a type of command that can be run from the control service
-type ControlCommandType interface {
-	InitFromString(string) (ControlCommand, error)
-	InitFromJSON(map[string]interface{}) (ControlCommand, error)
-}
-
-// ControlCommand is an instance of a command that is being run from the control service
-type ControlCommand interface {
-	ControlFunc(*netceptor.Netceptor, ControlFuncOperations) (map[string]interface{}, error)
-}
-
-// ControlFuncOperations provides callbacks for control services to take actions
-type ControlFuncOperations interface {
-	BridgeConn(message string, bc io.ReadWriteCloser, bcName string) error
-	ReadFromConn(message string, out io.Writer) error
-	WriteToConn(message string, in chan []byte) error
-	Close() error
-}
 
 // sockControl implements the ControlFuncOperations interface that is passed back to control functions
 type sockControl struct {

--- a/pkg/controlsvc/controlsvc_stub.go
+++ b/pkg/controlsvc/controlsvc_stub.go
@@ -1,0 +1,44 @@
+// +build no_controlsvc
+
+// Stub package to satisfy controlsvc dependencies while providing no functionality
+
+package controlsvc
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"net"
+	"os"
+)
+
+// ErrNotImplemented is returned by most functions in this unit since it is a non-functional stub
+var ErrNotImplemented = fmt.Errorf("not implemented")
+
+// Server is an instance of a control service
+type Server struct {
+}
+
+// New returns a new instance of a control service.
+func New(stdServices bool, nc *netceptor.Netceptor) *Server {
+	return &Server{}
+}
+
+// MainInstance is the global instance of the control service instantiated by the command-line main() function
+var MainInstance *Server
+
+// AddControlFunc registers a function that can be used from a control socket.
+func (s *Server) AddControlFunc(name string, cType ControlCommandType) error {
+	return nil
+}
+
+// RunControlSession runs the server protocol on the given connection
+func (s *Server) RunControlSession(conn net.Conn) {
+}
+
+// RunControlSvc runs the main accept loop of the control service
+func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.Config,
+	unixSocket string, unixSocketPermissions os.FileMode) error {
+	return ErrNotImplemented
+}

--- a/pkg/controlsvc/interfaces.go
+++ b/pkg/controlsvc/interfaces.go
@@ -1,0 +1,25 @@
+package controlsvc
+
+import (
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"io"
+)
+
+// ControlCommandType is a type of command that can be run from the control service
+type ControlCommandType interface {
+	InitFromString(string) (ControlCommand, error)
+	InitFromJSON(map[string]interface{}) (ControlCommand, error)
+}
+
+// ControlCommand is an instance of a command that is being run from the control service
+type ControlCommand interface {
+	ControlFunc(*netceptor.Netceptor, ControlFuncOperations) (map[string]interface{}, error)
+}
+
+// ControlFuncOperations provides callbacks for control services to take actions
+type ControlFuncOperations interface {
+	BridgeConn(message string, bc io.ReadWriteCloser, bcName string) error
+	ReadFromConn(message string, out io.Writer) error
+	WriteToConn(message string, in chan []byte) error
+	Close() error
+}

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -1,3 +1,5 @@
+// +build !no_tls_config
+
 package netceptor
 
 import (

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -1,4 +1,5 @@
-// +build !windows
+// +build !windows,!no_command_service
+// +build !windows,!no_services
 
 package services
 

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -1,4 +1,5 @@
-//+build linux
+// +build linux,!no_ip_router
+// +build linux,!no_services
 
 package services
 

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -1,3 +1,6 @@
+// +build !no_proxies
+// +build !no_services
+
 package services
 
 import (

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -1,3 +1,6 @@
+// +build !no_proxies
+// +build !no_services
+
 package services
 
 import (

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -1,3 +1,6 @@
+// +build !no_proxies
+// +build !no_services
+
 package services
 
 import (

--- a/pkg/utils/flock.go
+++ b/pkg/utils/flock.go
@@ -1,4 +1,4 @@
-//+build !windows
+// +build !windows
 
 package utils
 

--- a/pkg/utils/flock_windows.go
+++ b/pkg/utils/flock_windows.go
@@ -1,4 +1,4 @@
-//+build windows
+// +build windows
 
 package utils
 

--- a/pkg/utils/unixsock.go
+++ b/pkg/utils/unixsock.go
@@ -1,4 +1,4 @@
-//+build !windows
+// +build !windows
 
 package utils
 

--- a/pkg/utils/unixsock_windows.go
+++ b/pkg/utils/unixsock_windows.go
@@ -1,4 +1,4 @@
-//+build windows
+// +build windows
 
 package utils
 

--- a/pkg/workceptor/cmdline.go
+++ b/pkg/workceptor/cmdline.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import "github.com/project-receptor/receptor/pkg/cmdline"

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/command_detach_unixlike.go
+++ b/pkg/workceptor/command_detach_unixlike.go
@@ -1,4 +1,4 @@
-//+build !windows
+// +build !windows,!no_workceptor
 
 package workceptor
 

--- a/pkg/workceptor/command_detach_windows.go
+++ b/pkg/workceptor/command_detach_windows.go
@@ -1,4 +1,4 @@
-//+build windows
+// +build windows,!no_workceptor
 
 package workceptor
 

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/interfaces.go
+++ b/pkg/workceptor/interfaces.go
@@ -1,0 +1,34 @@
+package workceptor
+
+// WorkUnit represents a local unit of work
+type WorkUnit interface {
+	Init(w *Workceptor, unitID string, workType string, params string)
+	ID() string
+	UnitDir() string
+	StatusFileName() string
+	StdoutFileName() string
+	Save() error
+	Load() error
+	UpdateBasicStatus(state int, detail string, stdoutSize int64)
+	UpdateFullStatus(statusFunc func(*StatusFileData))
+	LastUpdateError() error
+	Status() *StatusFileData
+	Start() error
+	Restart() error
+	Cancel() error
+	Release(force bool) error
+}
+
+// NewWorkerFunc represents a factory of WorkUnit instances
+type NewWorkerFunc func() WorkUnit
+
+// StatusFileData is the structure of the JSON data saved to a status file.
+// This struct should only contain value types, except for ExtraData.
+type StatusFileData struct {
+	State      int
+	Detail     string
+	StdoutSize int64
+	WorkType   string
+	Params     string
+	ExtraData  interface{}
+}

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (

--- a/pkg/workceptor/workceptor_stub.go
+++ b/pkg/workceptor/workceptor_stub.go
@@ -1,0 +1,77 @@
+// +build no_workceptor
+
+package workceptor
+
+// Stub file to satisfy dependencies when Workceptor is not compiled in
+
+import (
+	"context"
+	"fmt"
+	"github.com/project-receptor/receptor/pkg/controlsvc"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+)
+
+// ErrNotImplemented is returned from functions that are stubbed out
+var ErrNotImplemented = fmt.Errorf("not implemented")
+
+// Workceptor is the main object that handles unit-of-work management
+type Workceptor struct {
+}
+
+// New constructs a new Workceptor instance
+func New(ctx context.Context, nc *netceptor.Netceptor, dataDir string) (*Workceptor, error) {
+	return &Workceptor{}, nil
+}
+
+// MainInstance is the global instance of Workceptor instantiated by the command-line main() function
+var MainInstance *Workceptor
+
+// RegisterWithControlService registers this workceptor instance with a control service instance
+func (w *Workceptor) RegisterWithControlService(cs *controlsvc.Server) error {
+	return nil
+}
+
+// RegisterWorker notifies the Workceptor of a new kind of work that can be done
+func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc) error {
+	return ErrNotImplemented
+}
+
+// AllocateUnit creates a new local work unit and generates an identifier for it
+func (w *Workceptor) AllocateUnit(workTypeName string, params string) (WorkUnit, error) {
+	return nil, ErrNotImplemented
+}
+
+// AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
+func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, params string) (WorkUnit, error) {
+	return nil, ErrNotImplemented
+}
+
+// StartUnit starts a unit of work
+func (w *Workceptor) StartUnit(unitID string) error {
+	return ErrNotImplemented
+}
+
+// ListKnownUnitIDs returns a slice containing the known unit IDs
+func (w *Workceptor) ListKnownUnitIDs() []string {
+	return []string{}
+}
+
+// UnitStatus returns the state of a unit
+func (w *Workceptor) UnitStatus(unitID string) (*StatusFileData, error) {
+	return nil, ErrNotImplemented
+}
+
+// CancelUnit cancels a unit of work, killing any processes
+func (w *Workceptor) CancelUnit(unitID string) error {
+	return ErrNotImplemented
+}
+
+// ReleaseUnit releases (deletes) resources from a unit of work, including stdout.  Release implies Cancel.
+func (w *Workceptor) ReleaseUnit(unitID string, force bool) error {
+	return ErrNotImplemented
+}
+
+// GetResults returns a live stream of the results of a unit
+func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan struct{}) (chan []byte, error) {
+	return nil, ErrNotImplemented
+}

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -1,3 +1,5 @@
+// +build !no_workceptor
+
 package workceptor
 
 import (
@@ -48,45 +50,12 @@ func WorkStateToString(workState int) string {
 	}
 }
 
-// WorkUnit represents a local unit of work
-type WorkUnit interface {
-	Init(w *Workceptor, unitID string, workType string, params string)
-	ID() string
-	UnitDir() string
-	StatusFileName() string
-	StdoutFileName() string
-	Save() error
-	Load() error
-	UpdateBasicStatus(state int, detail string, stdoutSize int64)
-	UpdateFullStatus(statusFunc func(*StatusFileData))
-	LastUpdateError() error
-	Status() *StatusFileData
-	Start() error
-	Restart() error
-	Cancel() error
-	Release(force bool) error
-}
-
 // ErrPending is returned when an operation hasn't succeeded or failed yet
 var ErrPending = fmt.Errorf("operation pending")
 
 // IsPending returns true if the error is an ErrPending
 func IsPending(err error) bool {
 	return err == ErrPending
-}
-
-// NewWorkerFunc represents a factory of WorkUnit instances
-type NewWorkerFunc func() WorkUnit
-
-// StatusFileData is the structure of the JSON data saved to a status file.
-// This struct should only contain value types, except for ExtraData.
-type StatusFileData struct {
-	State      int
-	Detail     string
-	StdoutSize int64
-	WorkType   string
-	Params     string
-	ExtraData  interface{}
 }
 
 // BaseWorkUnit includes data common to all work units, and partially implements the WorkUnit interface


### PR DESCRIPTION
This PR implements https://github.com/project-receptor/receptor/issues/160.  The idea is that some Receptor users want only specific functionality, and want to deploy it into security-sensitive environments, and aren't comfortable with all of Receptor's _other_ functionality sitting around maybe being accidentally usable or otherwise presenting unnecessary attack surface.

The following build tags are available:

* no_controlsvc:  Disable the control service
* no_backends:    Disable all backends (except external via the API)
* no_tcp_backend: Disable the TCP backend
* no_udp_backend: Disable the UDP backend
* no_websocket_backend: Disable the websocket backent
* no_services:    Disable all services
* no_proxies:     Disable the TCP, UDP and Unix proxy services
* no_ip_router:   Disable the IP router service
* no_tls_config:  Disable the ability to configure TLS server/client configs
* no_workceptor:  Disable the unit-of-work subsystem (be network only)

In a couple cases, it is necessary to provide non-functional stub code so that the rest of the code can compile.  CI now runs a build with everything disabled, to ensure that these stub files are kept up to date with any changes to the main code.