### PR TITLE
Return error if GetConfigForClient not re-configured

### DIFF
--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -70,7 +70,7 @@ func (cfg TLSServerCfg) Prepare() error {
 		// make GetConfigForClient non-nil for now, and later fill in the callback
 		// after cloning the tls
 		tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
-			return nil, nil
+			return nil, fmt.Errorf("GetConfigForClient callback not properly configured")
 		}
 	}
 	return MainInstance.SetServerTLSConfig(cfg.Name, tlscfg)


### PR DESCRIPTION
If `VerifyClientNodeID` is set to `True`, we set up a dummy config with a `GetConfigForClient` callback defined. The expectation is that this callback will be filled in later after we call `tls.Clone()` in `conn.go`.

However, receptor now supports TLS server configurations in other places, like the control service via TCP, which does not execute the callback reconfiguration.

For safety, we should initially set the callback to return an error. That way if it's ever used before we reconfigure the callback, the handshake will fail.

https://golang.org/pkg/crypto/tls/#Config
> If the returned Config is nil, the original Config will be used.

that would be bad, as the original config in this case is a dummy config