### PR TITLE
Fix race condition when send happens after close

### DIFF
--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -1030,8 +1030,8 @@ func (s *Netceptor) handleMessageData(md *messageData) error {
 		}
 		s.listenerLock.RLock()
 		pc, ok := s.listenerRegistry[md.ToService]
-		s.listenerLock.RUnlock()
-		if !ok {
+		if !ok || pc.context.Err() != nil {
+			s.listenerLock.RUnlock()
 			if md.FromNode == s.nodeID {
 				return fmt.Errorf(ProblemServiceUnknown)
 			}
@@ -1045,6 +1045,7 @@ func (s *Netceptor) handleMessageData(md *messageData) error {
 			return nil
 		}
 		pc.recvChan <- md
+		s.listenerLock.RUnlock()
 		return nil
 	}
 	return s.forwardMessage(md)

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -182,10 +182,10 @@ func (pc *PacketConn) Close() error {
 	pc.s.listenerLock.Lock()
 	defer pc.s.listenerLock.Unlock()
 	delete(pc.s.listenerRegistry, pc.localService)
-	close(pc.recvChan)
 	if pc.cancel != nil {
 		pc.cancel()
 	}
+	close(pc.recvChan)
 	if pc.advertise {
 		err := pc.s.removeLocalServiceAdvertisement(pc.localService)
 		if err != nil {


### PR DESCRIPTION
This PR fixes a potential race condition that I think may be the cause of https://github.com/project-receptor/receptor/issues/207.  In `handleMessageData`, the `listenerLock` read lock is released immediately on obtaining the result from the lookup.  This means that potentially, `packetconn.Close()` could be called after we look up the listener, but before we send to `pc.recvChan`.

The fix is to hold the lock while also checking whether the packetconn's context is still good, and if it is, continue holding the lock through the channel send.  Any call to `Close()` will be blocked (because it requests a write lock on `listenerLock`) until the channel send completes.

In the case that the connection is still in the listener table but the context is cancelled, we send an unreachable message.  This is future-proofing - in the current code, it is not possible for this to happen because `packetconn.Close()` requests the lock before cancelling the context.  Checking the context here protects against the case where a future code change unwittingly decides to cancel the context in some other circumstance, like an error handler.