### PR TITLE
Add connection info to service advertisement 

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -64,10 +64,10 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 	_ = s.addNameHash(service)
 	var connType byte
 	if tlscfg == nil {
-		connType = typeConnNonTLS
+		connType = ConnTypeStream
 		tlscfg = generateServerTLSConfig()
 	} else {
-		connType = typeConnTLS
+		connType = ConnTypeStreamTLS
 		tlscfg = tlscfg.Clone()
 		tlscfg.NextProtos = []string{"netceptor"}
 		if tlscfg.GetConfigForClient != nil {

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -179,9 +179,12 @@ type routingUpdate struct {
 }
 
 const (
-	typePacketConn = 0
-	typeConnNonTLS = 1
-	typeConnTLS    = 2
+	// ConnTypeDatagram indicates a packetconn (datagram) service listener
+	ConnTypeDatagram = 0
+	// ConnTypeStream indicates a conn (stream) service listener, without a user-defined TLS
+	ConnTypeStream = 1
+	// ConnTypeStreamTLS indicates the service listens on a packetconn connection, with a user-defined TLS
+	ConnTypeStreamTLS = 2
 )
 
 // ServiceAdvertisement is the data associated with a service advertisement

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -178,12 +178,19 @@ type routingUpdate struct {
 	SuspectedDuplicate uint64
 }
 
+const (
+	typePacketConn = 0
+	typeConnNonTLS = 1
+	typeConnTLS    = 2
+)
+
 // ServiceAdvertisement is the data associated with a service advertisement
 type ServiceAdvertisement struct {
-	NodeID  string
-	Service string
-	Time    time.Time
-	Tags    map[string]string
+	NodeID   string
+	Service  string
+	Time     time.Time
+	ConnType byte
+	Tags     map[string]string
 }
 
 // serviceAdvertisementFull is the whole message from the network
@@ -410,7 +417,7 @@ func (s *Netceptor) PathCost(nodeID string) (float64, error) {
 	return cost, nil
 }
 
-func (s *Netceptor) addLocalServiceAdvertisement(service string, tags map[string]string) {
+func (s *Netceptor) addLocalServiceAdvertisement(service string, connType byte, tags map[string]string) {
 	s.serviceAdsLock.Lock()
 	defer s.serviceAdsLock.Unlock()
 	n, ok := s.serviceAdsReceived[s.nodeID]
@@ -419,10 +426,11 @@ func (s *Netceptor) addLocalServiceAdvertisement(service string, tags map[string
 		s.serviceAdsReceived[s.nodeID] = n
 	}
 	n[service] = &ServiceAdvertisement{
-		NodeID:  s.nodeID,
-		Service: service,
-		Time:    time.Now(),
-		Tags:    tags,
+		NodeID:   s.nodeID,
+		Service:  service,
+		Time:     time.Now(),
+		ConnType: connType,
+		Tags:     tags,
 	}
 	s.sendServiceAdsChan <- 0
 }
@@ -431,15 +439,17 @@ func (s *Netceptor) removeLocalServiceAdvertisement(service string) error {
 	s.serviceAdsLock.Lock()
 	defer s.serviceAdsLock.Unlock()
 	n, ok := s.serviceAdsReceived[s.nodeID]
+	connType := n[service].ConnType
 	if ok {
 		delete(n, service)
 	}
 	sa := &serviceAdvertisementFull{
 		ServiceAdvertisement: &ServiceAdvertisement{
-			NodeID:  s.nodeID,
-			Service: service,
-			Time:    time.Now(),
-			Tags:    nil,
+			NodeID:   s.nodeID,
+			Service:  service,
+			Time:     time.Now(),
+			ConnType: connType,
+			Tags:     nil,
 		},
 		Cancel: true,
 	}
@@ -453,7 +463,8 @@ func (s *Netceptor) removeLocalServiceAdvertisement(service string) error {
 
 // Send a single service broadcast
 func (s *Netceptor) sendServiceAd(si *ServiceAdvertisement) error {
-	logger.Debug("Sending service advertisement: %s\n", si)
+
+	logger.Debug("Sending service advertisement: %v\n", si)
 	sf := serviceAdvertisementFull{
 		ServiceAdvertisement: si,
 		Cancel:               false,
@@ -473,10 +484,11 @@ func (s *Netceptor) sendServiceAds() {
 	for sn := range s.listenerRegistry {
 		if s.listenerRegistry[sn].advertise {
 			sa := ServiceAdvertisement{
-				NodeID:  s.nodeID,
-				Service: sn,
-				Time:    time.Now(),
-				Tags:    s.listenerRegistry[sn].adTags,
+				NodeID:   s.nodeID,
+				Service:  sn,
+				Time:     time.Now(),
+				ConnType: s.listenerRegistry[sn].connType,
+				Tags:     s.listenerRegistry[sn].adTags,
 			}
 			ads = append(ads, sa)
 		}

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -18,6 +18,7 @@ type PacketConn struct {
 	writeDeadline      time.Time
 	advertise          bool
 	adTags             map[string]string
+	connType           byte
 	hopsToLive         byte
 	unreachableMsgChan chan interface{}
 	unreachableSubs    *utils.Broker
@@ -48,6 +49,7 @@ func (s *Netceptor) ListenPacket(service string) (*PacketConn, error) {
 		recvChan:     make(chan *messageData),
 		advertise:    false,
 		adTags:       nil,
+		connType:     typePacketConn,
 		hopsToLive:   MaxForwardingHops,
 	}
 	pc.startUnreachable()
@@ -64,7 +66,7 @@ func (s *Netceptor) ListenPacketAndAdvertise(service string, tags map[string]str
 	}
 	pc.advertise = true
 	pc.adTags = tags
-	s.addLocalServiceAdvertisement(service, tags)
+	s.addLocalServiceAdvertisement(service, typePacketConn, tags)
 	return pc, nil
 }
 

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -49,7 +49,7 @@ func (s *Netceptor) ListenPacket(service string) (*PacketConn, error) {
 		recvChan:     make(chan *messageData),
 		advertise:    false,
 		adTags:       nil,
-		connType:     typePacketConn,
+		connType:     ConnTypeDatagram,
 		hopsToLive:   MaxForwardingHops,
 	}
 	pc.startUnreachable()
@@ -66,7 +66,7 @@ func (s *Netceptor) ListenPacketAndAdvertise(service string, tags map[string]str
 	}
 	pc.advertise = true
 	pc.adTags = tags
-	s.addLocalServiceAdvertisement(service, typePacketConn, tags)
+	s.addLocalServiceAdvertisement(service, ConnTypeDatagram, tags)
 	return pc, nil
 }
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -97,10 +97,16 @@ def status(ctx):
     ads = status.pop('Advertisements', None)
     if ads:
         print()
-        print(f"{'Node':<{longest_node}} Service   Last Seen            Tags")
+        print(f"{'Node':<{longest_node}} Service   Type        Last Seen            Tags")
         for ad in ads:
             time = dateutil.parser.parse(ad['Time'])
-            print(f"{ad['NodeID']:<{longest_node}} {ad['Service']:<8}  {time:%Y-%m-%d %H:%M:%S}  ", end="")
+            if ad['ConnType'] == 0:
+                conn_type = 'PacketConn'
+            elif ad['ConnType'] == 1:
+                conn_type = 'ConnNonTLS'
+            elif ad['ConnType'] == 2:
+                conn_type = 'ConnTLS'
+            print(f"{ad['NodeID']:<{longest_node}} {ad['Service']:<9} {conn_type:<11} {time:%Y-%m-%d %H:%M:%S}  ", end="")
             pprint(ad['Tags'])
 
     if status:

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -97,16 +97,16 @@ def status(ctx):
     ads = status.pop('Advertisements', None)
     if ads:
         print()
-        print(f"{'Node':<{longest_node}} Service   Type        Last Seen            Tags")
+        print(f"{'Node':<{longest_node}} Service   Type       Last Seen            Tags")
         for ad in ads:
             time = dateutil.parser.parse(ad['Time'])
             if ad['ConnType'] == 0:
-                conn_type = 'PacketConn'
+                conn_type = 'Datagram'
             elif ad['ConnType'] == 1:
-                conn_type = 'ConnNonTLS'
+                conn_type = 'Stream'
             elif ad['ConnType'] == 2:
-                conn_type = 'ConnTLS'
-            print(f"{ad['NodeID']:<{longest_node}} {ad['Service']:<9} {conn_type:<11} {time:%Y-%m-%d %H:%M:%S}  ", end="")
+                conn_type = 'StreamTLS'
+            print(f"{ad['NodeID']:<{longest_node}} {ad['Service']:<9} {conn_type:<10} {time:%Y-%m-%d %H:%M:%S}  ", end="")
             pprint(ad['Tags'])
 
     if status:


### PR DESCRIPTION
related #206 

calling `status` now has connection information

```
Node ID: foo

Node         Service   Type       Last Seen            Tags
foo          control   StreamTLS  2020-11-13 17:37:11  None
foo          echo      Stream     2020-11-13 17:37:11  {'type': 'Command Service'}
foo          udp       Datagram   2020-11-13 17:37:11  {'address': 'localhost:8989', 'type': 'UDP Proxy'}
```

I added a single byte to the ServiceAdvertisement struct to keep track of the connection information.
As it stands, cli.py maps the byte to the string. That means calling `status` from the unix socket will only display the byte (0,1, or 2), not the string, which is less useful.