### PR TITLE
Override labels in container image, to avoid getting the Fedora ones

### DIFF
--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,6 +1,11 @@
 FROM fedora:32
 ARG VERSION
 
+LABEL license="ASL2"
+LABEL name="receptor"
+LABEL vendor="project-receptor"
+LABEL version="${VERSION}"
+
 RUN dnf -y update && \
     dnf -y install dumb-init python3-click python3-dateutil && \
     dnf clean all


### PR DESCRIPTION
The Receptor container is inheriting labels with the Fedora license, vendor etc.  We should override these with our own.