### PR TITLE
Submit work to remote has option to provide a tlsclient config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,6 @@ ci: pre-commit build-all test
 
 version:
 	@echo $(VERSION) > .VERSION
-	@echo $(VERSION) > receptorctl/.VERSION
 	@echo ".VERSION created for $(VERSION)"
 
 SPECFILES = packaging/rpm/receptor.spec packaging/rpm/receptorctl.spec packaging/rpm/receptor-python-worker.spec

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,11 @@ testloop: receptor
 ci: pre-commit build-all test
 	@echo "All done"
 
+version:
+	@echo $(VERSION) > .VERSION
+	@echo $(VERSION) > receptorctl/.VERSION
+	@echo ".VERSION created for $(VERSION)"
+
 SPECFILES = packaging/rpm/receptor.spec packaging/rpm/receptorctl.spec packaging/rpm/receptor-python-worker.spec
 
 specfiles: $(SPECFILES)

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -139,7 +139,7 @@ func (t *workceptorCommandType) InitFromJSON(config map[string]interface{}) (con
 		if err != nil {
 			return nil, err
 		}
-		c.params["tlsconfigname"], err = strFromMap(config, "tlsconfigname")
+		c.params["tlsclient"], err = strFromMap(config, "tlsclient")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -169,9 +169,13 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if err != nil {
 			return nil, err
 		}
+		tlsclient, err := strFromMap(c.params, "tlsclient")
+		if err != nil {
+			tlsclient = "" // optional so don't return
+		}
 		workParams := make(map[string]string)
 		for k, v := range c.params {
-			if k == "command" || k == "subcommand" || k == "node" || k == "worktype" {
+			if k == "command" || k == "subcommand" || k == "node" || k == "worktype" || k == "tlsclient" {
 				continue
 			}
 			vStr, ok := v.(string)
@@ -184,7 +188,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if workNode == nc.NodeID() || strings.EqualFold(workNode, "localhost") {
 			worker, err = c.w.AllocateUnit(workType, workParams)
 		} else {
-			worker, err = c.w.AllocateRemoteUnit(workNode, workType, workParams)
+			worker, err = c.w.AllocateRemoteUnit(workNode, workType, tlsclient, workParams)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -139,6 +139,10 @@ func (t *workceptorCommandType) InitFromJSON(config map[string]interface{}) (con
 		if err != nil {
 			return nil, err
 		}
+		c.params["tlsconfigname"], err = strFromMap(config, "tlsconfigname")
+		if err != nil {
+			return nil, err
+		}
 	case "status", "cancel", "release", "force-release":
 		c.params["unitid"], err = strFromMap(config, "unitid")
 		if err != nil {

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -139,10 +139,6 @@ func (t *workceptorCommandType) InitFromJSON(config map[string]interface{}) (con
 		if err != nil {
 			return nil, err
 		}
-		c.params["tlsclient"], err = strFromMap(config, "tlsclient")
-		if err != nil {
-			return nil, err
-		}
 	case "status", "cancel", "release", "force-release":
 		c.params["unitid"], err = strFromMap(config, "unitid")
 		if err != nil {

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -89,17 +89,17 @@ func (rw *remoteUnit) connectToRemote(ctx context.Context) (net.Conn, *bufio.Rea
 }
 
 // getConnection retries connectToRemote until connected or the context expires
-func (rw *remoteUnit) getConnection(mw *utils.JobContext) (net.Conn, *bufio.Reader) {
+func (rw *remoteUnit) getConnection(ctx context.Context) (net.Conn, *bufio.Reader) {
 	connectDelay := utils.NewIncrementalDuration(SuccessWorkSleep, MaxWorkSleep, 1.5)
 	for {
-		conn, reader, err := rw.connectToRemote(mw)
+		conn, reader, err := rw.connectToRemote(ctx)
 		if err == nil {
 			return conn, reader
 		}
 		logger.Warning("Connection to %s failed with error: %s",
 			rw.Status().ExtraData.(*remoteExtraData).RemoteNode, err)
 		select {
-		case <-mw.Done():
+		case <-ctx.Done():
 			return nil, nil
 		case <-connectDelay.NextTimeout():
 		}
@@ -121,9 +121,9 @@ func (rw *remoteUnit) connectAndRun(ctx context.Context, action actionFunc) erro
 // getConnectionAndRun retries connecting to a host and, once the connection succeeds, runs an action function.
 // If firstTimeSync is true, a single attempt is made on the calling goroutine. If the initial attempt fails to
 // connect or firstTimeSync is false, we run return ErrPending to the caller.
-func (rw *remoteUnit) getConnectionAndRun(mw *utils.JobContext, firstTimeSync bool, action actionFunc) error {
+func (rw *remoteUnit) getConnectionAndRun(ctx context.Context, firstTimeSync bool, action actionFunc) error {
 	if firstTimeSync {
-		err := rw.connectAndRun(mw, action)
+		err := rw.connectAndRun(ctx, action)
 		if err == nil {
 			return nil
 		} else if !utils.ErrorIsKind(err, "connection") {
@@ -131,9 +131,9 @@ func (rw *remoteUnit) getConnectionAndRun(mw *utils.JobContext, firstTimeSync bo
 		}
 	}
 	go func() {
-		conn, reader := rw.getConnection(mw)
+		conn, reader := rw.getConnection(ctx)
 		if conn != nil {
-			_ = action(mw, conn, reader)
+			_ = action(ctx, conn, reader)
 		}
 	}()
 	return ErrPending

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -83,7 +83,7 @@ func (rw *remoteUnit) getConnection(mw *utils.JobContext) (net.Conn, *bufio.Read
 			return conn, reader
 		}
 		status := rw.Status()
-		logger.Debug("Connection to %s failed with error: %s",
+		logger.Warning("Connection to %s failed with error: %s",
 			status.ExtraData.(*remoteExtraData).RemoteNode, err)
 		errStr := err.Error()
 		if strings.Contains(errStr, "CRYPTO_ERROR") {

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -464,7 +464,7 @@ func (rw *remoteUnit) startOrRestart(start bool) error {
 	}
 	go func() {
 		rw.monitorRemoteUnit(rw.topJC, false)
-		mw.WorkerDone()
+		rw.topJC.WorkerDone()
 	}()
 	return nil
 }

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -471,7 +471,10 @@ func (rw *remoteUnit) startOrRestart(start bool) error {
 			return rw.cancelOrReleaseRemoteUnit(ctx, conn, reader, red.LocalReleased, false)
 		})
 	}
-	go rw.monitorRemoteUnit(rw.topJC, false)
+	go func() {
+		rw.monitorRemoteUnit(rw.topJC, false)
+		rw.topJC.WorkerDone()
+	}()
 	return nil
 }
 

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -96,6 +96,7 @@ func (rw *remoteUnit) getConnection(mw *utils.JobContext) (net.Conn, *bufio.Read
 			})
 			if shouldExit {
 				mw.Cancel()
+				return nil, nil
 			}
 		}
 		select {

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -442,7 +442,6 @@ func (rw *remoteUnit) runAndMonitor(mw *utils.JobContext, forRelease bool, actio
 		}()
 		return nil
 	}, func() {
-		mw.Cancel()
 		mw.WorkerDone()
 	})
 }

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -495,6 +495,7 @@ func (rw *remoteUnit) cancelOrRelease(release bool, force bool) error {
 		if release {
 			return rw.BaseWorkUnit.Release(true)
 		}
+		return nil
 	}
 	if release && force {
 		_ = rw.connectAndRun(rw.w.ctx, func(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -97,6 +97,7 @@ func (rw *remoteUnit) getConnection(mw *utils.JobContext) (net.Conn, *bufio.Read
 				rw.UpdateFullStatus(func(status *StatusFileData) {
 					status.State = WorkStateFailed
 				})
+				mw.WorkerDone()
 				mw.Cancel()
 			}
 		}
@@ -504,6 +505,10 @@ func (rw *remoteUnit) Cancel() error {
 
 // Release releases resources associated with a job.  Implies Cancel.
 func (rw *remoteUnit) Release(force bool) error {
+	// if remote work has not started, force release
+	if rw.Status().ExtraData.(*remoteExtraData).RemoteStarted == false {
+		force = true
+	}
 	return rw.cancelOrRelease(true, force)
 }
 

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -150,7 +150,11 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 }
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
+<<<<<<< HEAD
 func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, params map[string]string) (WorkUnit, error) {
+=======
+func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, params, tlsConfigName string) (WorkUnit, error) {
+>>>>>>> function param name change
 	rw, err := w.AllocateUnit("remote", params)
 	if err != nil {
 		return nil, err
@@ -159,7 +163,11 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
+<<<<<<< HEAD
 		ed.TLSConfigName = params["tlsclient"]
+=======
+		ed.TLSConfigName = tlsConfigName
+>>>>>>> function param name change
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -150,11 +150,7 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 }
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
-<<<<<<< HEAD
 func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, params map[string]string) (WorkUnit, error) {
-=======
-func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, params, tlsConfigName string) (WorkUnit, error) {
->>>>>>> function param name change
 	rw, err := w.AllocateUnit("remote", params)
 	if err != nil {
 		return nil, err
@@ -163,11 +159,7 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, params, tlsC
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
-<<<<<<< HEAD
 		ed.TLSConfigName = params["tlsclient"]
-=======
-		ed.TLSConfigName = tlsConfigName
->>>>>>> function param name change
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -159,7 +159,7 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
-		ed.TLSClient = params["tlsclient"] // set to "" if tlsclient not defined
+		ed.TLSClient = params["tlsclient"] // will set to "" if tlsclient not defined
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -159,7 +159,7 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
-		ed.TLSConfigName = params["tlsclient"]
+		ed.TLSConfigName = params["tlsclient"] // "" if tlsclient not defined""
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -151,6 +151,10 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
 func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, params map[string]string) (WorkUnit, error) {
+	tlsclient, ok := params["tlsclient"]
+	if ok {
+		delete(params, "tlsclient")
+	}
 	rw, err := w.AllocateUnit("remote", params)
 	if err != nil {
 		return nil, err
@@ -159,7 +163,7 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
-		ed.TLSClient = params["tlsclient"] // will set to "" if tlsclient not defined
+		ed.TLSClient = tlsclient // will set to "" if tlsclient not defined
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -159,7 +159,7 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
-		ed.TLSConfigName = params["tlsclient"] // "" if tlsclient not defined""
+		ed.TLSClient = params["tlsclient"] // set to "" if tlsclient not defined
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -159,6 +159,7 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
+		ed.TLSConfigName = params["tlsclient"]
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -150,11 +150,7 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 }
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
-func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, params map[string]string) (WorkUnit, error) {
-	tlsclient, ok := params["tlsclient"]
-	if ok {
-		delete(params, "tlsclient")
-	}
+func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsclient string, params map[string]string) (WorkUnit, error) {
 	rw, err := w.AllocateUnit("remote", params)
 	if err != nil {
 		return nil, err
@@ -163,7 +159,7 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string
 		ed := status.ExtraData.(*remoteExtraData)
 		ed.RemoteNode = remoteNode
 		ed.RemoteWorkType = remoteWorkType
-		ed.TLSClient = tlsclient // will set to "" if tlsclient not defined
+		ed.TLSClient = tlsclient
 	})
 	if rw.LastUpdateError() != nil {
 		return nil, rw.LastUpdateError()

--- a/pkg/workceptor/workceptor_stub.go
+++ b/pkg/workceptor/workceptor_stub.go
@@ -42,7 +42,7 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params string) (WorkUnit,
 }
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
-func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, params string) (WorkUnit, error) {
+func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, tlsclient string, params string) (WorkUnit, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -200,10 +200,11 @@ def list(ctx, quiet):
 @click.option('--node', type=str, help="Receptor node to run the work on. Defaults to the local node.")
 @click.option('--payload', '-p', type=str, help="File containing unit of work data. Use - for stdin.")
 @click.option('--payload-literal', '-l', type=str, help="Use the command line string as the literal unit of work data.")
+@click.option('--tlsclient', type=str, default="", help="TLS client used when submitting work to a remote node")
 @click.option('--follow', '-f', help="Remain attached to the job and print its results to stdout", is_flag=True)
 @click.option('--rm', help="Release unit after completion", is_flag=True)
 @click.argument('params', nargs=-1, type=click.UNPROCESSED)
-def submit(ctx, worktype, node, payload, payload_literal, follow, rm, params):
+def submit(ctx, worktype, node, payload, payload_literal, tlsclient, follow, rm, params):
     if not payload and not payload_literal:
         print("Must provide one of --payload or --payload-literal.")
         sys.exit(1)
@@ -224,7 +225,7 @@ def submit(ctx, worktype, node, payload, payload_literal, follow, rm, params):
         rc = get_rc(ctx)
         if node == "":
             node = None
-        work = rc.submit_work(node, worktype, " ".join(params), payload_data)
+        work = rc.submit_work(node, worktype, " ".join(params), payload_data, tlsclient)
         result = work.pop('result')
         unitid = work.pop('unitid')
         if follow:

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -91,8 +91,8 @@ class ReceptorControl:
             "tlsclient": tlsclient,
             "params": params,
         }
-        commandStr = json.dumps(commandMap)
-        command = f"{commandStr}\n"
+        commandJson = json.dumps(commandMap)
+        command = f"{commandJson}\n"
         self.writestr(command)
         text = self.readstr()
         m = re.compile("Work unit created with ID (.+). Send stdin data and EOF.").fullmatch(text)
@@ -127,4 +127,3 @@ class ReceptorControl:
             raise RuntimeError(errmsg)
         self.socket.shutdown(socket.SHUT_WR)
         return self.sockfile
-

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -80,10 +80,19 @@ class ReceptorControl:
         if not str.startswith(text, "Connecting"):
             raise RuntimeError(text)
 
-    def submit_work(self, node, worktype, params, payload):
+    def submit_work(self, node, worktype, params, payload, tlsclient):
         if node is None:
             node = "localhost"
-        command = f"work submit {node} {worktype} {params}\n"
+        commandMap = {
+            "command": "work",
+            "subcommand": "submit",
+            "node": node,
+            "worktype": worktype,
+            "tlsclient": tlsclient,
+            "params": params,
+        }
+        commandStr = json.dumps(commandMap)
+        command = f"{commandStr}\n"
         self.writestr(command)
         text = self.readstr()
         m = re.compile("Work unit created with ID (.+). Send stdin data and EOF.").fullmatch(text)

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -127,3 +127,4 @@ class ReceptorControl:
             raise RuntimeError(errmsg)
         self.socket.shutdown(socket.SHUT_WR)
         return self.sockfile
+


### PR DESCRIPTION
Works with `InitFromJson` by providing a `tlsclient` option

e.g.

```json
{"command":"work","subcommand":"submit","worktype":"100cat","tlsclient":"client","node":"bar","params":""}
```

Therefore, I changed `receptorctl work submit` to use JSON encoded strings when writing to the control socket.

**Behavior if wrong TLS configuration is provided**
If remote job has not yet started, we fail the job and add `Incorrect tlsclient to remote service` message to the status Detail field.
If remote job has already started (maybe tls server was reconfigured), we do not fail the job but still provide the same Detail message.

Here are the logger Warning messages that appear when providing incorrect tls information
_client provided no tlsclient_
`WARNING Connection to bar failed with error: CRYPTO_ERROR: insecure connection to secure service`

_client provided wrong ca_
`WARNING Connection to bar failed with error: CRYPTO_ERROR: x509: certificate signed by unknown authority (possibly because of "crypto/rsa: verification error" while trying to verify candidate authority certificate "Easy-RSA CA")`

_client provided wrong certs and keys_
`WARNING Connection to bar failed with error: CRYPTO_ERROR: tls: bad certificate`

**Other changes**,

`LocalStarted` in `remoteExtraData` renamed to `RemoteStarted`

If `RemoteStarted` is false, we can do a `release` with force, since nothing has actually started on the remote. Otherwise if we are having issues connecting to remote, we must do a `force-release` even though we know nothing has started there.

added a `made version` target which saves the .VERSION files

**To do in other PRs**:
provide tls expectations in service advertisement
add a test case that provides tlsclient
