### PR TITLE
trim spaces in allowedpeers list

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -56,6 +56,9 @@ func (cfg nodeCfg) Init() error {
 	var allowedPeers []string
 	if cfg.AllowedPeers != "" {
 		allowedPeers = strings.Split(cfg.AllowedPeers, ",")
+		for i := range allowedPeers {
+			allowedPeers[i] = strings.TrimSpace(allowedPeers[i])
+		}
 	}
 	netceptor.MainInstance = netceptor.New(context.Background(), cfg.ID, allowedPeers)
 	workceptor.MainInstance, err = workceptor.New(context.Background(), netceptor.MainInstance, cfg.DataDir)


### PR DESCRIPTION
this keeps tripping me up.

`allowedpeers: bar, foo` will be recognized as `bar` and `foo` as expected (no spaces)