### PR TITLE
k8s work units can restart

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -750,7 +750,7 @@ type WorkKubeCfg struct {
 	AllowRuntimeTLS     bool   `description:"Allow passing TLS parameters at runtime" default:"false"`
 	AllowRuntimeCommand bool   `description:"Allow specifying image & command at runtime" default:"false"`
 	AllowRuntimeParams  bool   `description:"Allow adding command parameters at runtime" default:"false"`
-	DeletePodOnRestart  bool   `description:"On restart, delete any pods that are in pending state" default:"true"`
+	DeletePodOnRestart  bool   `description:"On restart, delete the pod if in pending state" default:"true"`
 	StreamMethod        string `description:"Method for connecting to worker pods: logger or tcp" default:"logger"`
 }
 

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -648,8 +648,8 @@ func (kw *kubeUnit) UnredactedStatus() *StatusFileData {
 	return status
 }
 
-// Start launches a job with given parameters.
-func (kw *kubeUnit) StartOrRestart() error {
+// startOrRestart is a shared implementation of Start() and Restart()
+func (kw *kubeUnit) startOrRestart() error {
 	kw.ctx, kw.cancel = context.WithCancel(kw.w.ctx)
 	// Connect to the Kubernetes API
 	err := kw.connectToKube()
@@ -676,7 +676,7 @@ func (kw *kubeUnit) Restart() error {
 	}
 	isTCP := kw.streamMethod == "tcp"
 	if status.State == WorkStateRunning && !isTCP {
-		return kw.StartOrRestart()
+		return kw.startOrRestart()
 	}
 	// Work unit is in Pending state
 	if kw.deletePodOnRestart {
@@ -696,9 +696,10 @@ func (kw *kubeUnit) Restart() error {
 	return fmt.Errorf("work unit is not in running state, cannot be restarted")
 }
 
+// Start launches a job with given parameters.
 func (kw *kubeUnit) Start() error {
 	kw.UpdateBasicStatus(WorkStatePending, "Connecting to Kubernetes", 0)
-	return kw.StartOrRestart()
+	return kw.startOrRestart()
 }
 
 // Cancel releases resources associated with a job, including cancelling it if running.

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -705,12 +705,10 @@ func (kw *kubeUnit) Start() error {
 // Cancel releases resources associated with a job, including cancelling it if running.
 func (kw *kubeUnit) Cancel() error {
 	if kw.pod != nil {
-		go func(pod string) {
-			err := kw.clientset.CoreV1().Pods(kw.status.ExtraData.(*kubeExtraData).KubeNamespace).Delete(context.Background(), pod, metav1.DeleteOptions{})
-			if err != nil {
-				logger.Error("Error deleting pod %s: %s", pod, err)
-			}
-		}(kw.pod.Name)
+		err := kw.clientset.CoreV1().Pods(kw.status.ExtraData.(*kubeExtraData).KubeNamespace).Delete(context.Background(), kw.pod.Name, metav1.DeleteOptions{})
+		if err != nil {
+			logger.Error("Error deleting pod %s: %s", kw.pod.Name, err)
+		}
 	}
 	if kw.cancel != nil {
 		kw.cancel()

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -679,13 +679,12 @@ func (kw *kubeUnit) Restart() error {
 		return kw.StartOrRestart()
 	} else if status.State == WorkStatePending {
 		if kw.deletePodOnRestart {
-			logger.Debug("Attempting to delete pod %s", ked.PodName)
 			err := kw.clientset.CoreV1().Pods(ked.KubeNamespace).Delete(context.Background(), ked.PodName, metav1.DeleteOptions{})
 			if err != nil {
 				logger.Error("Pod %s could not be deleted: %s", ked.PodName, err.Error())
 			}
 		}
-		return fmt.Errorf("Pod %s is not in running state, cannot be restarted", ked.PodName)
+		return fmt.Errorf("work unit is not in running state, cannot be restarted")
 	}
 	return nil
 }

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -188,7 +188,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 	ked := status.ExtraData.(*kubeExtraData)
 	var err error
 	var errMsg string
-	if status.State != WorkStateRunning {
+	if ked.PodName == "" {
 		// Create the pod
 		err := kw.createPod(nil)
 		if err == ErrPodCompleted {
@@ -276,7 +276,10 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 	// update from WorkStatePending to WorkStateRunning.
 	finishedChan := make(chan struct{})
 	if !skipStdin {
-		kw.UpdateBasicStatus(WorkStatePending, "Sending stdin to pod", 0)
+		kw.UpdateFullStatus(func(status *StatusFileData) {
+			status.State = WorkStatePending
+			status.Detail = "Sending stdin to pod"
+		})
 		go func() {
 			select {
 			case <-finishedChan:

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -27,7 +27,7 @@ type stdoutWriter struct {
 
 // newStdoutWriter allocates a new stdoutWriter, which writes to both the stdout and status files
 func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
-	writer, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0600)
+	writer, err := os.OpenFile(path.Join(unitdir, "stdout"), (os.O_APPEND|os.O_CREATE)+os.O_WRONLY+os.O_SYNC, 0600)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
related #86 

kubeunits can restart if both conditions are met

1. Work unit is in running state
2. `streammethod` is `logger`

If those fail, we have an option to delete the pod that is associated with the kubeunit,

`deletepodonrestart=<bool>: On restart, delete the pod if in pending state (default: true)`

streammethod `tcp` is complicated because we would need the pod to reconnect back to the tcp server after the receptor restart, so this PR does not address that.