### PR TITLE
Add --no-payload and pass-through command arguments

### DIFF
--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -108,11 +108,12 @@ class ReceptorControl:
             "worktype": worktype,
             "tlsclient": tlsclient,
         }
-        for k,v in params.items():
-            if k not in commandMap:
-                commandMap[k] = v
-            else:
-                raise RuntimeError(f"duplicate or illegal parameter {k}")
+        if params:
+            for k,v in params.items():
+                if k not in commandMap:
+                    commandMap[k] = v
+                else:
+                    raise RuntimeError(f"Duplicate or illegal parameter {k}")
         commandJson = json.dumps(commandMap)
         command = f"{commandJson}\n"
         self.writestr(command)


### PR DESCRIPTION
This addresses https://github.com/project-receptor/receptor/issues/210 by allowing a more natural syntax for additional run-time parameters to a work command.  Previously, you could do this with `receptorctl work submit echo ---param params="thing to echo"`, but this is awkward.  This PR allows you to do `receptorctl work submit echo thing to echo`, similar to the non-JSON command to the control service.

It is confusing that we have both Receptor-level "parameters" that go in the top of the `work submit` JSON command, and also "parameters" sent to a `work-command` when `allowruntimeparams=true` that go into the `params` key of the JSON command.  Perhaps we should choose different vocabulary terms and use them consistently.

This PR also adds a `--no-payload` option.  People have been trying to accomplish this with `--payload-literal=""` which doesn't work, so clearly there's a need for it.