### PR TITLE
Add tls support to receptorctl

### DIFF
--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -7,7 +7,7 @@ LABEL vendor="project-receptor"
 LABEL version="${VERSION}"
 
 RUN dnf -y update && \
-    dnf -y install dumb-init python3-click python3-dateutil python3-pip && \
+    dnf -y install dumb-init python3-click python3-pyyaml python3-dateutil python3-pip && \
     dnf clean all
 
 COPY receptorctl-${VERSION}-py3-none-any.whl /tmp

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -7,7 +7,7 @@ LABEL vendor="project-receptor"
 LABEL version="${VERSION}"
 
 RUN dnf -y update && \
-    dnf -y install dumb-init python3-click python3-pyyaml python3-dateutil python3-pip && \
+    dnf -y install dumb-init python3-click python3-dateutil python3-pip && \
     dnf clean all
 
 COPY receptorctl-${VERSION}-py3-none-any.whl /tmp

--- a/packaging/rpm/receptorctl.spec.j2
+++ b/packaging/rpm/receptorctl.spec.j2
@@ -20,6 +20,7 @@ BuildRequires: python36-setuptools
 Requires: python36
 Requires: python36-setuptools
 Requires: python36-dateutil
+Requires: python36-pyyaml
 %else
 BuildRequires: python3
 BuildRequires: python3-setuptools

--- a/packaging/rpm/receptorctl.spec.j2
+++ b/packaging/rpm/receptorctl.spec.j2
@@ -27,6 +27,7 @@ Requires: python3
 Requires: python3-setuptools
 Requires: python3-dateutil
 Requires: python3-click
+Requires: python3-pyyaml
 %endif
 
 %description

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -31,17 +31,23 @@ class IgnoreRequiredWithHelp(click.Group):
 @click.pass_context
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")
-@click.option('--rootcas', default="", envvar='RECEPTORCTL_ROOTCAS', required=False, show_envvar=True,
-              help="Root CA bundle to use instead of system trust when connecting with tls")
-def cli(ctx, socket, rootcas):
+# @click.option('--rootcas', default="", envvar='RECEPTORCTL_ROOTCAS', required=False, show_envvar=True,
+#               help="Root CA bundle to use instead of system trust when connecting with tls")
+@click.option('--tlsclient', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
+              help="TLS client name specified in yaml")
+@click.option('--yaml', default=None, envvar='RECEPTORCTL_YAML', required=False, show_envvar=True,
+              help="Yaml file name configured for receptor")
+def cli(ctx, socket, yaml, tlsclient):
     ctx.obj = dict()
     ctx.obj['socket'] = socket
-    ctx.obj['rootcas'] = rootcas
-
+    # ctx.obj['rootcas'] = rootcas
+    ctx.obj['yaml'] = yaml
+    ctx.obj['tlsclient'] = tlsclient
 
 def get_rc(ctx):
     rc = ReceptorControl()
-    rc.connect(ctx.obj['socket'], ctx.obj['rootcas'])
+    rc.readyaml(ctx.obj['yaml'], ctx.obj['tlsclient'])
+    rc.connect(ctx.obj['socket'])
     return rc
 
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -31,18 +31,18 @@ class IgnoreRequiredWithHelp(click.Group):
 @click.pass_context
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")
-@click.option('--yaml', default=None, envvar='RECEPTORCTL_YAML', required=False, show_envvar=True,
-              help="Yaml filename configured for receptor")
-@click.option('--tlsclient', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
-              help="TLS client name specified in yaml")
+@click.option('--config', default=None, envvar='RECEPTORCTL_CONFIG', required=False, show_envvar=True,
+              help="Config filename configured for receptor")
+@click.option('--tls-client', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
+              help="TLS client name specified in config")
 @click.option('--rootcas', default=None, help="Root CA bundle to use instead of system trust when connecting with tls")
 @click.option('--key', default=None, help="Client private key filename")
 @click.option('--cert', default=None, help="Client certificate filename")
 @click.option('--insecureskipverify', default=False, help="Accept any server cert", show_default=True)
-def cli(ctx, socket, yaml, tlsclient, rootcas, key, cert, insecureskipverify):
+def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
     ctx.obj = dict()
     ctx.obj['socket'] = socket
-    ctx.obj['yaml'] = yaml
+    ctx.obj['config'] = config
     ctx.obj['tlsclient'] = tlsclient
     ctx.obj['rootcas'] = rootcas
     ctx.obj['key'] = key
@@ -51,7 +51,7 @@ def cli(ctx, socket, yaml, tlsclient, rootcas, key, cert, insecureskipverify):
 
 def get_rc(ctx):
     rc = ReceptorControl()
-    rc.readyaml(ctx.obj)
+    rc.readconfig(ctx.obj)
     rc.connect(ctx.obj)
     return rc
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -31,23 +31,32 @@ class IgnoreRequiredWithHelp(click.Group):
 @click.pass_context
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")
-# @click.option('--rootcas', default="", envvar='RECEPTORCTL_ROOTCAS', required=False, show_envvar=True,
-#               help="Root CA bundle to use instead of system trust when connecting with tls")
-@click.option('--tlsclient', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
-              help="TLS client name specified in yaml")
 @click.option('--yaml', default=None, envvar='RECEPTORCTL_YAML', required=False, show_envvar=True,
               help="Yaml file name configured for receptor")
-def cli(ctx, socket, yaml, tlsclient):
+@click.option('--tlsclient', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
+              help="TLS client name specified in yaml")
+@click.option('--rootcas', default=None, envvar='RECEPTORCTL_ROOTCAS', required=False, show_envvar=True,
+              help="Root CA bundle to use instead of system trust when connecting with tls")
+@click.option('--key', default=None, envvar='RECEPTORCTL_KEY', required=False, show_envvar=True,
+              help="")
+@click.option('--cert', default=None, envvar='RECEPTORCTL_CERT', required=False, show_envvar=True,
+              help="")
+@click.option('--insecureskipverify', default=False, envvar='RECEPTORCTL_INSECURESKIPVERIFY', required=False, show_envvar=True,
+              help="")
+def cli(ctx, socket, yaml, tlsclient, rootcas, key, cert, insecureskipverify):
     ctx.obj = dict()
     ctx.obj['socket'] = socket
-    # ctx.obj['rootcas'] = rootcas
     ctx.obj['yaml'] = yaml
     ctx.obj['tlsclient'] = tlsclient
+    ctx.obj['rootcas'] = rootcas
+    ctx.obj['key'] = key
+    ctx.obj['cert'] = cert
+    ctx.obj['insecureskipverify'] = insecureskipverify
 
 def get_rc(ctx):
     rc = ReceptorControl()
-    rc.readyaml(ctx.obj['yaml'], ctx.obj['tlsclient'])
-    rc.connect(ctx.obj['socket'])
+    rc.readyaml(ctx.obj)
+    rc.connect(ctx.obj)
     return rc
 
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -31,14 +31,17 @@ class IgnoreRequiredWithHelp(click.Group):
 @click.pass_context
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")
-def cli(ctx, socket):
+@click.option('--rootcas', default="", envvar='RECEPTORCTL_ROOTCAS', required=False, show_envvar=True,
+              help="Root CA bundle to use instead of system trust when connecting with tls")
+def cli(ctx, socket, rootcas):
     ctx.obj = dict()
     ctx.obj['socket'] = socket
+    ctx.obj['rootcas'] = rootcas
 
 
 def get_rc(ctx):
     rc = ReceptorControl()
-    rc.connect(ctx.obj['socket'])
+    rc.connect(ctx.obj['socket'], ctx.obj['rootcas'])
     return rc
 
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -31,7 +31,7 @@ class IgnoreRequiredWithHelp(click.Group):
 @click.pass_context
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")
-@click.option('--config', default=None, envvar='RECEPTORCTL_CONFIG', required=False, show_envvar=True,
+@click.option('--config', '-c', default=None, envvar='RECEPTORCTL_CONFIG', required=False, show_envvar=True,
               help="Config filename configured for receptor")
 @click.option('--tls-client', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
               help="TLS client name specified in config")
@@ -39,11 +39,11 @@ class IgnoreRequiredWithHelp(click.Group):
 @click.option('--key', default=None, help="Client private key filename")
 @click.option('--cert', default=None, help="Client certificate filename")
 @click.option('--insecureskipverify', default=False, help="Accept any server cert", show_default=True)
-def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
+def cli(ctx, socket, config, tls_client, rootcas, key, cert, insecureskipverify):
     ctx.obj = dict()
     ctx.obj['socket'] = socket
     ctx.obj['config'] = config
-    ctx.obj['tlsclient'] = tlsclient
+    ctx.obj['tls-client'] = tls_client
     ctx.obj['rootcas'] = rootcas
     ctx.obj['key'] = key
     ctx.obj['cert'] = cert

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -32,17 +32,13 @@ class IgnoreRequiredWithHelp(click.Group):
 @click.option('--socket', envvar='RECEPTORCTL_SOCKET', required=True, show_envvar=True,
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")
 @click.option('--yaml', default=None, envvar='RECEPTORCTL_YAML', required=False, show_envvar=True,
-              help="Yaml file name configured for receptor")
+              help="Yaml filename configured for receptor")
 @click.option('--tlsclient', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
               help="TLS client name specified in yaml")
-@click.option('--rootcas', default=None, envvar='RECEPTORCTL_ROOTCAS', required=False, show_envvar=True,
-              help="Root CA bundle to use instead of system trust when connecting with tls")
-@click.option('--key', default=None, envvar='RECEPTORCTL_KEY', required=False, show_envvar=True,
-              help="")
-@click.option('--cert', default=None, envvar='RECEPTORCTL_CERT', required=False, show_envvar=True,
-              help="")
-@click.option('--insecureskipverify', default=False, envvar='RECEPTORCTL_INSECURESKIPVERIFY', required=False, show_envvar=True,
-              help="")
+@click.option('--rootcas', default=None, help="Root CA bundle to use instead of system trust when connecting with tls")
+@click.option('--key', default=None, help="Client private key filename")
+@click.option('--cert', default=None, help="Client certificate filename")
+@click.option('--insecureskipverify', default=False, help="Accept any server cert", show_default=True)
 def cli(ctx, socket, yaml, tlsclient, rootcas, key, cert, insecureskipverify):
     ctx.obj = dict()
     ctx.obj['socket'] = socket

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -45,7 +45,7 @@ class ReceptorControl:
                 key = i.get("tls-client", None)
                 if key:
                      if key["name"] == tlsclient:
-                         ctxobj["key"] = key.get("key", ctxobj["key"])
+                         ctxobj["key"] = key.get("key", ctxobj["key"]) # if not in yaml, keep the value
                          ctxobj["cert"]= key.get("cert", ctxobj["cert"])
                          ctxobj["rootcas"] = key.get("rootcas", ctxobj["rootcas"])
                          ctxobj["insecureskipverify"] = key.get("insecureskipverify", ctxobj["insecureskipverify"])
@@ -66,10 +66,11 @@ class ReceptorControl:
         m = re.compile("(tcp|tls):(//)?([a-zA-Z0-9-]+):([0-9]+)|(unix:(//)?)?([^:]+)").fullmatch(address)
         if m:
             if m[7]:
-                path = os.path.expanduser(m[6])
+                path = os.path.expanduser(m[7])
                 if not os.path.exists(path):
                     raise ValueError(f"Socket path does not exist: {path}")
                 self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                print(path)
                 self.socket.connect(path)
                 self.sockfile = self.socket.makefile('rwb')
                 self.handshake()

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -45,7 +45,7 @@ class ReceptorControl:
                 key = i.get("tls-client", None)
                 if key:
                      if key["name"] == tlsclient:
-                         ctxobj["key"] = key.get("key", ctxobj["key"]) # if not in yaml, keep the value
+                         ctxobj["key"] = key.get("key", ctxobj["key"]) # if not in yaml, keep the previous value
                          ctxobj["cert"]= key.get("cert", ctxobj["cert"])
                          ctxobj["rootcas"] = key.get("rootcas", ctxobj["rootcas"])
                          ctxobj["insecureskipverify"] = key.get("insecureskipverify", ctxobj["insecureskipverify"])

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -128,17 +128,23 @@ class ReceptorControl:
         if not str.startswith(text, "Connecting"):
             raise RuntimeError(text)
 
-    def submit_work(self, node, worktype, payload, tlsclient, ttl, params):
+    def submit_work(self, worktype, payload, node=None, tlsclient=None, ttl=None, params=None):
         if node is None:
             node = "localhost"
+
         commandMap = {
             "command": "work",
             "subcommand": "submit",
             "node": node,
             "worktype": worktype,
-            "tlsclient": tlsclient,
-            "ttl": ttl,
         }
+
+        if tlsclient:
+            commandMap['tlsclient'] = tlsclient
+
+        if ttl:
+            commandMap['ttl'] = ttl
+
         if params:
             for k,v in params.items():
                 if k not in commandMap:

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -70,7 +70,6 @@ class ReceptorControl:
                 if not os.path.exists(path):
                     raise ValueError(f"Socket path does not exist: {path}")
                 self.socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                print(path)
                 self.socket.connect(path)
                 self.sockfile = self.socket.makefile('rwb')
                 self.handshake()

--- a/receptorctl/setup.py
+++ b/receptorctl/setup.py
@@ -36,6 +36,7 @@ setup(
         "setuptools",
         "python-dateutil",
         "click",
+        "pyyaml"
     ],
     zip_safe=False,
     entry_points={

--- a/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
+++ b/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
@@ -3,17 +3,17 @@
 - tcp-listener:
     port: 11111
 - control-service:
-    filename: /tmp/node1.sock
+    filename: /tmp/receptorctltest/node1.sock
 - tcp-server:
     port: 11112
     remotenode: localhost
     remoteservice: control
 - tls-server:
     name: tlsserver
-    key: /tmp/receptorctltest/ca.key
-    cert: /tmp/receptorctltest/ca.crt
-    # requireclientcert: false
-    # clientcas: /tmp/receptorctltest_ca.crt
+    key: /tmp/receptorctltest/server.key
+    cert: /tmp/receptorctltest/server.crt
+    requireclientcert: true
+    clientcas: /tmp/receptorctltest/ca.crt
 - control-service:
     service: ctltls
     tcplisten: 11113

--- a/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
+++ b/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
@@ -8,3 +8,13 @@
     port: 11112
     remotenode: localhost
     remoteservice: control
+- tls-server:
+    name: tlsserver
+    key: /tmp/receptorctltest.key
+    cert: /tmp/receptorctltest.crt
+    # requireclientcert: false
+    # clientcas: /tmp/receptorctltest_ca.crt
+- control-service:
+    service: ctltls
+    tcplisten: 11113
+    tcptls: tlsserver

--- a/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
+++ b/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
@@ -10,8 +10,8 @@
     remoteservice: control
 - tls-server:
     name: tlsserver
-    key: /tmp/receptorctltest.key
-    cert: /tmp/receptorctltest.crt
+    key: /tmp/receptorctltest/ca.key
+    cert: /tmp/receptorctltest/ca.crt
     # requireclientcert: false
     # clientcas: /tmp/receptorctltest_ca.crt
 - control-service:

--- a/receptorctl/tests/mesh-definitions/mesh1/node2.yaml
+++ b/receptorctl/tests/mesh-definitions/mesh1/node2.yaml
@@ -3,4 +3,4 @@
 - tcp-peer:
     address: localhost:11111
 - control-service:
-    filename: /tmp/node2.sock
+    filename: /tmp/receptorctltest/node2.sock

--- a/receptorctl/tests/tests.py
+++ b/receptorctl/tests/tests.py
@@ -1,15 +1,46 @@
 import pytest
 import subprocess
+import os
 from receptorctl import ReceptorControl
 import time
 
+connDict = {
+    "socket":None,
+    "rootcas":None,
+    "key":None,
+    "cert":None,
+    "insecureskipverify":False,
+}
+
 @pytest.fixture(scope="class")
 def receptor_mesh(request):
+    caKeyPath = "/tmp/receptorctltest_ca.key"
+    caCrtPath = "/tmp/receptorctltest_ca.crt"
+    keyPath = "/tmp/receptorctltest.key"
+    crtPath = "/tmp/receptorctltest.crt"
+    csrPath = "/tmp/receptorctltest.csa"
+    extPath = "/tmp/receptorctltest.ext"
+    # create x509 extension
+    with open(extPath, "w") as ext:
+        ext.write("subjectAltName=DNS:localhost")
+        ext.close()
+    # create CA
+    os.system("openssl genrsa -out " + caKeyPath + " 1024")
+    os.system("openssl req -x509 -new -nodes -key " + caKeyPath + " -subj /C=/ST=/L=/O=/OU=ReceptorTesting/CN=ca -sha256 -out " + caCrtPath)
+    # create key
+    os.system("openssl genrsa -out " + keyPath + " 1024")
+    # create cert request
+    os.system("openssl req -new -sha256 -key " + keyPath + " -subj /C=/ST=/L=/O=/OU=ReceptorTesting/CN=localhost -out " + csrPath)
+    # sign cert request
+    os.system("openssl x509 -req -extfile " + extPath + " -in " + csrPath + " -CA " + caCrtPath + " -CAkey " + caKeyPath + " -CAcreateserial -out " + crtPath + " -sha256")
+
     node1 = subprocess.Popen(["receptor", "-c", "tests/mesh-definitions/mesh1/node1.yaml"])
     node2 = subprocess.Popen(["receptor", "-c", "tests/mesh-definitions/mesh1/node2.yaml"])
+
     time.sleep(0.5)
     node1_controller = ReceptorControl()
-    node1_controller.connect("unix:///tmp/node1.sock")
+    connDict["socket"] = "unix:///tmp/node1.sock"
+    node1_controller.connect(connDict)
 
     while True:
         status = node1_controller.simple_command("status")
@@ -28,28 +59,42 @@ def receptor_mesh(request):
 class TestReceptorCTL:
     def test_simple_command(self):
         node1_controller = ReceptorControl()
-        node1_controller.connect("unix:///tmp/node1.sock")
+        connDict["socket"] = "unix:///tmp/node1.sock"
+        node1_controller.connect(connDict)
         status = node1_controller.simple_command("status")
         node1_controller.close()
         assert not (set(["Advertisements", "Connections", "KnownConnectionCosts", "NodeID", "RoutingTable"]) - status.keys())
 
     def test_simple_command_fail(self):
         node1_controller = ReceptorControl()
-        node1_controller.connect("unix:///tmp/node1.sock")
+        connDict["socket"] = "unix:///tmp/node1.sock"
+        node1_controller.connect(connDict)
         with pytest.raises(RuntimeError):
             node1_controller.simple_command("doesnotexist")
         node1_controller.close()
 
     def test_tcp_control_service(self):
         node1_controller = ReceptorControl()
-        node1_controller.connect("tcp://localhost:11112")
+        connDict["socket"] = "tcp://localhost:11112"
+        node1_controller.connect(connDict)
+        status = node1_controller.simple_command("status")
+        node1_controller.close()
+        assert not (set(["Advertisements", "Connections", "KnownConnectionCosts", "NodeID", "RoutingTable"]) - status.keys())
+
+    def test_tcp_control_service_tls(self):
+        node1_controller = ReceptorControl()
+        connDict["socket"] = "tls://localhost:11113"
+        connDict["rootcas"] = "/tmp/receptorctltest_ca.crt"
+        connDict["insecureskipverify"] = True
+        node1_controller.connect(connDict)
         status = node1_controller.simple_command("status")
         node1_controller.close()
         assert not (set(["Advertisements", "Connections", "KnownConnectionCosts", "NodeID", "RoutingTable"]) - status.keys())
 
     def test_connect_to_service(self):
         node1_controller = ReceptorControl()
-        node1_controller.connect("unix:///tmp/node1.sock")
+        connDict["socket"] = "unix:///tmp/node1.sock"
+        node1_controller.connect(connDict)
         node1_controller.connect_to_service("node2", "control", "")
         node1_controller.handshake()
         status = node1_controller.simple_command("status")


### PR DESCRIPTION
related https://github.com/project-receptor/receptor/issues/224

Can now do the following,
`receptorctl --socket tls://localhost:11114 --rootcas ca.crt --key client.key --cert client.crt --insecureskipverify true status`

One can also point to a receptor-compatible yaml file with tls client information

foo.yaml
```yaml
- tls-client:
    name: thisclient
    rootcas: ca.crt
    insecureskipverify: true
    cert: client.crt
    key: client.key
```
`receptorctl --socket tls://localhost:11114 --yaml  foo.yaml --tlsclient thisclient status`

or set up environment variables

`export RECEPTORCTL_YAML=foo.yaml` and `export RECEPTORCTL_TLSCLIENT=thisclient`

if `rootcas` is None (default), then it _should_ use system certs, although I could not get this to work properly on my machine.

https://docs.python.org/3/library/ssl.html#ssl.SSLContext.load_default_certs
