### PR TITLE
Add system CPU cores and total memory installed in status output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/jupp0r/go-priority-queue v0.0.0-20160601094913-ab1073853bde
 	github.com/lucas-clemente/quic-go v0.18.1
 	github.com/minio/highwayhash v1.0.0
+	github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4
 	github.com/prep/socketpair v0.0.0-20171228153254-c2c6a7f821c2
 	github.com/rogpeppe/go-internal v1.6.1
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.8.1/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/openzipkin/zipkin-go v0.1.1/go.mod h1:NtoC/o8u3JlF1lSlyPNswIbeQH9bJTmOf0Erfk+hxe8=
+github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4 h1:MfIUBZ1bz7TgvQLVa/yPJZOGeKEgs6eTKUjz3zB4B+U=
+github.com/pbnjay/memory v0.0.0-20190104145345-974d429e7ae4/go.mod h1:RMU2gJXhratVxBDTFeOdNhd540tG57lt9FIUV0YLvIQ=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -45,7 +45,7 @@ func (c *statusCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOper
 	status := nc.Status()
 	statusGetters := make(map[string]func() interface{})
 	statusGetters["Version"] = func() interface{} { return version.Version }
-	statusGetters["SystemCPUCores"] = func() interface{} { return utils.GetSysCPUCores() }
+	statusGetters["SystemCPUCount"] = func() interface{} { return utils.GetSysCPUCount() }
 	statusGetters["SystemMemoryMB"] = func() interface{} { return utils.GetSysMemoryMB() }
 	statusGetters["NodeID"] = func() interface{} { return status.NodeID }
 	statusGetters["Connections"] = func() interface{} { return status.Connections }

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -3,6 +3,7 @@ package controlsvc
 import (
 	"fmt"
 	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/utils"
 	"github.com/project-receptor/receptor/pkg/version"
 )
 
@@ -44,6 +45,8 @@ func (c *statusCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOper
 	status := nc.Status()
 	statusGetters := make(map[string]func() interface{})
 	statusGetters["Version"] = func() interface{} { return version.Version }
+	statusGetters["SystemCPUCores"] = func() interface{} { return utils.GetSysCPUCores() }
+	statusGetters["SystemMemoryMB"] = func() interface{} { return utils.GetSysMemoryMB() }
 	statusGetters["NodeID"] = func() interface{} { return status.NodeID }
 	statusGetters["Connections"] = func() interface{} { return status.Connections }
 	statusGetters["RoutingTable"] = func() interface{} { return status.RoutingTable }

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -46,7 +46,7 @@ func (c *statusCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOper
 	statusGetters := make(map[string]func() interface{})
 	statusGetters["Version"] = func() interface{} { return version.Version }
 	statusGetters["SystemCPUCount"] = func() interface{} { return utils.GetSysCPUCount() }
-	statusGetters["SystemMemoryMB"] = func() interface{} { return utils.GetSysMemoryMB() }
+	statusGetters["SystemMemoryMiB"] = func() interface{} { return utils.GetSysMemoryMiB() }
 	statusGetters["NodeID"] = func() interface{} { return status.NodeID }
 	statusGetters["Connections"] = func() interface{} { return status.Connections }
 	statusGetters["RoutingTable"] = func() interface{} { return status.RoutingTable }

--- a/pkg/utils/sysinfo.go
+++ b/pkg/utils/sysinfo.go
@@ -10,7 +10,7 @@ func GetSysCPUCount() int {
 	return runtime.NumCPU()
 }
 
-// GetSysMemoryMB returns the capacity (in MB) of the physical memory installed on the system
-func GetSysMemoryMB() uint {
-	return uint(memory.TotalMemory() / 1e6)
+// GetSysMemoryMiB returns the capacity (in mebibytes) of the physical memory installed on the system
+func GetSysMemoryMiB() uint64 {
+	return memory.TotalMemory() / 1048576
 }

--- a/pkg/utils/sysinfo.go
+++ b/pkg/utils/sysinfo.go
@@ -5,8 +5,8 @@ import (
 	"runtime"
 )
 
-// GetSysCPUCores returns number of CPU cores on the system
-func GetSysCPUCores() int {
+// GetSysCPUCount returns number of logical CPU cores on the system
+func GetSysCPUCount() int {
 	return runtime.NumCPU()
 }
 

--- a/pkg/utils/sysinfo.go
+++ b/pkg/utils/sysinfo.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"github.com/pbnjay/memory"
+	"runtime"
+)
+
+// GetSysCPUCores returns number of CPU cores on the system
+func GetSysCPUCores() int {
+	return runtime.NumCPU()
+}
+
+// GetSysMemoryMB returns the capacity (in MB) of the physical memory installed on the system
+func GetSysMemoryMB() uint {
+	return uint(memory.TotalMemory() / 1e6)
+}

--- a/pkg/utils/sysinfo.go
+++ b/pkg/utils/sysinfo.go
@@ -12,5 +12,5 @@ func GetSysCPUCount() int {
 
 // GetSysMemoryMiB returns the capacity (in mebibytes) of the physical memory installed on the system
 func GetSysMemoryMiB() uint64 {
-	return memory.TotalMemory() / 1048576
+	return memory.TotalMemory() / 1048576 // bytes to MiB
 }

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -55,9 +55,12 @@ def status(ctx):
 
     node_id = status.pop('NodeID')
     print(f"Node ID: {node_id}")
-
     version = status.pop('Version')
     print(f"Version: {version}")
+    sysCores = status.pop('SystemCPUCores')
+    print(f"System CPU Cores: {sysCores}")
+    sysMemory = status.pop('SystemMemoryMB')
+    print(f"System Memory MB: {sysMemory}")
 
     longest_node = 12
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -59,8 +59,8 @@ def status(ctx):
     print(f"Version: {version}")
     sysCPU = status.pop('SystemCPUCount')
     print(f"System CPU Count: {sysCPU}")
-    sysMemory = status.pop('SystemMemoryMB')
-    print(f"System Memory MB: {sysMemory}")
+    sysMemory = status.pop('SystemMemoryMiB')
+    print(f"System Memory MiB: {sysMemory}")
 
     longest_node = 12
 

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -57,8 +57,8 @@ def status(ctx):
     print(f"Node ID: {node_id}")
     version = status.pop('Version')
     print(f"Version: {version}")
-    sysCores = status.pop('SystemCPUCores')
-    print(f"System CPU Cores: {sysCores}")
+    sysCPU = status.pop('SystemCPUCount')
+    print(f"System CPU Count: {sysCPU}")
     sysMemory = status.pop('SystemMemoryMB')
     print(f"System Memory MB: {sysMemory}")
 


### PR DESCRIPTION
```
Node ID: foo
Version: 0.9.2-0.git.35.gcadd579
System CPU Count: 8
System Memory MB: 16651

Node         Service   Type       Last Seen            Tags
foo          control   StreamTLS  2020-11-23 15:00:37  None
foo          echo      Stream     2020-11-23 15:00:37  {'type': 'Command Service'}
foo          udp       Datagram   2020-11-23 15:00:37  {'address': 'localhost:8989', 'type': 'UDP Proxy'}
```

We can get number of cores from the built-in go library `runtime`. There doesn't seem to be a way to get total memory from this package.

For memory I use https://github.com/pbnjay/memory

It appears to be minimal and only relies on standard library. It claims to supports windows, linux, and macOS (I only tested on linux)

It seems there is hesitance to expose system memory as a function in the go standard library, which is discussed here https://github.com/golang/go/issues/21816