### PR TITLE
Improvements to receptorctl.socket_interface.submit_work interface

### DIFF
--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -98,17 +98,23 @@ class ReceptorControl:
         if not str.startswith(text, "Connecting"):
             raise RuntimeError(text)
 
-    def submit_work(self, node, worktype, payload, tlsclient, ttl, params):
+    def submit_work(self, worktype, payload, node=None, tlsclient=None, ttl=None, params=None):
         if node is None:
             node = "localhost"
+
         commandMap = {
             "command": "work",
             "subcommand": "submit",
             "node": node,
             "worktype": worktype,
-            "tlsclient": tlsclient,
-            "ttl": ttl,
         }
+
+        if tlsclient:
+            commandMap['tlsclient'] = tlsclient
+
+        if ttl:
+            commandMap['ttl'] = ttl
+
         if params:
             for k,v in params.items():
                 if k not in commandMap:


### PR DESCRIPTION
Usage before:

```
receptor_ctl.submit_work('localhost',
                         'worker',
                         sockout.makefile('rb'), '', '', {})
```

After:

```
receptor_ctl.submit_work(worktype='worker',
                         payload=sockout.makefile('rb'))
```

Note: `worktype` and `payload` are *required* keyword arguments, with no defaults. All other arguments are optional keyword arguments.