### PR TITLE
Use multi-stage build to ensure binary is compatible with image it's used in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,8 +145,8 @@ $(RECEPTOR_PYTHON_WORKER_WHEEL): receptor-python-worker/README.md receptor-pytho
 	@cd receptor-python-worker && python3 setup.py bdist_wheel
 
 container: .container-flag-$(VERSION)
-.container-flag-$(VERSION): receptor $(RECEPTORCTL_WHEEL) $(RECEPTOR_PYTHON_WORKER_WHEEL)
-	@cp receptor packaging/container
+.container-flag-$(VERSION): $(RECEPTORCTL_WHEEL) $(RECEPTOR_PYTHON_WORKER_WHEEL)
+	@tar --exclude-vcs-ignores -czf packaging/container/source.tar.gz .
 	@cp $(RECEPTORCTL_WHEEL) packaging/container
 	@cp $(RECEPTOR_PYTHON_WORKER_WHEEL) packaging/container
 	$(CONTAINERCMD) build packaging/container --build-arg VERSION=$(VERSION) -t $(TAG) $(if $(OFFICIAL),-t receptor:$(VERSION),)

--- a/packaging/container/.gitignore
+++ b/packaging/container/.gitignore
@@ -1,2 +1,3 @@
 receptor
 *.whl
+source.tar.gz

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,3 +1,11 @@
+FROM fedora:32 as builder
+
+RUN dnf -y update && dnf install -y golang make
+
+ADD source.tar.gz /source
+WORKDIR /source
+RUN make
+
 FROM fedora:32
 ARG VERSION
 
@@ -16,7 +24,7 @@ RUN pip3 install /tmp/*.whl
 RUN rm /tmp/*.whl
 
 COPY receptor.conf /etc/receptor/receptor.conf
-COPY receptor /usr/bin/receptor
+COPY --from=builder /source/receptor /usr/bin/receptor
 
 ENV RECEPTORCTL_SOCKET=/tmp/receptor.sock
 


### PR DESCRIPTION
I got bit by this earlier today, where the binary build on my f33 vm didnt work in the fedora 32 image used as the base image.