### PR TITLE
Allow tls-server to verify that client node id matches certificate CN

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -63,8 +63,8 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		tlscfg = generateServerTLSConfig()
 	} else {
 		tlscfg = tlscfg.Clone()
+		tlscfg.NextProtos = []string{"netceptor"}
 		if tlscfg.GetConfigForClient != nil {
-			tlscfg.NextProtos = []string{"netceptor"}
 			tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
 				tlscfg.VerifyPeerCertificate = getClientValidator(hi, tlscfg.ClientCAs)
 				return tlscfg, nil

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -80,6 +80,8 @@ func (cfg TLSServerCfg) Prepare() error {
 	}
 
 	if cfg.VerifyClientNodeID {
+		// make GetConfigForClient non-nil for now, and later fill in the callback
+		// after cloning the tls
 		tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
 			return nil, nil
 		}

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"github.com/project-receptor/receptor/pkg/cmdline"
 	"io/ioutil"
-	"strings"
 )
 
 // **************************************************************************
@@ -28,18 +27,6 @@ type TLSServerCfg struct {
 	RequireClientCert  bool   `description:"Require client certificates" default:"false"`
 	VerifyClientNodeID bool   `description:"Verify certificate CA matches client node id" default:"true"`
 	ClientCAs          string `description:"Filename of CA bundle to verify client certs with"`
-}
-
-func getClientValidator(helloInfo *tls.ClientHelloInfo, clientCAs *x509.CertPool) func([][]byte, [][]*x509.Certificate) error {
-	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
-		opts := x509.VerifyOptions{
-			Roots:     clientCAs,
-			KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
-			DNSName:   strings.Split(helloInfo.Conn.RemoteAddr().String(), ":")[0],
-		}
-		_, err := verifiedChains[0][0].Verify(opts)
-		return err
-	}
 }
 
 // Prepare creates the tls.config and stores it in the global map

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -78,18 +78,13 @@ func (cfg TLSServerCfg) Prepare() error {
 	} else {
 		tlscfg.ClientAuth = tls.NoClientCert
 	}
-	var serverConf *tls.Config
+
 	if cfg.VerifyClientNodeID {
-		tlscfg.NextProtos = []string{"netceptor"}
-		serverConf = &tls.Config{}
-		serverConf.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
-			tlscfg.VerifyPeerCertificate = getClientValidator(hi, tlscfg.ClientCAs)
-			return tlscfg, nil
+		tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
+			return nil, nil
 		}
-	} else {
-		serverConf = tlscfg
 	}
-	return MainInstance.SetServerTLSConfig(cfg.Name, serverConf)
+	return MainInstance.SetServerTLSConfig(cfg.Name, tlscfg)
 }
 
 // TLSClientCfg stores the configuration options for a TLS client
@@ -136,7 +131,6 @@ func (cfg TLSClientCfg) Prepare() error {
 	}
 
 	tlscfg.InsecureSkipVerify = cfg.InsecureSkipVerify
-	tlscfg.NextProtos = []string{"netceptor"}
 	return MainInstance.SetClientTLSConfig(cfg.Name, tlscfg)
 }
 

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -79,10 +79,9 @@ func (cfg TLSServerCfg) Prepare() error {
 		tlscfg.ClientAuth = tls.NoClientCert
 	}
 
-	tlscfg.NextProtos = []string{"netceptor"}
-
 	serverConf := tlscfg
 	if cfg.VerifyClientNodeID {
+		tlscfg.NextProtos = []string{"netceptor"}
 		serverConf = &tls.Config{}
 		serverConf.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
 			tlscfg.VerifyPeerCertificate = getClientValidator(hi, tlscfg.ClientCAs)

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -78,8 +78,7 @@ func (cfg TLSServerCfg) Prepare() error {
 	} else {
 		tlscfg.ClientAuth = tls.NoClientCert
 	}
-
-	serverConf := tlscfg
+	var serverConf *tls.Config
 	if cfg.VerifyClientNodeID {
 		tlscfg.NextProtos = []string{"netceptor"}
 		serverConf = &tls.Config{}
@@ -87,6 +86,8 @@ func (cfg TLSServerCfg) Prepare() error {
 			tlscfg.VerifyPeerCertificate = getClientValidator(hi, tlscfg.ClientCAs)
 			return tlscfg, nil
 		}
+	} else {
+		serverConf = tlscfg
 	}
 	return MainInstance.SetServerTLSConfig(cfg.Name, serverConf)
 }

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -92,7 +92,7 @@ func TestSSLListeners(t *testing.T) {
 			receptorStdOut := bytes.Buffer{}
 			port := utils.ReserveTCPPort()
 			defer utils.FreeTCPPort(port)
-			cmd := exec.Command("receptor", "--node", "id=test", "--tls-server", "name=server-tls", fmt.Sprintf("cert=%s", crt), fmt.Sprintf("key=%s", key), listener, fmt.Sprintf("port=%d", port), "tls=server-tls")
+			cmd := exec.Command("receptor", "--node", "id=test", "--tls-server", "name=server-tls", "verifyclientnodeid=false", fmt.Sprintf("cert=%s", crt), fmt.Sprintf("key=%s", key), listener, fmt.Sprintf("port=%d", port), "tls=server-tls")
 			cmd.Stdout = &receptorStdOut
 			err = cmd.Start()
 			if err != nil {

--- a/tests/functional/mesh/tls_test.go
+++ b/tests/functional/mesh/tls_test.go
@@ -71,9 +71,10 @@ func TestTCPSSLConnections(t *testing.T) {
 				Nodedef: []interface{}{
 					map[interface{}]interface{}{
 						"tls-server": map[interface{}]interface{}{
-							"name": "server-cert2",
-							"key":  key2,
-							"cert": crt2,
+							"name":               "server-cert2",
+							"key":                key2,
+							"cert":               crt2,
+							"verifyclientnodeid": false,
 						},
 					},
 					map[interface{}]interface{}{

--- a/tests/functional/mesh/tls_test.go
+++ b/tests/functional/mesh/tls_test.go
@@ -46,11 +46,12 @@ func TestTCPSSLConnections(t *testing.T) {
 				Nodedef: []interface{}{
 					map[interface{}]interface{}{
 						"tls-server": map[interface{}]interface{}{
-							"name":              "cert1",
-							"key":               key1,
-							"cert":              crt1,
-							"requireclientcert": true,
-							"clientcas":         caCrt,
+							"name":               "cert1",
+							"key":                key1,
+							"cert":               crt1,
+							"requireclientcert":  true,
+							"verifyclientnodeid": false,
+							"clientcas":          caCrt,
 						},
 					},
 					map[interface{}]interface{}{
@@ -176,11 +177,12 @@ func TestTCPSSLClientAuthFailNoKey(t *testing.T) {
 				Nodedef: []interface{}{
 					map[interface{}]interface{}{
 						"tls-server": map[interface{}]interface{}{
-							"name":              "cert1",
-							"key":               key1,
-							"cert":              crt1,
-							"requireclientcert": true,
-							"clientcas":         caCrt,
+							"name":               "cert1",
+							"key":                key1,
+							"cert":               crt1,
+							"requireclientcert":  true,
+							"verifyclientnodeid": false,
+							"clientcas":          caCrt,
 						},
 					},
 					map[interface{}]interface{}{
@@ -265,11 +267,12 @@ func TestTCPSSLClientAuthFailBadKey(t *testing.T) {
 				Nodedef: []interface{}{
 					map[interface{}]interface{}{
 						"tls-server": map[interface{}]interface{}{
-							"name":              "cert1",
-							"key":               key1,
-							"cert":              crt1,
-							"requireclientcert": true,
-							"clientcas":         caCrt,
+							"name":               "cert1",
+							"key":                key1,
+							"cert":               crt1,
+							"requireclientcert":  true,
+							"verifyclientnodeid": false,
+							"clientcas":          caCrt,
 						},
 					},
 					map[interface{}]interface{}{

--- a/tests/functional/mesh/tls_test.go
+++ b/tests/functional/mesh/tls_test.go
@@ -431,9 +431,10 @@ func TestTCPSSLServerAuthFailBadKey(t *testing.T) {
 				Nodedef: []interface{}{
 					map[interface{}]interface{}{
 						"tls-server": map[interface{}]interface{}{
-							"name": "cert1",
-							"key":  key1,
-							"cert": crt1,
+							"name":               "cert1",
+							"key":                key1,
+							"cert":               crt1,
+							"verifyclientnodeid": false,
 						},
 					},
 					map[interface{}]interface{}{

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -212,8 +212,7 @@ func TestWork(t *testing.T) {
 	})
 
 	t.Run("work submit with incorrect tlsclient CN", func(t *testing.T) {
-		// tests that submitting work with tlsclient wrong CN information
-		// immediately fails the job
+		// tests that submitting work with wrong cert CN immediately fails the job
 		// also tests that releasing a job that has not been started on remote
 		// will not attempt to connect to remote
 		t.Parallel()

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -43,6 +43,10 @@ func TestWork(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		key3, crt3, err := utils.GenerateCertWithCA("node1wrongCN", caKey, caCrt, "node1wrongCN")
+		if err != nil {
+			t.Fatal(err)
+		}
 		// Generate a mesh with 3 nodes
 		data.Nodes["node2"] = &mesh.YamlNode{
 			Connections: map[string]mesh.YamlConnection{},
@@ -58,11 +62,12 @@ func TestWork(t *testing.T) {
 				},
 				map[interface{}]interface{}{
 					"tls-server": map[interface{}]interface{}{
-						"name":              "control_tls",
-						"cert":              crt2,
-						"key":               key2,
-						"requireclientcert": true,
-						"clientcas":         caCrt,
+						"name":               "control_tls",
+						"cert":               crt2,
+						"key":                key2,
+						"requireclientcert":  true,
+						"verifyclientnodeid": true,
+						"clientcas":          caCrt,
 					},
 				},
 				map[interface{}]interface{}{
@@ -90,6 +95,15 @@ func TestWork(t *testing.T) {
 						"insecureskipverify": false,
 						"cert":               crt1,
 						"key":                key1,
+					},
+				},
+				map[interface{}]interface{}{
+					"tls-client": map[interface{}]interface{}{
+						"name":               "tlsclientwrongCN",
+						"rootcas":            caCrt,
+						"insecureskipverify": false,
+						"cert":               crt3,
+						"key":                key3,
 					},
 				},
 			},
@@ -197,8 +211,8 @@ func TestWork(t *testing.T) {
 		}
 	})
 
-	t.Run("work submit with incorrect tlsclient", func(t *testing.T) {
-		// tests that submitting work with incorrect tlsclient information
+	t.Run("work submit with incorrect tlsclient CN", func(t *testing.T) {
+		// tests that submitting work with tlsclient wrong CN information
 		// immediately fails the job
 		// also tests that releasing a job that has not been started on remote
 		// will not attempt to connect to remote
@@ -207,27 +221,27 @@ func TestWork(t *testing.T) {
 		defer tearDown(controllers, m)
 		nodes := m.Nodes()
 
-		command := `{"command":"work","subcommand":"submit","worktype":"echosleepshort","tlsclient":"","node":"node2","params":""}`
-		unitID, err := controllers["node3"].WorkSubmitJSON(command)
+		command := `{"command":"work","subcommand":"submit","worktype":"echosleepshort","tlsclient":"tlsclientwrongCN","node":"node2","params":""}`
+		unitID, err := controllers["node1"].WorkSubmitJSON(command)
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
-		err = controllers["node3"].AssertWorkFailed(ctx, unitID)
+		err = controllers["node1"].AssertWorkFailed(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		_, err = controllers["node3"].WorkRelease(unitID)
+		_, err = controllers["node1"].WorkRelease(unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ = context.WithTimeout(context.Background(), 10*time.Second)
-		err = controllers["node3"].AssertWorkReleased(ctx, unitID)
+		err = controllers["node1"].AssertWorkReleased(ctx, unitID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		ctx, _ = context.WithTimeout(context.Background(), 20*time.Second)
-		err = assertFilesReleased(ctx, nodes["node3"].Dir(), "node3", unitID)
+		err = assertFilesReleased(ctx, nodes["node1"].Dir(), "node1", unitID)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
related #185 

adds the following option to `--tls-server`,
`verifyclientnodeid=<bool>: Verify certificate CA matches client node id (default: true)`

If true, the server will check that the connecting client node id matches the Common Name in the client certificate.

It does this through the `tls.Config` callback, `VerifyPeerCertificate`. This callback will be called after the regular tls verification takes place.

In order to know which client is connecting, we must use yet another callback called `GetConfigForClient` which is called during the handshake. This callback sends in `net.Conn` information, where we can extract the connecting `RemoteAddr`.

I've updated two tests in `TestWork` which ensures the verification works when a correct tls client cert is provided, and that a failure occurs when providing a tls client cert with the wrong CN.