### PR TITLE
Fix hang on non-TLS-to-TLS control socket connection

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,7 @@ github.com/marten-seemann/qpack v0.1.0/go.mod h1:LFt1NU/Ptjip0C2CPkhimBz5CGE3WGD
 github.com/marten-seemann/qpack v0.2.0/go.mod h1:F7Gl5L1jIgN1D11ucXefiuJS9UMVP2opoCp2jDKb7wc=
 github.com/marten-seemann/qtls v0.9.1 h1:O0YKQxNVPaiFgMng0suWEOY2Sb4LT2sRn9Qimq3Z1IQ=
 github.com/marten-seemann/qtls v0.9.1/go.mod h1:T1MmAdDPyISzxlK6kjRr0pcZFBVd1OZbBb/j3cvzHhk=
+github.com/marten-seemann/qtls v0.10.0 h1:ECsuYUKalRL240rRD4Ri33ISb7kAQ3qGDlrrl55b2pc=
 github.com/marten-seemann/qtls v0.10.0/go.mod h1:UvMd1oaYDACI99/oZUYLzMCkBXQVT0aGm99sJhbT8hs=
 github.com/marten-seemann/qtls-go1-15 v0.1.0 h1:i/YPXVxz8q9umso/5y474CNcHmTpA+5DH+mFPjx6PZg=
 github.com/marten-seemann/qtls-go1-15 v0.1.0/go.mod h1:GyFwywLKkRt+6mfU99csTEY1joMZz5vmB1WNZH3P81I=

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -24,7 +24,7 @@ class ReceptorControl:
     def handshake(self):
         m = re.compile("Receptor Control, node (.+)").fullmatch(self.readstr())
         if not m:
-            raise RuntimeError("Failed to handshake with Receptor socket")
+            raise RuntimeError("Failed to connect to Receptor socket")
         self.remote_node = m[1]
 
     def read_and_parse_json(self):


### PR DESCRIPTION
When Receptor is running a TLS listener on a control socket, and a user running receptorctl or netcat accidentally connects using non-TLS, the server-side TLS waits indefinitely because there is no timeout by default.  If the client doesn't send anything and doesn't time out, we just hang indefinitely.  This PR adds a 10 second timeout to the server-side TLS handshake to avoid this situation.  See https://github.com/project-receptor/receptor/issues/245.