### PR TITLE
Kubernetes TCP streaming

### DIFF
--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -235,7 +235,7 @@ func setValue(field *reflect.Value, value interface{}) error {
 	valueType := reflect.TypeOf(value)
 
 	// If the value is directly convertible to the field, just set it
-	if valueType.ConvertibleTo(fieldType) {
+	if fieldKind == valueType.Kind() && valueType.ConvertibleTo(fieldType) {
 		field.Set(reflect.ValueOf(value).Convert(fieldType))
 		return nil
 	}
@@ -318,6 +318,13 @@ func setValue(field *reflect.Value, value interface{}) error {
 			return nil
 		}
 	}
+
+	// If the destination is a string, try a last ditch string conversion
+	if fieldKind == reflect.String {
+		field.Set(reflect.ValueOf(fmt.Sprintf("%v", value)))
+		return nil
+	}
+
 	return fmt.Errorf("type error (expected %s)", fieldType)
 }
 

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -244,7 +244,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 
 // RunControlSvc runs the main accept loop of the control service
 func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.Config,
-	unixSocket string, TCPListen string, tcptls *tls.Config, unixSocketPermissions os.FileMode) error {
+	unixSocket string, unixSocketPermissions os.FileMode, TCPListen string, tcptls *tls.Config) error {
 	var uli net.Listener
 	var lock *utils.FLock
 	var err error
@@ -387,7 +387,7 @@ func (cfg CmdlineConfigUnix) Run() error {
 		}
 	}
 	err = MainInstance.RunControlSvc(context.Background(), cfg.Service, tlscfg, cfg.Filename,
-		cfg.TCPListen, tcptls, os.FileMode(cfg.Permissions))
+		os.FileMode(cfg.Permissions), cfg.TCPListen, tcptls)
 	if err != nil {
 		return err
 	}

--- a/pkg/controlsvc/controlsvc_stub.go
+++ b/pkg/controlsvc/controlsvc_stub.go
@@ -39,6 +39,6 @@ func (s *Server) RunControlSession(conn net.Conn) {
 
 // RunControlSvc runs the main accept loop of the control service
 func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.Config,
-	unixSocket string, unixSocketPermissions os.FileMode) error {
+	unixSocket string, unixSocketPermissions os.FileMode, tcpListen string, tcptls *tls.Config) error {
 	return ErrNotImplemented
 }

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -54,7 +54,25 @@ class ReceptorControl:
             elif m[2] and m[3]:
                 host = m[2]
                 port = m[3]
-                print(f"TCP socket, host {host} port {port}")
+                self.socket = None
+                addrs = socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM, 0, socket.AI_PASSIVE)
+                for addr in addrs:
+                    family, type, proto, canonname, sockaddr = addr
+                    try:
+                        self.socket = socket.socket(family, type, proto)
+                    except OSError:
+                        self.socket = None
+                        continue
+                    try:
+                        self.socket.connect(sockaddr)
+                    except OSError:
+                        self.socket.close()
+                        self.socket = None
+                        continue
+                    self.sockfile = self.socket.makefile('rwb')
+                    break
+                if self.socket is None:
+                    raise ValueError(f"Could not connect to host {host} port {port}")
                 self.handshake()
                 return
         raise ValueError(f"Invalid socket address {address}")

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -485,7 +485,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 		node.controlSocket = filepath.Join(tempdir, "controlsock")
 
 		node.controlServer = controlsvc.New(true, node.NetceptorInstance)
-		err = node.controlServer.RunControlSvc(ctx, "control", nil, node.controlSocket, os.FileMode(0600))
+		err = node.controlServer.RunControlSvc(ctx, "control", nil, node.controlSocket, os.FileMode(0600), "", nil)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR adds a configurable ability to stream to/from a worker pod using cluster-local TCP instead of the SPDY streaming built into Kubernetes, which is a bit janky and slow.  To use this, run a Receptor container within Kubernetes, configure its service account to be able to create pods, and give it a configuration like:

```
- work-kubernetes:
    worktype: tcpcat
    image: alpine/socat
    command: sh -c "nc $RECEPTOR_HOST $RECEPTOR_PORT -e awk '{system(\"echo \"$1\"; sleep 0.5\")}'"
    authmethod: incluster
    streammethod: tcp
    namespace: test
```

Receptor creates the worker pod and sets the RECEPTOR_HOST and RECEPTOR_PORT environment variables.  The pod is then expected to make a TCP connection back to this host and port, and then receive its stdin and produce its stdout from/to the TCP stream socket.

This PR also includes several improvements that were necessary for writing or testing this feature:
* Change the order of operations in the Kubernetes logger streaming method to avoid a case where the log fails to open
* Add the ability for a control socket to listen directly on a TCP port
* Add the ability for receptorctl to connect to a control socket via TCP (which I apparently just forgot to write earlier)
* When someone gives an integer value for a string field in a YAML config, do the right thing instead of passing a weird string representation of the binary value of the integer (in case you do `tcplisten: 12345`)
* Move the `monitorLocalStatus()` function from the command work unit to the base work unit, so the Kubernetes worker can use it