### PR TITLE
Container mesh ssl

### DIFF
--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -5,10 +5,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/project-receptor/receptor/tests/functional/lib/utils"
-	"io/ioutil"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -90,17 +87,7 @@ func TestSSLListeners(t *testing.T) {
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup the mesh directory
-			baseDir := filepath.Join(os.TempDir(), "receptor-testing", t.Name())
-			err := os.MkdirAll(baseDir, 0755)
-			if err != nil {
-				t.Fatal(err)
-			}
-			tempdir, err := ioutil.TempDir(baseDir, "certs-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			key, crt, err := utils.GenerateCert(tempdir, "test", "localhost")
+			key, crt, err := utils.GenerateCert("test", "localhost")
 
 			receptorStdOut := bytes.Buffer{}
 			port := utils.ReserveTCPPort()

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -149,7 +149,7 @@ func (m *CLIMesh) Nodes() map[string]Node {
 
 // NewCLIMeshFromFile Takes a filename of a file with a yaml description of a mesh, loads it and
 // calls NewMeshFromYaml on it
-func NewCLIMeshFromFile(filename, dirPrefix string) (Mesh, error) {
+func NewCLIMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 	yamlDat, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -162,19 +162,17 @@ func NewCLIMeshFromFile(filename, dirPrefix string) (Mesh, error) {
 		return nil, err
 	}
 
-	return NewCLIMeshFromYaml(MeshDefinition, dirPrefix)
+	return NewCLIMeshFromYaml(MeshDefinition, dirSuffix)
 }
 
 // NewCLIMeshFromYaml takes a yaml mesh description and returns a mesh of nodes
 // listening and dialing as defined in the yaml
-func NewCLIMeshFromYaml(MeshDefinition YamlData, dirPrefix string) (*CLIMesh, error) {
+func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, error) {
 	mesh := &CLIMesh{}
 	// Setup the mesh directory
-	var baseDir string
-	if dirPrefix == "" {
-		baseDir = TestBaseDir
-	} else {
-		baseDir = dirPrefix
+	baseDir := utils.TestBaseDir
+	if dirSuffix != "" {
+		baseDir = filepath.Join(utils.TestBaseDir, dirSuffix)
 	}
 	err := os.MkdirAll(baseDir, 0755)
 	if err != nil {
@@ -356,7 +354,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirPrefix string) (*CLIMesh, er
 				}
 			}
 		}
-		tempdir, err := ioutil.TempDir(ControlSocketBaseDir, "")
+		tempdir, err := ioutil.TempDir(utils.ControlSocketBaseDir, "")
 		if err != nil {
 			return nil, err
 		}

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -182,7 +182,7 @@ func (m *LibMesh) Dir() string {
 
 // NewLibMeshFromFile Takes a filename of a file with a yaml description of a mesh, loads it and
 // calls NewMeshFromYaml on it
-func NewLibMeshFromFile(filename, dirPrefix string) (Mesh, error) {
+func NewLibMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 	yamlDat, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, err
@@ -195,19 +195,17 @@ func NewLibMeshFromFile(filename, dirPrefix string) (Mesh, error) {
 		return nil, err
 	}
 
-	return NewLibMeshFromYaml(MeshDefinition, dirPrefix)
+	return NewLibMeshFromYaml(MeshDefinition, dirSuffix)
 }
 
 // NewLibMeshFromYaml takes a yaml mesh description and returns a mesh of nodes
 // listening and dialing as defined in the yaml
-func NewLibMeshFromYaml(MeshDefinition YamlData, dirPrefix string) (*LibMesh, error) {
+func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, error) {
 	mesh := &LibMesh{}
 	// Setup the mesh directory
-	var baseDir string
-	if dirPrefix == "" {
-		baseDir = TestBaseDir
-	} else {
-		baseDir = dirPrefix
+	baseDir := utils.TestBaseDir
+	if dirSuffix != "" {
+		baseDir = filepath.Join(utils.TestBaseDir, dirSuffix)
 	}
 	// Ignore the error, if the dir already exists thats fine
 	err := os.MkdirAll(baseDir, 0755)
@@ -480,7 +478,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirPrefix string) (*LibMesh, er
 		ctx, canceller := context.WithCancel(context.Background())
 		node.controlServerCanceller = canceller
 
-		tempdir, err := ioutil.TempDir(ControlSocketBaseDir, "")
+		tempdir, err := ioutil.TempDir(utils.ControlSocketBaseDir, "")
 		if err != nil {
 			return nil, err
 		}

--- a/tests/functional/lib/mesh/mesh.go
+++ b/tests/functional/lib/mesh/mesh.go
@@ -3,8 +3,6 @@ package mesh
 import (
 	"context"
 	"github.com/project-receptor/receptor/pkg/netceptor"
-	"os"
-	"path/filepath"
 )
 
 // Node Defines the interface for nodes made using the CLI, Library, and
@@ -85,19 +83,4 @@ func getListenerCost(listenerYaml map[interface{}]interface{}, nodeID string) fl
 		cost = 1.0
 	}
 	return cost
-}
-
-// TestBaseDir holds the base directory that all permanent test logs should go in
-var TestBaseDir string
-
-// ControlSocketBaseDir holds the base directory for controlsockets, control sockets
-// have a limited path length, therefore we cant always put them along side the
-// node they are attached to
-var ControlSocketBaseDir string
-
-func init() {
-	TestBaseDir = filepath.Join(os.TempDir(), "receptor-testing")
-	os.Mkdir(TestBaseDir, 0700)
-	ControlSocketBaseDir = filepath.Join(TestBaseDir, "controlsockets")
-	os.Mkdir(ControlSocketBaseDir, 0700)
 }

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -39,7 +38,7 @@ func TestMeshStartup(t *testing.T) {
 		t.Run(filename, func(t *testing.T) {
 			t.Parallel()
 			t.Logf("starting mesh")
-			m, err := mesh.NewCLIMeshFromFile(filename, filepath.Join(mesh.TestBaseDir, t.Name()))
+			m, err := mesh.NewCLIMeshFromFile(filename, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -93,7 +92,7 @@ func TestMeshConnections(t *testing.T) {
 		filename := data.filename
 		t.Run(filename, func(t *testing.T) {
 			t.Parallel()
-			m, err := mesh.NewCLIMeshFromFile(filename, filepath.Join(mesh.TestBaseDir, t.Name()))
+			m, err := mesh.NewCLIMeshFromFile(filename, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -134,7 +133,7 @@ func TestMeshShutdown(t *testing.T) {
 	for _, data := range testTable {
 		filename := data.filename
 		t.Run(filename, func(t *testing.T) {
-			m, err := mesh.NewLibMeshFromFile(filename, filepath.Join(mesh.TestBaseDir, t.Name()))
+			m, err := mesh.NewLibMeshFromFile(filename, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -219,7 +218,7 @@ func TestCosts(t *testing.T) {
 		},
 		Nodedef: []interface{}{},
 	}
-	m, err := mesh.NewCLIMeshFromYaml(data, filepath.Join(mesh.TestBaseDir, t.Name()))
+	m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -282,7 +281,7 @@ func benchmarkLinearMeshStartup(totalNodes int, b *testing.B) {
 
 		// Reset the Timer because building the yaml data for the mesh may have
 		// taken a bit
-		m, err := mesh.NewCLIMeshFromYaml(data, filepath.Join(mesh.TestBaseDir, b.Name()))
+		m, err := mesh.NewCLIMeshFromYaml(data, b.Name())
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/tests/functional/mesh/tls_test.go
+++ b/tests/functional/mesh/tls_test.go
@@ -6,9 +6,6 @@ import (
 	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
 	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
 	"github.com/project-receptor/receptor/tests/functional/lib/utils"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 )
@@ -25,26 +22,15 @@ func TestTCPSSLConnections(t *testing.T) {
 		listener := data.listener
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
-
-			// Setup the mesh directory
-			baseDir := filepath.Join(mesh.TestBaseDir, t.Name())
-			err := os.MkdirAll(baseDir, 0755)
+			caKey, caCrt, err := utils.GenerateCert("ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			tempdir, err := ioutil.TempDir(baseDir, "certs-")
+			key1, crt1, err := utils.GenerateCertWithCA("node1", caKey, caCrt, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			caKey, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
-			if err != nil {
-				t.Fatal(err)
-			}
-			key1, crt1, err := utils.GenerateCertWithCA(tempdir, "node1", caKey, caCrt, "localhost")
-			if err != nil {
-				t.Fatal(err)
-			}
-			key2, crt2, err := utils.GenerateCertWithCA(tempdir, "node2", caKey, caCrt, "localhost")
+			key2, crt2, err := utils.GenerateCertWithCA("node2", caKey, caCrt, "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -125,7 +111,7 @@ func TestTCPSSLConnections(t *testing.T) {
 					},
 				},
 			}
-			m, err := mesh.NewCLIMeshFromYaml(data, baseDir)
+			m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -170,21 +156,11 @@ func TestTCPSSLClientAuthFailNoKey(t *testing.T) {
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup the mesh directory
-			baseDir := filepath.Join(mesh.TestBaseDir, t.Name())
-			err := os.MkdirAll(baseDir, 0755)
+			_, caCrt, err := utils.GenerateCert("ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			tempdir, err := ioutil.TempDir(baseDir, "certs-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
-			if err != nil {
-				t.Fatal(err)
-			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
+			key1, crt1, err := utils.GenerateCert("node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -235,7 +211,7 @@ func TestTCPSSLClientAuthFailNoKey(t *testing.T) {
 					},
 				},
 			}
-			m, err := mesh.NewCLIMeshFromYaml(data, baseDir)
+			m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -264,26 +240,16 @@ func TestTCPSSLClientAuthFailBadKey(t *testing.T) {
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup the mesh directory
-			baseDir := filepath.Join(mesh.TestBaseDir, t.Name())
-			err := os.MkdirAll(baseDir, 0755)
+			_, caCrt, err := utils.GenerateCert("ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			tempdir, err := ioutil.TempDir(baseDir, "certs-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
-			if err != nil {
-				t.Fatal(err)
-			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
+			key1, crt1, err := utils.GenerateCert("node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			key2, crt2, err := utils.GenerateCert(tempdir, "node2", "localhost")
+			key2, crt2, err := utils.GenerateCert("node2", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -334,7 +300,7 @@ func TestTCPSSLClientAuthFailBadKey(t *testing.T) {
 					},
 				},
 			}
-			m, err := mesh.NewCLIMeshFromYaml(data, baseDir)
+			m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -363,21 +329,11 @@ func TestTCPSSLServerAuthFailNoKey(t *testing.T) {
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup the mesh directory
-			baseDir := filepath.Join(mesh.TestBaseDir, t.Name())
-			err := os.MkdirAll(baseDir, 0755)
+			_, caCrt, err := utils.GenerateCert("ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			tempdir, err := ioutil.TempDir(baseDir, "certs-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
-			if err != nil {
-				t.Fatal(err)
-			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
+			key1, crt1, err := utils.GenerateCert("node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -417,7 +373,7 @@ func TestTCPSSLServerAuthFailNoKey(t *testing.T) {
 					},
 				},
 			}
-			m, err := mesh.NewCLIMeshFromYaml(data, baseDir)
+			m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -446,26 +402,16 @@ func TestTCPSSLServerAuthFailBadKey(t *testing.T) {
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
 
-			// Setup the mesh directory
-			baseDir := filepath.Join(mesh.TestBaseDir, t.Name())
-			err := os.MkdirAll(baseDir, 0755)
+			_, caCrt, err := utils.GenerateCert("ca", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
-			tempdir, err := ioutil.TempDir(baseDir, "certs-")
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
-			if err != nil {
-				t.Fatal(err)
-			}
-			key1, crt1, err := utils.GenerateCert(tempdir, "node1", "localhost")
+			key1, crt1, err := utils.GenerateCert("node1", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			key2, crt2, err := utils.GenerateCert(tempdir, "node2", "localhost")
+			key2, crt2, err := utils.GenerateCert("node2", "localhost")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -514,7 +460,7 @@ func TestTCPSSLServerAuthFailBadKey(t *testing.T) {
 					},
 				},
 			}
-			m, err := mesh.NewCLIMeshFromYaml(data, baseDir)
+			m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
 	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
 	"github.com/project-receptor/receptor/tests/functional/lib/utils"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -32,24 +31,15 @@ func TestWork(t *testing.T) {
 		}
 		expectedResults := []byte("1\n2\n3\n4\n5\n")
 		// Setup certs
-		baseDir := filepath.Join(mesh.TestBaseDir, testName)
-		err := os.MkdirAll(baseDir, 0755)
+		caKey, caCrt, err := utils.GenerateCert("ca", "localhost")
 		if err != nil {
 			t.Fatal(err)
 		}
-		tempdir, err := ioutil.TempDir(baseDir, "certs-")
+		key1, crt1, err := utils.GenerateCertWithCA("node1", caKey, caCrt, "node1")
 		if err != nil {
 			t.Fatal(err)
 		}
-		caKey, caCrt, err := utils.GenerateCert(tempdir, "ca", "localhost")
-		if err != nil {
-			t.Fatal(err)
-		}
-		key1, crt1, err := utils.GenerateCertWithCA(tempdir, "node1", caKey, caCrt, "node1")
-		if err != nil {
-			t.Fatal(err)
-		}
-		key2, crt2, err := utils.GenerateCertWithCA(tempdir, "node2", caKey, caCrt, "node2")
+		key2, crt2, err := utils.GenerateCertWithCA("node2", caKey, caCrt, "node2")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,7 +110,7 @@ func TestWork(t *testing.T) {
 			},
 		}
 
-		m, err := mesh.NewCLIMeshFromYaml(data, filepath.Join(mesh.TestBaseDir, testName))
+		m, err := mesh.NewCLIMeshFromYaml(data, testName)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This makes it so we always create certs in a `CertBaseDir` and we always mount that in containers so they can reach any certs they need.

Meshes are all made in `TestBaseDir` and when you make a mesh, instead of specifying the whole path to where to build the mesh, you specify the suffix to add to `TestBaseDir` this makes it so all our test data will end up in `/tmp/receptor-testing` for easier discoverability and artifacting.