### PR TITLE
Add tests for submitting work via JSON with a tlsclient

### DIFF
--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -100,7 +100,7 @@ func TestSSLListeners(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			key, crt, err := utils.GenerateCert(tempdir, "test")
+			key, crt, err := utils.GenerateCert(tempdir, "test", "localhost")
 
 			receptorStdOut := bytes.Buffer{}
 			port := utils.ReserveTCPPort()

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -362,9 +362,9 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirPrefix string) (*CLIMesh, er
 		}
 		controlSocket := filepath.Join(tempdir, "controlsock")
 		node.controlSocket = controlSocket
-		tmp := make(map[interface{}]interface{})
-		tmp["filename"] = controlSocket
 		if needsControlService {
+			tmp := make(map[interface{}]interface{})
+			tmp["filename"] = controlSocket
 			controlServiceYaml := make(map[interface{}]interface{})
 			controlServiceYaml["control-service"] = tmp
 			MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, controlServiceYaml)

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -334,6 +334,28 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirPrefix string) (*CLIMesh, er
 
 	// Setup the controlsvc and sockets
 	for k, node := range nodes {
+		controlSocket := ""
+		needsControlService := true
+		for _, attr := range MeshDefinition.Nodes[k].Nodedef {
+			attrMap := attr.(map[interface{}]interface{})
+			for k, v := range attrMap {
+				k = k.(string)
+				if k == "control-service" {
+					vMap, _ := v.(map[interface{}]interface{})
+					csvName, ok := vMap["service"]
+					if ok {
+						if csvName == "control" {
+							controlSocket = vMap["filename"].(string)
+							needsControlService = false
+						}
+					}
+				}
+			}
+		}
+		if !needsControlService {
+			node.controlSocket = controlSocket
+			continue
+		}
 		tempdir, err := ioutil.TempDir(ControlSocketBaseDir, "")
 		if err != nil {
 			return nil, err

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -209,6 +209,19 @@ func (r *ReceptorControl) getWorkSubmitResponse() (string, error) {
 	return unitID, nil
 }
 
+// WorkSubmitJSON begins work on remote node via JSON command
+func (r *ReceptorControl) WorkSubmitJSON(command string) (string, error) {
+	_, err := r.WriteStr(fmt.Sprintf("%s\n", command))
+	if err != nil {
+		return "", err
+	}
+	unitID, err := r.getWorkSubmitResponse()
+	if err != nil {
+		return "", err
+	}
+	return unitID, nil
+}
+
 // WorkSubmit begins work on remote node
 func (r *ReceptorControl) WorkSubmit(node, workType string) (string, error) {
 	_, err := r.WriteStr(fmt.Sprintf("work submit %s %s\n", node, workType))

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os/exec"
 	"path/filepath"
@@ -121,7 +122,7 @@ func FreeUDPPort(portNum int) {
 
 // GenerateCert generates a private and public key for testing in the directory
 // specified
-func GenerateCert(dir, name string) (keyPath, certPath string, e error) {
+func GenerateCert(dir, name, commonName string) (keyPath, certPath string, e error) {
 	KeyPath := filepath.Join(dir, name+".key")
 	CrtPath := filepath.Join(dir, name+".crt")
 	// Create our private key
@@ -131,7 +132,7 @@ func GenerateCert(dir, name string) (keyPath, certPath string, e error) {
 		return "", "", err
 	}
 	// Create our certificate
-	cmd = exec.Command("openssl", "req", "-x509", "-new", "-nodes", "-key", KeyPath, "-subj", "/C=/ST=/L=/O=Receptor Testing/OU=/CN=localhost", "-sha256", "-out", CrtPath)
+	cmd = exec.Command("openssl", "req", "-x509", "-new", "-nodes", "-key", KeyPath, "-subj", fmt.Sprintf("/C=/ST=/L=/O=Receptor Testing/OU=/CN=%s", commonName), "-sha256", "-out", CrtPath)
 	err = cmd.Run()
 	if err != nil {
 		return "", "", err
@@ -141,7 +142,7 @@ func GenerateCert(dir, name string) (keyPath, certPath string, e error) {
 
 // GenerateCertWithCA generates a private and public key for testing in the directory
 // specified using the ca specified
-func GenerateCertWithCA(dir, name, caKeyPath, caCrtPath string) (keyPath, certPath string, e error) {
+func GenerateCertWithCA(dir, name, caKeyPath, caCrtPath, commonName string) (keyPath, certPath string, e error) {
 	KeyPath := filepath.Join(dir, name+".key")
 	CrtPath := filepath.Join(dir, name+".crt")
 	CSRPath := filepath.Join(dir, name+".csa")
@@ -153,7 +154,7 @@ func GenerateCertWithCA(dir, name, caKeyPath, caCrtPath string) (keyPath, certPa
 	}
 
 	// Create our certificate request
-	cmd = exec.Command("openssl", "req", "-new", "-sha256", "-key", KeyPath, "-subj", "/C=/ST=/L=/O=Receptor Testing/OU=/CN=localhost", "-out", CSRPath)
+	cmd = exec.Command("openssl", "req", "-new", "-sha256", "-key", KeyPath, "-subj", fmt.Sprintf("/C=/ST=/L=/O=Receptor Testing/OU=/CN=%s", commonName), "-out", CSRPath)
 	err = cmd.Run()
 	if err != nil {
 		return "", "", err

--- a/tests/functional/mesh/tls_test.go
+++ b/tests/functional/mesh/tls_test.go
@@ -36,15 +36,15 @@ func TestTCPSSLConnections(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			caKey, caCrt, err := utils.GenerateCert(tempdir, "ca")
+			caKey, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			key1, crt1, err := utils.GenerateCertWithCA(tempdir, "node1", caKey, caCrt)
+			key1, crt1, err := utils.GenerateCertWithCA(tempdir, "node1", caKey, caCrt, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			key2, crt2, err := utils.GenerateCertWithCA(tempdir, "node2", caKey, caCrt)
+			key2, crt2, err := utils.GenerateCertWithCA(tempdir, "node2", caKey, caCrt, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -180,11 +180,11 @@ func TestTCPSSLClientAuthFailNoKey(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca")
+			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1")
+			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -274,16 +274,16 @@ func TestTCPSSLClientAuthFailBadKey(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca")
+			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1")
+			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			key2, crt2, err := utils.GenerateCert(tempdir, "node2")
+			key2, crt2, err := utils.GenerateCert(tempdir, "node2", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -373,11 +373,11 @@ func TestTCPSSLServerAuthFailNoKey(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca")
+			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1")
+			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -456,16 +456,16 @@ func TestTCPSSLServerAuthFailBadKey(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca")
+			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1")
+			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			key2, crt2, err := utils.GenerateCert(tempdir, "node2")
+			key2, crt2, err := utils.GenerateCert(tempdir, "node2", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -2,10 +2,12 @@ package mesh
 
 import (
 	"context"
+	"fmt"
 	_ "github.com/fortytw2/leaktest"
 	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
 	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
 	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +17,7 @@ import (
 func TestWork(t *testing.T) {
 	t.Parallel()
 	// Setup our mesh yaml data
-	workSetup := func(testName string) (*receptorcontrol.ReceptorControl, *mesh.CLIMesh, []byte) {
+	workSetup := func(testName string) (map[string]*receptorcontrol.ReceptorControl, *mesh.CLIMesh, []byte) {
 		data := mesh.YamlData{}
 		data.Nodes = make(map[string]*mesh.YamlNode)
 		echoSleepLong := map[interface{}]interface{}{
@@ -29,6 +31,34 @@ func TestWork(t *testing.T) {
 			"params":   "-c \"for i in {1..5}; do echo $i;done\"",
 		}
 		expectedResults := []byte("1\n2\n3\n4\n5\n")
+		// Setup certs
+		baseDir := filepath.Join(mesh.TestBaseDir, testName)
+		err := os.MkdirAll(baseDir, 0755)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tempdir, err := ioutil.TempDir(baseDir, "certs-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		caKey, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
+		if err != nil {
+			t.Fatal(err)
+		}
+		key1, crt1, err := utils.GenerateCertWithCA(tempdir, "node1", caKey, caCrt, "node1")
+		if err != nil {
+			t.Fatal(err)
+		}
+		key2, crt2, err := utils.GenerateCertWithCA(tempdir, "node2", caKey, caCrt, "node2")
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Setup control service
+		tempdir, err = ioutil.TempDir(mesh.ControlSocketBaseDir, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		controlSocket := filepath.Join(tempdir, "controlsock")
 		// Generate a mesh with 3 nodes
 		data.Nodes["node2"] = &mesh.YamlNode{
 			Connections: map[string]mesh.YamlConnection{},
@@ -42,6 +72,25 @@ func TestWork(t *testing.T) {
 						},
 					},
 				},
+				map[interface{}]interface{}{
+					"tls-server": map[interface{}]interface{}{
+						"name":              "control_tls",
+						"cert":              crt2,
+						"key":               key2,
+						"requireclientcert": true,
+						"clientcas":         caCrt,
+					},
+				},
+				map[interface{}]interface{}{
+					"control-service": map[interface{}]interface{}{
+						"service":  "control",
+						"tls":      "control_tls",
+						"filename": controlSocket,
+					},
+				},
+				map[interface{}]interface{}{
+					"work-command": echoSleepShort,
+				},
 			},
 		}
 		data.Nodes["node1"] = &mesh.YamlNode{
@@ -50,7 +99,17 @@ func TestWork(t *testing.T) {
 					Index: 0,
 				},
 			},
-			Nodedef: []interface{}{},
+			Nodedef: []interface{}{
+				map[interface{}]interface{}{
+					"tls-client": map[interface{}]interface{}{
+						"name":               "tlsclient",
+						"rootcas":            caCrt,
+						"insecureskipverify": false,
+						"cert":               crt1,
+						"key":                key1,
+					},
+				},
+			},
 		}
 		data.Nodes["node3"] = &mesh.YamlNode{
 			Connections: map[string]mesh.YamlConnection{
@@ -80,29 +139,44 @@ func TestWork(t *testing.T) {
 		}
 
 		nodes := m.Nodes()
-		controller := receptorcontrol.New()
-		err = controller.Connect(nodes["node1"].ControlSocket())
-		if err != nil {
-			t.Fatal(err)
+		controllers := make(map[string]*receptorcontrol.ReceptorControl)
+		for k := range nodes {
+			controller := receptorcontrol.New()
+			err = controller.Connect(nodes[k].ControlSocket())
+			if err != nil {
+				t.Fatal(err)
+			}
+			controllers[k] = controller
 		}
-		return controller, m, expectedResults
+		return controllers, m, expectedResults
 	}
 
-	tearDown := func(controller *receptorcontrol.ReceptorControl, m *mesh.CLIMesh) {
+	tearDown := func(controllers map[string]*receptorcontrol.ReceptorControl, m *mesh.CLIMesh) {
 		defer m.WaitForShutdown()
 		defer m.Destroy()
-		defer controller.Close()
+		defer func() {
+			for _, controller := range controllers {
+				controller.Close()
+			}
+		}()
 	}
 
-	assertFilesReleased := func(nodeDir, nodeID, unitID string) {
+	assertFilesReleased := func(ctx context.Context, nodeDir, nodeID, unitID string) error {
 		workPath := filepath.Join(nodeDir, "datadir", nodeID, unitID)
-		_, err := os.Stat(workPath)
-		if !os.IsNotExist(err) {
-			t.Errorf("unitID %s on %s did not release", unitID, nodeID)
+		check := func() bool {
+			_, err := os.Stat(workPath)
+			if os.IsNotExist(err) {
+				return true
+			}
+			return false
 		}
+		if !utils.CheckUntilTimeout(ctx, 3000*time.Millisecond, check) {
+			return fmt.Errorf("unitID %s on %s did not release", unitID, nodeID)
+		}
+		return nil
 	}
 
-	assertStdoutFizeSize := func(ctx context.Context, nodeDir, nodeID, unitID string, waitUntilSize int) {
+	assertStdoutFizeSize := func(ctx context.Context, nodeDir, nodeID, unitID string, waitUntilSize int) error {
 		stdoutFilename := filepath.Join(nodeDir, "datadir", nodeID, unitID, "stdout")
 		check := func() bool {
 			_, err := os.Stat(stdoutFilename)
@@ -116,35 +190,92 @@ func TestWork(t *testing.T) {
 			return false
 		}
 		if !utils.CheckUntilTimeout(ctx, 3000*time.Millisecond, check) {
-			t.Errorf("file size not correct for %s", stdoutFilename)
+			return fmt.Errorf("file size not correct for %s", stdoutFilename)
 		}
+		return nil
 	}
 
-	t.Run("cancel then release remote work", func(t *testing.T) {
+	t.Run("work submit with tlsclient", func(t *testing.T) {
+		// tests work submit via json
+		// tests connecting to remote control service with tlsclient
 		t.Parallel()
-		controller, m, _ := workSetup(t.Name())
-		defer tearDown(controller, m)
-		nodes := m.Nodes()
+		controllers, m, _ := workSetup(t.Name())
+		defer tearDown(controllers, m)
 
-		unitID, err := controller.WorkSubmit("node3", "echosleeplong")
+		command := `{"command":"work","subcommand":"submit","worktype":"echosleepshort","tlsclient":"tlsclient","node":"node2","params":""}`
+		unitID, err := controllers["node1"].WorkSubmitJSON(command)
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-		err = controller.AssertWorkRunning(ctx, unitID)
+		err = controllers["node1"].AssertWorkSucceeded(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = controller.WorkCancel(unitID)
+	})
+
+	t.Run("work submit with incorrect tlsclient", func(t *testing.T) {
+		// tests that submitting work with incorrect tlsclient information
+		// immediately fails the job
+		// also tests that releasing a job that has not been started on remote
+		// will not attempt to connect to remote
+		t.Parallel()
+		controllers, m, _ := workSetup(t.Name())
+		defer tearDown(controllers, m)
+		nodes := m.Nodes()
+
+		command := `{"command":"work","subcommand":"submit","worktype":"echosleepshort","tlsclient":"","node":"node2","params":""}`
+		unitID, err := controllers["node3"].WorkSubmitJSON(command)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+		err = controllers["node3"].AssertWorkFailed(ctx, unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = controllers["node3"].WorkRelease(unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
-		err = controller.AssertWorkCancelled(ctx, unitID)
+		err = controllers["node3"].AssertWorkReleased(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		workStatus, err := controller.GetWorkStatus(unitID)
+		ctx, _ = context.WithTimeout(context.Background(), 20*time.Second)
+		err = assertFilesReleased(ctx, nodes["node3"].Dir(), "node3", unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("cancel then release remote work", func(t *testing.T) {
+		// also tests that release still works after control service restarts
+		t.Parallel()
+		controllers, m, _ := workSetup(t.Name())
+		defer tearDown(controllers, m)
+		nodes := m.Nodes()
+
+		unitID, err := controllers["node1"].WorkSubmit("node3", "echosleeplong")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
+		err = controllers["node1"].AssertWorkRunning(ctx, unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = controllers["node1"].WorkCancel(unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+		err = controllers["node1"].AssertWorkCancelled(ctx, unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		workStatus, err := controllers["node1"].GetWorkStatus(unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -152,34 +283,63 @@ func TestWork(t *testing.T) {
 		if remoteUnitID == "" {
 			t.Errorf("remoteUnitID should not be empty")
 		}
-
-		_, err = controller.WorkRelease(unitID)
+		nodes["node1"].Shutdown()
+		nodes["node1"].WaitForShutdown()
+		err = nodes["node1"].Start()
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
-		err = controller.AssertWorkReleased(ctx, unitID)
+		err = m.WaitForReady(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
-		assertFilesReleased(nodes["node1"].Dir(), "node1", unitID)
-		assertFilesReleased(nodes["node3"].Dir(), "node3", remoteUnitID)
+		err = controllers["node1"].Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = controllers["node1"].Reconnect()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, err = controllers["node1"].WorkRelease(unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
+		err = controllers["node1"].AssertWorkReleased(ctx, unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+		err = assertFilesReleased(ctx, nodes["node1"].Dir(), "node1", unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
+		err = assertFilesReleased(ctx, nodes["node3"].Dir(), "node3", remoteUnitID)
+		if err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	t.Run("work submit while remote node is down", func(t *testing.T) {
 		t.Parallel()
-		controller, m, _ := workSetup(t.Name())
-		defer tearDown(controller, m)
+		controllers, m, _ := workSetup(t.Name())
+		defer tearDown(controllers, m)
 		nodes := m.Nodes()
 
 		nodes["node3"].Shutdown()
 		nodes["node3"].WaitForShutdown()
-		unitID, err := controller.WorkSubmit("node3", "echosleepshort")
+		unitID, err := controllers["node1"].WorkSubmit("node3", "echosleepshort")
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-		err = controller.AssertWorkPending(ctx, unitID)
+		err = controllers["node1"].AssertWorkPending(ctx, unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
 		err = nodes["node3"].Start()
 		if err != nil {
 			t.Fatal(err)
@@ -187,9 +347,11 @@ func TestWork(t *testing.T) {
 		// Wait for node3 to join the mesh again
 		ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
 		err = m.WaitForReady(ctx)
-
+		if err != nil {
+			t.Fatal(err)
+		}
 		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
-		err = controller.AssertWorkSucceeded(ctx, unitID)
+		err = controllers["node1"].AssertWorkSucceeded(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -197,22 +359,25 @@ func TestWork(t *testing.T) {
 
 	t.Run("work streaming resumes when relay node restarts", func(t *testing.T) {
 		t.Parallel()
-		controller, m, expectedResults := workSetup(t.Name())
-		defer tearDown(controller, m)
+		controllers, m, expectedResults := workSetup(t.Name())
+		defer tearDown(controllers, m)
 		nodes := m.Nodes()
 
-		unitID, err := controller.WorkSubmit("node3", "echosleeplong")
+		unitID, err := controllers["node1"].WorkSubmit("node3", "echosleeplong")
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
-		err = controller.AssertWorkRunning(ctx, unitID)
+		err = controllers["node1"].AssertWorkRunning(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ = context.WithTimeout(context.Background(), 20*time.Second)
-		assertStdoutFizeSize(ctx, nodes["node1"].Dir(), "node1", unitID, 1)
-		err = controller.AssertWorkResults(unitID, expectedResults[:1])
+		err = assertStdoutFizeSize(ctx, nodes["node1"].Dir(), "node1", unitID, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = controllers["node1"].AssertWorkResults(unitID, expectedResults[:1])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -222,15 +387,20 @@ func TestWork(t *testing.T) {
 		// Wait for node2 to join the mesh again
 		ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
 		err = m.WaitForReady(ctx)
-
-		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
-		err = controller.AssertWorkSucceeded(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
-		assertStdoutFizeSize(ctx, nodes["node1"].Dir(), "node1", unitID, 10)
-		err = controller.AssertWorkResults(unitID, expectedResults)
+		err = controllers["node1"].AssertWorkSucceeded(ctx, unitID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ctx, _ = context.WithTimeout(context.Background(), 30*time.Second)
+		err = assertStdoutFizeSize(ctx, nodes["node1"].Dir(), "node1", unitID, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = controllers["node1"].AssertWorkResults(unitID, expectedResults)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -53,12 +53,6 @@ func TestWork(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		// Setup control service
-		tempdir, err = ioutil.TempDir(mesh.ControlSocketBaseDir, "")
-		if err != nil {
-			t.Fatal(err)
-		}
-		controlSocket := filepath.Join(tempdir, "controlsock")
 		// Generate a mesh with 3 nodes
 		data.Nodes["node2"] = &mesh.YamlNode{
 			Connections: map[string]mesh.YamlConnection{},
@@ -83,9 +77,8 @@ func TestWork(t *testing.T) {
 				},
 				map[interface{}]interface{}{
 					"control-service": map[interface{}]interface{}{
-						"service":  "control",
-						"tls":      "control_tls",
-						"filename": controlSocket,
+						"service": "control",
+						"tls":     "control_tls",
 					},
 				},
 				map[interface{}]interface{}{


### PR DESCRIPTION
Recent API changes allow us to submit work with JSON

```golang
command := `{"command":"work","subcommand":"submit","worktype":"echosleepshort","tlsclient":"","node":"node2","params":""}`
unitID, err := controllers["node3"].WorkSubmitJSON(command)
```

This API supports adding a tlsclient that will be used when connecting to a remote control service that has TLS configured

**Other changes:**

You can now generate a certificate with a specified Common Name, which allows us to test with `insecureskipverify: false` at the receptor level.

You can now setup a control-service with service `control` in the node definitions. This allows us to set up control services with tls enabled.

```golang 
map[interface{}]interface{}{
	"control-service": map[interface{}]interface{}{
		"service":  "control",
		"tls":      "control_tls",
	},
},
```

When generating the mesh, it will skip over creating a control socket if the node already has a control-service with the `control` service defined.

It will however generate a control socket filename and append it to the definition.