### PR TITLE
Fixes some flake in TestHopCountLimit

### DIFF
--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -596,7 +596,9 @@ func (s *Netceptor) SubscribeRoutingUpdates() chan map[string]string {
 				}
 				select {
 				case uChan <- msg:
-				default:
+				case <-s.context.Done():
+					close(uChan)
+					return
 				}
 			case <-s.context.Done():
 				close(uChan)


### PR DESCRIPTION
There is a race condition in SubscribeRoutingUpdates where we may miss
the first routing update because the channel is unbuffered and the send
is non-blocking, blocks the send so it is less likely we will miss any
routing updates.
