### PR TITLE
Add --ttl (time to live) option to remote work submission commands

### DIFF
--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -173,6 +173,10 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if err != nil {
 			tlsclient = "" // optional so don't return
 		}
+		ttl, err := strFromMap(c.params, "ttl")
+		if err != nil {
+			ttl = ""
+		}
 		workParams := make(map[string]string)
 		for k, v := range c.params {
 			if k == "command" || k == "subcommand" || k == "node" || k == "worktype" || k == "tlsclient" {
@@ -188,7 +192,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if workNode == nc.NodeID() || strings.EqualFold(workNode, "localhost") {
 			worker, err = c.w.AllocateUnit(workType, workParams)
 		} else {
-			worker, err = c.w.AllocateRemoteUnit(workNode, workType, tlsclient, workParams)
+			worker, err = c.w.AllocateRemoteUnit(workNode, workType, tlsclient, ttl, workParams)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -179,7 +179,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		}
 		workParams := make(map[string]string)
 		for k, v := range c.params {
-			if k == "command" || k == "subcommand" || k == "node" || k == "worktype" || k == "tlsclient" {
+			if k == "command" || k == "subcommand" || k == "node" || k == "worktype" || k == "tlsclient" || k == "ttl" {
 				continue
 			}
 			vStr, ok := v.(string)
@@ -190,6 +190,9 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		}
 		var worker WorkUnit
 		if workNode == nc.NodeID() || strings.EqualFold(workNode, "localhost") {
+			if ttl != "" {
+				return nil, fmt.Errorf("ttl option is intended for remote work only")
+			}
 			worker, err = c.w.AllocateUnit(workType, workParams)
 		} else {
 			worker, err = c.w.AllocateRemoteUnit(workNode, workType, tlsclient, ttl, workParams)

--- a/pkg/workceptor/workceptor_stub.go
+++ b/pkg/workceptor/workceptor_stub.go
@@ -42,7 +42,7 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params string) (WorkUnit,
 }
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
-func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, tlsclient string, params string) (WorkUnit, error) {
+func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, tlsclient string, ttl string, params string) (WorkUnit, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -202,11 +202,12 @@ def list(ctx, quiet):
 @click.option('--payload-literal', '-l', type=str, help="Use the command line string as the literal unit of work data.")
 @click.option('--no-payload', '-n', is_flag=True, help="Send an empty payload.")
 @click.option('--tlsclient', type=str, default="", help="TLS client used when submitting work to a remote node")
+@click.option('--ttl', type=str, default="", help="Time to live until remote work must start, e.g. 1h20m30s or 30m10s")
 @click.option('--follow', '-f', help="Remain attached to the job and print its results to stdout", is_flag=True)
 @click.option('--rm', help="Release unit after completion", is_flag=True)
 @click.option('--param', '-a', help="Additional Receptor parameter (key=value format)", multiple=True)
 @click.argument('cmdparams', type=str, required=False, nargs=-1)
-def submit(ctx, worktype, node, payload, no_payload, payload_literal, tlsclient, follow, rm, param, cmdparams):
+def submit(ctx, worktype, node, payload, no_payload, payload_literal, tlsclient, ttl, follow, rm, param, cmdparams):
     pcmds = 0
     if payload:
         pcmds += 1
@@ -243,7 +244,7 @@ def submit(ctx, worktype, node, payload, no_payload, payload_literal, tlsclient,
         if node == "":
             node = None
         rc = get_rc(ctx)
-        work = rc.submit_work(node, worktype, payload_data, tlsclient, params)
+        work = rc.submit_work(node, worktype, payload_data, tlsclient, ttl, params)
         result = work.pop('result')
         unitid = work.pop('unitid')
         if follow:

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -98,7 +98,7 @@ class ReceptorControl:
         if not str.startswith(text, "Connecting"):
             raise RuntimeError(text)
 
-    def submit_work(self, node, worktype, payload, tlsclient, params):
+    def submit_work(self, node, worktype, payload, tlsclient, ttl, params):
         if node is None:
             node = "localhost"
         commandMap = {
@@ -107,6 +107,7 @@ class ReceptorControl:
             "node": node,
             "worktype": worktype,
             "tlsclient": tlsclient,
+            "ttl": ttl,
         }
         if params:
             for k,v in params.items():


### PR DESCRIPTION
related #22 

**What is added**
Adds `--ttl` to `receptorctl` and our JSON work submission, e.g.

`receptorctl --socket /tmp/foo.sock work submit 100cat --node bar --tlsclient client --ttl 3s --payload -`

If the remote work does not start before this time, the work unit is terminated and marked with a Failed status.

**--ttl format**
`--ttl` is a string and is flexible, described here https://golang.org/pkg/time/#ParseDuration

e.g. `10h30m10s`, `0.5h` are valid

**Internal representation**
Receptor converts this duration into an `Expiration time.Time` field on our RemoteExtraData structure

Here is what the new status looks like

```
'Y0NSwpjQ': {'Detail': 'Running: PID 228982',
              'ExtraData': {'Expiration': '2020-10-07T16:42:38.018557837-04:00',
                            'LocalCancelled': False,
                            'LocalReleased': False,
                            'RemoteNode': 'bar',
                            'RemoteParams': {'ttl': '3s'},
                            'RemoteStarted': True,
                            'RemoteUnitID': 'IgIKO6od',
                            'RemoteWorkType': '100cat',
                            'TLSClient': 'client'},
              'State': 1,
              'StateName': 'Running',
              'StdoutSize': 12,
              'WorkType': 'remote'}}
```

Here is the error message that hits if the work unit times out

`{'3weUcmLn': {'Detail': 'Work unit expired on Wed Oct 7 16:43:13',`

**Additional Notes**
The "nil" `time.Time` is Zero time, so work units without a user-provided TTL look like this

```
{'dO0iAgiv': {'Detail': 'Starting Worker',
              'ExtraData': {'Expiration': '0001-01-01T00:00:00Z',
```

Not very pretty unfortunately, but maybe not a big deal. An alternative is to just store the expiration as a string (if ttl not set, "") and do conversions to `time.Time` wherever needed.