### PR TITLE
Remove ctxobj in ReceptorControl

### DIFF
--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -33,27 +33,17 @@ class IgnoreRequiredWithHelp(click.Group):
               help="Control socket address to connect to Receptor (defaults to Unix socket, use tcp:// for TCP socket)")
 @click.option('--config', '-c', default=None, envvar='RECEPTORCTL_CONFIG', required=False, show_envvar=True,
               help="Config filename configured for receptor")
-@click.option('--tls-client', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
+@click.option('--tls-client', 'tlsclient', default=None, envvar='RECEPTORCTL_TLSCLIENT', required=False, show_envvar=True,
               help="TLS client name specified in config")
 @click.option('--rootcas', default=None, help="Root CA bundle to use instead of system trust when connecting with tls")
 @click.option('--key', default=None, help="Client private key filename")
 @click.option('--cert', default=None, help="Client certificate filename")
 @click.option('--insecureskipverify', default=False, help="Accept any server cert", show_default=True)
-def cli(ctx, socket, config, tls_client, rootcas, key, cert, insecureskipverify):
+def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
     ctx.obj = dict()
-    ctx.obj['socket'] = socket
-    ctx.obj['config'] = config
-    ctx.obj['tls-client'] = tls_client
-    ctx.obj['rootcas'] = rootcas
-    ctx.obj['key'] = key
-    ctx.obj['cert'] = cert
-    ctx.obj['insecureskipverify'] = insecureskipverify
-
+    ctx.obj['rc'] = ReceptorControl(socket, config=config, tlsclient=tlsclient, rootcas=rootcas, key=key, cert=cert, insecureskipverify=insecureskipverify)
 def get_rc(ctx):
-    rc = ReceptorControl()
-    rc.readconfig(ctx.obj)
-    rc.connect(ctx.obj)
-    return rc
+    return ctx.obj['rc']
 
 
 @cli.command(help="Show the status of the Receptor network.")

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -30,7 +30,6 @@ class ReceptorControl:
         self.insecureskipverify = insecureskipverify
         if config and tlsclient:
             self.readconfig(config, tlsclient)
-        self.connect()
 
     def readstr(self):
         return self.sockfile.readline().decode().strip()

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -112,7 +112,7 @@ class ReceptorControl:
                     raise ValueError(f"Could not connect to host {host} port {port}")
                 self.handshake()
                 return
-        raise ValueError(f"Invalid socket address {self.socketfile}")
+        raise ValueError(f"Invalid socket address {self.socketaddress}")
 
     def close(self):
         if self.sockfile is not None:

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -203,4 +203,9 @@ class ReceptorControl:
                 errmsg = errmsg + ": " + text[7:]
             raise RuntimeError(errmsg)
         shutdown_write(self.socket)
+        try:
+            self.socket.close()
+        except:
+            pass
+        self.socket = None
         return self.sockfile

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -14,25 +14,22 @@ class ReceptorControl:
             raise RuntimeError("Cannot specify both config and rootcas, key, cert")
         if config and not tlsclient:
             raise RuntimeError("Must specify both config and tlsclient")
-        self.socketaddress = socketaddress
         self.socket = None
         self.sockfile = None
         self.remote_node = None
+        self.socketaddress = socketaddress
         self.rootcas = rootcas
         self.key = key
         self.cert = cert
         self.insecureskipverify = insecureskipverify
-
         if config and tlsclient:
             self.readconfig(config, tlsclient)
-
         self.connect()
 
     def readstr(self):
         return self.sockfile.readline().decode().strip()
 
     def writestr(self, str):
-        import pdb; pdb.set_trace()
         self.sockfile.write(str.encode())
         self.sockfile.flush()
 
@@ -69,7 +66,6 @@ class ReceptorControl:
         return self.read_and_parse_json()
 
     def connect(self):
-        import pdb; pdb.set_trace()
         if self.socket is not None:
             return
         m = re.compile("(tcp|tls):(//)?([a-zA-Z0-9-]+):([0-9]+)|(unix:(//)?)?([^:]+)").fullmatch(self.socketaddress)

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -8,6 +8,12 @@ import json
 import ssl
 import yaml
 
+def shutdown_write(sock):
+    if isinstance(sock, ssl.SSLSocket):
+        super(ssl.SSLSocket, sock).shutdown(socket.SHUT_WR)
+    else:
+        sock.shutdown(socket.SHUT_WR)
+
 class ReceptorControl:
     def __init__(self, socketaddress, config=None, tlsclient=None, rootcas=None, key=None, cert=None, insecureskipverify=False):
         if config and any((rootcas, key, cert)):
@@ -179,7 +185,7 @@ class ReceptorControl:
         else:
             raise RuntimeError("Unknown payload type")
         self.sockfile.flush()
-        self.socket.shutdown(socket.SHUT_WR)
+        shutdown_write(self.socket)
         text = self.readstr()
         self.close()
         if text.startswith("ERROR:"):
@@ -197,5 +203,5 @@ class ReceptorControl:
             if str.startswith(text, "ERROR: "):
                 errmsg = errmsg + ": " + text[7:]
             raise RuntimeError(errmsg)
-        self.socket.shutdown(socket.SHUT_WR)
+        shutdown_write(self.socket)
         return self.sockfile

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -123,16 +123,14 @@ class ReceptorControl:
         if self.sockfile is not None:
             try:
                 self.sockfile.close()
-            except:
-                pass
-            self.sockfile = None
+            finally:
+                self.sockfile = None
 
         if self.socket is not None:
             try:
                 self.socket.close()
-            except:
-                pass
-            self.socket = None
+            finally:
+                self.socket = None
 
     def connect_to_service(self, node, service, tlsclient):
         self.connect()
@@ -203,9 +201,9 @@ class ReceptorControl:
                 errmsg = errmsg + ": " + text[7:]
             raise RuntimeError(errmsg)
         shutdown_write(self.socket)
+        # Close socket but not sockfile.  This leaves the connection open until the caller closes sockfile.
         try:
             self.socket.close()
-        except:
-            pass
-        self.socket = None
+        finally:
+            self.socket = None
         return self.sockfile


### PR DESCRIPTION
Now TLS information is supplied to the ReceptorControl `__init__`, instead of the `.connect()`

the connection remains open so that you can sequence commands together

```python
rc = receptorctl.ReceptorControl("tls://localhost:8888", config="foo.yml", tlsclient="client")
rc.simple_command("status")
rc.simple_command("work list")
rc.get_work_results("6ByU8r4b")
```

Note:
Also addresses an issue where shutting down the write side of the socket does not behave correctly for SSLSocket
https://bugs.python.org/issue18880