### PR TITLE
Add arbitrary parameter passing to work units

### DIFF
--- a/pkg/workceptor/interfaces.go
+++ b/pkg/workceptor/interfaces.go
@@ -2,7 +2,8 @@ package workceptor
 
 // WorkUnit represents a local unit of work
 type WorkUnit interface {
-	Init(w *Workceptor, unitID string, workType string, params string)
+	Init(w *Workceptor, unitID string, workType string)
+	SetParamsAndSave(params map[string]string) error
 	ID() string
 	UnitDir() string
 	StatusFileName() string
@@ -29,6 +30,5 @@ type StatusFileData struct {
 	Detail     string
 	StdoutSize int64
 	WorkType   string
-	Params     string
 	ExtraData  interface{}
 }

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -32,7 +32,7 @@ func TestWorkceptorJson(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	cw, err := w.AllocateUnit("command", "")
+	cw, err := w.AllocateUnit("command", make(map[string]string))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestWorkceptorJson(t *testing.T) {
 		t.Fatal(err)
 	}
 	cw2 := newCommandWorker()
-	cw2.Init(w, cw.ID(), "command", "")
+	cw2.Init(w, cw.ID(), "command")
 	err = cw2.Load()
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -24,7 +24,7 @@ func (pw *pythonUnit) Start() error {
 	for k, v := range pw.config {
 		config[k] = v
 	}
-	config["params"] = pw.Status().Params
+	config["params"] = pw.Status().ExtraData.(*commandExtraData).Params
 	configJSON, err := json.Marshal(config)
 	if err != nil {
 		return err

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -29,7 +29,7 @@ type remoteUnit struct {
 type remoteExtraData struct {
 	RemoteNode     string
 	RemoteWorkType string
-	RemoteParams   string
+	RemoteParams   map[string]string
 	RemoteUnitID   string
 	LocalStarted   bool
 	LocalCancelled bool
@@ -370,10 +370,20 @@ func (rw *remoteUnit) monitorRemoteUnit(ctx context.Context, forRelease bool) {
 }
 
 // Init initializes the work unit data
-func (rw *remoteUnit) Init(w *Workceptor, ident string, workType string, params string) {
-	rw.BaseWorkUnit.Init(w, ident, workType, params)
-	rw.status.ExtraData = &remoteExtraData{}
+func (rw *remoteUnit) Init(w *Workceptor, ident string, workType string) {
+	rw.BaseWorkUnit.Init(w, ident, workType)
+	red := &remoteExtraData{}
+	red.RemoteParams = make(map[string]string)
+	rw.status.ExtraData = red
 	rw.topJC = &utils.JobContext{}
+}
+
+// SetParamsAndSave sets the unit's parameters and saves it
+func (rw *remoteUnit) SetParamsAndSave(params map[string]string) error {
+	for k, v := range params {
+		rw.status.ExtraData.(*remoteExtraData).RemoteParams[k] = v
+	}
+	return rw.Save()
 }
 
 // Status returns a copy of the status currently loaded in memory

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -70,20 +70,24 @@ type BaseWorkUnit struct {
 	lastUpdateError error
 }
 
-// Init initializes the work unit data
-func (bwu *BaseWorkUnit) Init(w *Workceptor, unitID string, workType string, params string) {
+// Init initializes the basic work unit data, in memory only.
+func (bwu *BaseWorkUnit) Init(w *Workceptor, unitID string, workType string) {
 	bwu.w = w
 	bwu.status.State = WorkStatePending
-	bwu.status.Detail = ""
+	bwu.status.Detail = "Unit Created"
 	bwu.status.StdoutSize = 0
 	bwu.status.WorkType = workType
-	bwu.status.Params = params
 	bwu.status.ExtraData = nil
 	bwu.unitID = unitID
 	bwu.unitDir = path.Join(w.dataDir, unitID)
 	bwu.statusFileName = path.Join(bwu.unitDir, "status")
 	bwu.stdoutFileName = path.Join(bwu.unitDir, "stdout")
 	bwu.statusLock = &sync.RWMutex{}
+}
+
+// SetParamsAndSave configures this unit with given parameters and saves it, overwriting the status file.
+func (bwu *BaseWorkUnit) SetParamsAndSave(params map[string]string) error {
+	return bwu.Save()
 }
 
 // UnitDir returns the unit directory of this work unit


### PR DESCRIPTION
* Move Params string field (representing command-line parameters) from the base StatusFileData to commandExtraData/kubeExtraData, since those are the only places where it is relevant
* Add a new params map[string]string to AllocateUnit/AllocateRemoteUnit, which represents generic and extensible parameters
* Have remoteWorkUnit pass arbitrary parameters to its remote peer, so it can be used with any current or future work type
* Clarify that work unit Init method is supposed to just allocate memory, and create a separate SetParamsAndSave for when we want to initialize a new unit and overwrite its status file

On the last bullet, the idea is that if you are creating a _new_ work unit, you do Init and then SetParamsAndSave.  If you are reloading an _existing_ work unit, you do Init and then Load.  Everything that writes to the unit is contained in SetParamsAndSave, so we don't get cases where loading a unit inadvertently changes something because we were only thinking about the new-unit case when we wrote the constructor code.