### PR TITLE
Get rid of long list of booleans in AddConfigType

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -92,9 +92,9 @@ func (cfg nullBackendCfg) Run() error {
 }
 
 func main() {
-	cmdline.AddConfigType("node", "Node configuration of this instance", nodeCfg{}, true, true, false, false, nil)
-	cmdline.AddConfigType("local-only", "Run a self-contained node with no backends", nullBackendCfg{}, false, true, false, false, nil)
-	cmdline.AddConfigType("version", "Show the Receptor version", versionCfg{}, false, false, true, false, nil)
+	cmdline.AddConfigType("node", "Node configuration of this instance", nodeCfg{}, cmdline.Required, cmdline.Singleton)
+	cmdline.AddConfigType("local-only", "Run a self-contained node with no backends", nullBackendCfg{}, cmdline.Singleton)
+	cmdline.AddConfigType("version", "Show the Receptor version", versionCfg{}, cmdline.Exclusive)
 	cmdline.ParseAndRun(os.Args[1:], []string{"Init", "Prepare", "Run"})
 
 	// Fancy footwork to set an error exitcode if we're immediately exiting at startup

--- a/pkg/backends/cmdline.go
+++ b/pkg/backends/cmdline.go
@@ -2,7 +2,7 @@ package backends
 
 import "github.com/project-receptor/receptor/pkg/cmdline"
 
-var backendSection = &cmdline.Section{
+var backendSection = &cmdline.ConfigSection{
 	Description: "Commands to configure back-ends, which connect Receptor nodes together:",
 	Order:       10,
 }

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -290,6 +290,6 @@ func (cfg TCPDialerCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("tcp-listener", "Run a backend listener on a TCP port", TCPListenerCfg{}, false, false, false, false, backendSection)
-	cmdline.AddConfigType("tcp-peer", "Make an outbound backend connection to a TCP peer", TCPDialerCfg{}, false, false, false, false, backendSection)
+	cmdline.AddConfigType("tcp-listener", "Run a backend listener on a TCP port", TCPListenerCfg{}, cmdline.Section(backendSection))
+	cmdline.AddConfigType("tcp-peer", "Make an outbound backend connection to a TCP peer", TCPDialerCfg{}, cmdline.Section(backendSection))
 }

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -315,6 +315,6 @@ func (cfg UDPDialerCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("UDP-listener", "Run a backend listener on a UDP port", UDPListenerCfg{}, false, false, false, false, backendSection)
-	cmdline.AddConfigType("UDP-peer", "Make an outbound backend connection to a UDP peer", UDPDialerCfg{}, false, false, false, false, backendSection)
+	cmdline.AddConfigType("UDP-listener", "Run a backend listener on a UDP port", UDPListenerCfg{}, cmdline.Section(backendSection))
+	cmdline.AddConfigType("UDP-peer", "Make an outbound backend connection to a UDP peer", UDPDialerCfg{}, cmdline.Section(backendSection))
 }

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -307,6 +307,6 @@ func (cfg WebsocketDialerCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("ws-listener", "Run an http server that accepts websocket connections", WebsocketListenerCfg{}, false, false, false, false, backendSection)
-	cmdline.AddConfigType("ws-peer", "Connect outbound to a websocket peer", WebsocketDialerCfg{}, false, false, false, false, backendSection)
+	cmdline.AddConfigType("ws-listener", "Run an http server that accepts websocket connections", WebsocketListenerCfg{}, cmdline.Section(backendSection))
+	cmdline.AddConfigType("ws-peer", "Connect outbound to a websocket peer", WebsocketDialerCfg{}, cmdline.Section(backendSection))
 }

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -348,10 +348,8 @@ func (cfg CmdlineConfigWindows) Run() error {
 
 func init() {
 	if runtime.GOOS == "windows" {
-		cmdline.AddConfigType("control-service", "Run a control service",
-			CmdlineConfigWindows{}, false, false, false, false, nil)
+		cmdline.AddConfigType("control-service", "Run a control service", CmdlineConfigWindows{})
 	} else {
-		cmdline.AddConfigType("control-service", "Run a control service",
-			CmdlineConfigUnix{}, false, false, false, false, nil)
+		cmdline.AddConfigType("control-service", "Run a control service", CmdlineConfigUnix{})
 	}
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -133,6 +133,6 @@ func init() {
 	log.SetOutput(os.Stdout)
 	log.SetFlags(log.Ldate | log.Ltime)
 
-	cmdline.AddConfigType("log-level", "Set specific log level output", loglevelCfg{}, false, true, false, false, nil)
-	cmdline.AddConfigType("trace", "Enables packet tracing output", traceCfg{}, false, true, false, false, nil)
+	cmdline.AddConfigType("log-level", "Set specific log level output", loglevelCfg{}, cmdline.Singleton)
+	cmdline.AddConfigType("trace", "Enables packet tracing output", traceCfg{}, cmdline.Singleton)
 }

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -14,7 +14,7 @@ import (
 // Command line
 // **************************************************************************
 
-var configSection = &cmdline.Section{
+var configSection = &cmdline.ConfigSection{
 	Description: "Commands that configure resources used by other commands:",
 	Order:       5,
 }
@@ -117,6 +117,6 @@ func (cfg TLSClientCfg) Prepare() error {
 }
 
 func init() {
-	cmdline.AddConfigType("tls-server", "Define a TLS server configuration", TLSServerCfg{}, false, false, false, false, configSection)
-	cmdline.AddConfigType("tls-client", "Define a TLS client configuration", TLSClientCfg{}, false, false, false, false, configSection)
+	cmdline.AddConfigType("tls-server", "Define a TLS server configuration", TLSServerCfg{}, cmdline.Section(configSection))
+	cmdline.AddConfigType("tls-client", "Define a TLS client configuration", TLSClientCfg{}, cmdline.Section(configSection))
 }

--- a/pkg/services/cmdline.go
+++ b/pkg/services/cmdline.go
@@ -2,7 +2,7 @@ package services
 
 import "github.com/project-receptor/receptor/pkg/cmdline"
 
-var servicesSection = &cmdline.Section{
+var servicesSection = &cmdline.ConfigSection{
 	Description: "Commands to configure services that run on top of the Receptor mesh:",
 	Order:       20,
 }

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -70,6 +70,5 @@ func (cfg CommandSvcCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("command-service",
-		"Run an interactive command via a Receptor service", CommandSvcCfg{}, false, false, false, false, servicesSection)
+	cmdline.AddConfigType("command-service", "Run an interactive command via a Receptor service", CommandSvcCfg{}, cmdline.Section(servicesSection))
 }

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -366,5 +366,5 @@ func (cfg IPRouterCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("ip-router", "Run an IP router using a tun interface", IPRouterCfg{}, false, false, false, false, servicesSection)
+	cmdline.AddConfigType("ip-router", "Run an IP router using a tun interface", IPRouterCfg{}, cmdline.Section(servicesSection))
 }

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -127,8 +127,6 @@ func (cfg TCPProxyOutboundCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("tcp-server",
-		"Listen for TCP and forward via Receptor", TCPProxyInboundCfg{}, false, false, false, false, servicesSection)
-	cmdline.AddConfigType("tcp-client",
-		"Listen on a Receptor service and forward via TCP", TCPProxyOutboundCfg{}, false, false, false, false, servicesSection)
+	cmdline.AddConfigType("tcp-server", "Listen for TCP and forward via Receptor", TCPProxyInboundCfg{}, cmdline.Section(servicesSection))
+	cmdline.AddConfigType("tcp-client", "Listen on a Receptor service and forward via TCP", TCPProxyOutboundCfg{}, cmdline.Section(servicesSection))
 }

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -177,8 +177,6 @@ func (cfg UDPProxyOutboundCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("udp-server",
-		"Listen for UDP and forward via Receptor", UDPProxyInboundCfg{}, false, false, false, false, servicesSection)
-	cmdline.AddConfigType("udp-client",
-		"Listen on a Receptor service and forward via UDP", UDPProxyOutboundCfg{}, false, false, false, false, servicesSection)
+	cmdline.AddConfigType("udp-server", "Listen for UDP and forward via Receptor", UDPProxyInboundCfg{}, cmdline.Section(servicesSection))
+	cmdline.AddConfigType("udp-client", "Listen on a Receptor service and forward via UDP", UDPProxyOutboundCfg{}, cmdline.Section(servicesSection))
 }

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -110,9 +110,7 @@ func (cfg UnixProxyOutboundCfg) Run() error {
 
 func init() {
 	if runtime.GOOS != "windows" {
-		cmdline.AddConfigType("unix-socket-server",
-			"Listen on a Unix socket and forward via Receptor", UnixProxyInboundCfg{}, false, false, false, false, servicesSection)
-		cmdline.AddConfigType("unix-socket-client",
-			"Listen via Receptor and forward to a Unix socket", UnixProxyOutboundCfg{}, false, false, false, false, servicesSection)
+		cmdline.AddConfigType("unix-socket-server", "Listen on a Unix socket and forward via Receptor", UnixProxyInboundCfg{}, cmdline.Section(servicesSection))
+		cmdline.AddConfigType("unix-socket-client", "Listen via Receptor and forward to a Unix socket", UnixProxyOutboundCfg{}, cmdline.Section(servicesSection))
 	}
 }

--- a/pkg/workceptor/cmdline.go
+++ b/pkg/workceptor/cmdline.go
@@ -4,7 +4,7 @@ package workceptor
 
 import "github.com/project-receptor/receptor/pkg/cmdline"
 
-var workersSection = &cmdline.Section{
+var workersSection = &cmdline.ConfigSection{
 	Description: "Commands to configure workers that process units of work:",
 	Order:       30,
 }

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -358,6 +358,6 @@ func (cfg CommandRunnerCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("work-command", "Run a worker using an external command", CommandCfg{}, false, false, false, false, workersSection)
-	cmdline.AddConfigType("command-runner", "Wrapper around a process invocation", CommandRunnerCfg{}, false, false, true, true, nil)
+	cmdline.AddConfigType("work-command", "Run a worker using an external command", CommandCfg{}, cmdline.Section(workersSection))
+	cmdline.AddConfigType("command-runner", "Wrapper around a process invocation", CommandRunnerCfg{}, cmdline.Exclusive, cmdline.Hidden)
 }

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -421,5 +421,5 @@ func (cfg WorkKubeCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("work-kubernetes", "Run a worker using Kubernetes", WorkKubeCfg{}, false, false, false, false, workersSection)
+	cmdline.AddConfigType("work-kubernetes", "Run a worker using Kubernetes", WorkKubeCfg{}, cmdline.Section(workersSection))
 }

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -62,5 +62,5 @@ func (cfg WorkPythonCfg) Run() error {
 }
 
 func init() {
-	cmdline.AddConfigType("work-python", "Run a worker using a Python plugin", WorkPythonCfg{}, false, false, false, false, workersSection)
+	cmdline.AddConfigType("work-python", "Run a worker using a Python plugin", WorkPythonCfg{}, cmdline.Section(workersSection))
 }


### PR DESCRIPTION
```
cmdline.AddConfigType("whatever", "Configure the whatever", whateverCfg{}, false, true, false, false, nil)
```
Quick, does the "true" mean this parameter is exclusive, singleton, hidden or required?

Long lists of booleans are hard to read, easy to mix up, and just generally ugly.  So instead we can use Rob Pike's [self-referential functions](https://commandcenter.blogspot.com/2014/01/self-referential-functions-and-design.html) pattern, which gives us calls like:

```
cmdline.AddConfigType("whatever", "Configure the whatever", whateverCfg{}, cmdline.Singleton)
```

Now it's obvious that it's a singleton.  Not to mention, if we add more flags or options to cmdline in the future, we don't have to keep breaking existing callers.