### PR TITLE
Add direct support for Gorilla websockets in ExternalBackend

### DIFF
--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -3,6 +3,7 @@ package netceptor
 import (
 	"context"
 	"fmt"
+	"github.com/gorilla/websocket"
 	"github.com/project-receptor/receptor/pkg/framer"
 	"net"
 	"time"
@@ -14,6 +15,128 @@ type ExternalBackend struct {
 	ctx      context.Context
 	cancel   context.CancelFunc
 	sessChan chan BackendSession
+}
+
+// MessageConn is an abstract connection that sends and receives whole messages (datagrams)
+type MessageConn interface {
+	WriteMessage(ctx context.Context, data []byte) error
+	ReadMessage(ctx context.Context, timeout time.Duration) ([]byte, error)
+	SetReadDeadline(t time.Time) error
+	Close() error
+}
+
+// netMessageConn implements MessageConn for Go net.Conn
+type netMessageConn struct {
+	conn   net.Conn
+	framer framer.Framer
+}
+
+// MessageConnFromNetConn returns a MessageConnection that wraps a net.Conn
+func MessageConnFromNetConn(conn net.Conn) MessageConn {
+	return &netMessageConn{
+		conn:   conn,
+		framer: framer.New(),
+	}
+}
+
+// WriteMessage writes a message to the connection
+func (mc *netMessageConn) WriteMessage(ctx context.Context, data []byte) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("session closed: %s", ctx.Err())
+	}
+	buf := mc.framer.SendData(data)
+	n, err := mc.conn.Write(buf)
+	if err != nil {
+		return err
+	}
+	if n != len(buf) {
+		return fmt.Errorf("partial data sent")
+	}
+	return nil
+}
+
+// ReadMessage reads a message from the connection
+func (mc *netMessageConn) ReadMessage(ctx context.Context, timeout time.Duration) ([]byte, error) {
+	buf := make([]byte, MTU)
+	err := mc.conn.SetReadDeadline(time.Now().Add(timeout))
+	if err != nil {
+		return nil, err
+	}
+	for {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("session closed: %s", ctx.Err())
+		}
+		if mc.framer.MessageReady() {
+			break
+		}
+		n, err := mc.conn.Read(buf)
+		if n > 0 {
+			mc.framer.RecvData(buf[:n])
+		}
+		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
+			return nil, ErrTimeout
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	buf, err = mc.framer.GetMessage()
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// SetReadDeadline sets the deadline by which a message must be read from the connection
+func (mc *netMessageConn) SetReadDeadline(t time.Time) error {
+	panic("implement me")
+}
+
+// Close closes the connection
+func (mc *netMessageConn) Close() error {
+	return mc.conn.Close()
+}
+
+// websocketMessageConn implements MessageConn for Gorilla websocket.Conn
+type websocketMessageConn struct {
+	conn *websocket.Conn
+}
+
+// MessageConnFromWebsocketConn returns a MessageConnection that wraps a Gorilla websocket.Conn
+func MessageConnFromWebsocketConn(conn *websocket.Conn) MessageConn {
+	return &websocketMessageConn{
+		conn: conn,
+	}
+}
+
+// WriteMessage writes a message to the connection
+func (mc *websocketMessageConn) WriteMessage(ctx context.Context, data []byte) error {
+	if ctx.Err() != nil {
+		return fmt.Errorf("session closed: %s", ctx.Err())
+	}
+	return mc.conn.WriteMessage(websocket.BinaryMessage, data)
+}
+
+// ReadMessage reads a message from the connection
+func (mc *websocketMessageConn) ReadMessage(ctx context.Context, timeout time.Duration) ([]byte, error) {
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("session closed: %s", ctx.Err())
+	}
+	messageType, data, err := mc.conn.ReadMessage()
+	if messageType != websocket.BinaryMessage {
+		return nil, fmt.Errorf("received message of wrong type")
+	}
+	return data, err
+}
+
+// SetReadDeadline sets the deadline by which a message must be read from the connection
+func (mc *websocketMessageConn) SetReadDeadline(t time.Time) error {
+	return mc.conn.SetReadDeadline(t)
+}
+
+// Close closes the connection
+func (mc *websocketMessageConn) Close() error {
+	return mc.conn.Close()
 }
 
 // NewExternalBackend initializes a new ExternalBackend object
@@ -32,18 +155,16 @@ func (b *ExternalBackend) Start(ctx context.Context) (chan BackendSession, error
 // ExternalSession implements BackendSession for external backends.
 type ExternalSession struct {
 	eb          *ExternalBackend
-	conn        net.Conn
-	framer      framer.Framer
+	conn        MessageConn
 	shouldClose bool
 }
 
 // NewConnection is called by the external code when a new connection is available.  The
 // connection will be closed when the session ends if closeConnWithSession is true.
-func (b *ExternalBackend) NewConnection(conn net.Conn, closeConnWithSession bool) {
+func (b *ExternalBackend) NewConnection(conn MessageConn, closeConnWithSession bool) {
 	ebs := &ExternalSession{
 		eb:          b,
 		conn:        conn,
-		framer:      framer.New(),
 		shouldClose: closeConnWithSession,
 	}
 	b.sessChan <- ebs
@@ -51,49 +172,12 @@ func (b *ExternalBackend) NewConnection(conn net.Conn, closeConnWithSession bool
 
 // Send sends data over the session
 func (es *ExternalSession) Send(data []byte) error {
-	if es.eb.ctx.Err() != nil {
-		return fmt.Errorf("session closed: %s", es.eb.ctx.Err())
-	}
-	buf := es.framer.SendData(data)
-	n, err := es.conn.Write(buf)
-	if err != nil {
-		return err
-	}
-	if n != len(buf) {
-		return fmt.Errorf("partial data sent")
-	}
-	return nil
+	return es.conn.WriteMessage(es.eb.ctx, data)
 }
 
 // Recv receives data via the session
 func (es *ExternalSession) Recv(timeout time.Duration) ([]byte, error) {
-	// Recv receives data via the session
-	buf := make([]byte, MTU)
-	for {
-		if es.eb.ctx.Err() != nil {
-			return nil, fmt.Errorf("session closed: %s", es.eb.ctx.Err())
-		}
-		if es.framer.MessageReady() {
-			break
-		}
-		err := es.conn.SetReadDeadline(time.Now().Add(timeout))
-		if err != nil {
-			return nil, err
-		}
-		n, err := es.conn.Read(buf)
-		if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
-			return nil, ErrTimeout
-		}
-		if err != nil {
-			return nil, err
-		}
-		es.framer.RecvData(buf[:n])
-	}
-	buf, err := es.framer.GetMessage()
-	if err != nil {
-		return nil, err
-	}
-	return buf, nil
+	return es.conn.ReadMessage(es.eb.ctx, timeout)
 }
 
 // Close closes the session

--- a/pkg/netceptor/hopcount_test.go
+++ b/pkg/netceptor/hopcount_test.go
@@ -66,8 +66,8 @@ func TestHopCountLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	b1.NewConnection(c1, true)
-	b2.NewConnection(c2, true)
+	b1.NewConnection(MessageConnFromNetConn(c1), true)
+	b2.NewConnection(MessageConnFromNetConn(c2), true)
 
 	// Wait for the nodes to establish routing to each other
 	timeout, _ := context.WithTimeout(context.Background(), 2*time.Second)


### PR DESCRIPTION
This PR alters ExternalBackend so that instead of taking a `net.Conn`, it takes a new interface called a `MessageConn`, which can be a wrapper around either `net.Conn` or Gorilla `websocket.Conn`.  Talking directly to `websocket.Conn` allows us to avoid the use of `Framer` when it isn't required.

So if you have existing code:
```
var eb ExternalBackend
var conn net.Conn

...

eb.NewConnection(conn, true)
```

it will need to be changed to:

```
eb.NewConnection(MessageConnFromNetConn(conn), true)
```

and if you have a `websockets.Conn`, you can now do:

```
eb.NewConnection(MessageConnFromWebsocketConn(wsconn), true)
```
