### PR TITLE
Several small fixes

### DIFF
--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/framer"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/utils"
 	"io"
 	"net"
 	"sync"
@@ -169,7 +170,7 @@ func (ns *TCPSession) Send(data []byte) error {
 
 // Recv receives data via the session
 func (ns *TCPSession) Recv(timeout time.Duration) ([]byte, error) {
-	buf := make([]byte, netceptor.MTU)
+	buf := make([]byte, utils.NormalBufferSize)
 	for {
 		if ns.framer.MessageReady() {
 			break

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/utils"
 	"net"
 	"sync"
 	"time"
@@ -86,7 +87,7 @@ func (ns *UDPDialerSession) Recv(timeout time.Duration) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	buf := make([]byte, netceptor.MTU)
+	buf := make([]byte, utils.NormalBufferSize)
 	n, err := ns.conn.Read(buf)
 	if nerr, ok := err.(net.Error); ok && nerr.Timeout() {
 		return nil, netceptor.ErrTimeout
@@ -149,7 +150,7 @@ func (b *UDPListener) LocalAddr() net.Addr {
 func (b *UDPListener) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	sessChan := make(chan netceptor.BackendSession)
 	go func() {
-		buf := make([]byte, netceptor.MTU)
+		buf := make([]byte, utils.NormalBufferSize)
 		for {
 			select {
 			case <-ctx.Done():

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -40,13 +40,7 @@ func dialerSession(ctx context.Context, redial bool, redialDelay time.Duration,
 					return
 				}
 			}
-			done := false
-			select {
-			case <-ctx.Done():
-				done = true
-			default:
-			}
-			if redial && !done {
+			if redial && ctx.Err() == nil {
 				if err != nil {
 					logger.Warning("Backend connection failed (will retry): %s\n", err)
 				} else {
@@ -61,7 +55,7 @@ func dialerSession(ctx context.Context, redial bool, redialDelay time.Duration,
 			} else {
 				if err != nil {
 					logger.Error("Backend connection failed: %s\n", err)
-				} else if !done {
+				} else if ctx.Err() != nil {
 					logger.Error("Backend connection exited\n")
 				}
 				return

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -373,6 +373,9 @@ type CmdlineConfigUnix struct {
 
 // Run runs the action
 func (cfg CmdlineConfigUnix) Run() error {
+	if cfg.TLS != "" && cfg.TCPListen != "" && cfg.TCPTLS == "" {
+		logger.Warning("Control service %s has TLS configured on the Receptor listener but not the TCP listener.", cfg.Service)
+	}
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {
 		return err

--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -107,7 +107,7 @@ func ping(nc *netceptor.Netceptor, target string, hopsToLive byte) (time.Duratio
 }
 
 func (c *pingCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
-	pingTime, pingRemote, err := ping(nc, c.target, netceptor.MaxForwardingHops)
+	pingTime, pingRemote, err := ping(nc, c.target, nc.MaxForwardingHops())
 	cfr := make(map[string]interface{})
 	if err == nil {
 		cfr["Success"] = true

--- a/pkg/controlsvc/traceroute.go
+++ b/pkg/controlsvc/traceroute.go
@@ -38,7 +38,7 @@ func (t *tracerouteCommandType) InitFromJSON(config map[string]interface{}) (Con
 
 func (c *tracerouteCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
 	cfr := make(map[string]interface{})
-	for i := 0; i <= netceptor.MaxForwardingHops; i++ {
+	for i := 0; i <= int(nc.MaxForwardingHops()); i++ {
 		thisResult := make(map[string]interface{})
 		pingTime, pingRemote, err := ping(nc, c.target, byte(i))
 		thisResult["From"] = pingRemote

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -84,7 +84,7 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		advertise:    advertise,
 		adTags:       adTags,
 		connType:     connType,
-		hopsToLive:   MaxForwardingHops,
+		hopsToLive:   s.maxForwardingHops,
 	}
 	pc.startUnreachable()
 	s.listenerRegistry[service] = pc

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/gorilla/websocket"
 	"github.com/project-receptor/receptor/pkg/framer"
+	"github.com/project-receptor/receptor/pkg/utils"
 	"net"
 	"time"
 )
@@ -57,7 +58,7 @@ func (mc *netMessageConn) WriteMessage(ctx context.Context, data []byte) error {
 
 // ReadMessage reads a message from the connection
 func (mc *netMessageConn) ReadMessage(ctx context.Context, timeout time.Duration) ([]byte, error) {
-	buf := make([]byte, MTU)
+	buf := make([]byte, utils.NormalBufferSize)
 	err := mc.conn.SetReadDeadline(time.Now().Add(timeout))
 	if err != nil {
 		return nil, err

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -50,7 +50,7 @@ func (s *Netceptor) ListenPacket(service string) (*PacketConn, error) {
 		advertise:    false,
 		adTags:       nil,
 		connType:     ConnTypeDatagram,
-		hopsToLive:   MaxForwardingHops,
+		hopsToLive:   s.maxForwardingHops,
 	}
 	pc.startUnreachable()
 	s.listenerRegistry[service] = pc

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/utils"
 	"github.com/songgao/water"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/ipv4"
@@ -196,7 +197,7 @@ func (ipr *IPRouterService) runAdvertisingWatcher() {
 
 func (ipr *IPRouterService) runTunToNetceptor() {
 	logger.Debug("Running tunnel-to-Receptor forwarder\n")
-	buf := make([]byte, netceptor.MTU)
+	buf := make([]byte, utils.NormalBufferSize)
 	for {
 		if ipr.nc.Context().Err() != nil {
 			return
@@ -260,7 +261,7 @@ func (ipr *IPRouterService) runTunToNetceptor() {
 
 func (ipr *IPRouterService) runNetceptorToTun() {
 	logger.Debug("Running netceptor to tunnel forwarder\n")
-	buf := make([]byte, netceptor.MTU)
+	buf := make([]byte, utils.NormalBufferSize)
 	for {
 		if ipr.nc.Context().Err() != nil {
 			return

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -8,13 +8,14 @@ import (
 	"github.com/project-receptor/receptor/pkg/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/utils"
 	"net"
 )
 
 // UDPProxyServiceInbound listens on a UDP port and forwards packets to a remote Receptor service
 func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node string, service string) error {
 	connMap := make(map[string]*netceptor.PacketConn)
-	buffer := make([]byte, netceptor.MTU)
+	buffer := make([]byte, utils.NormalBufferSize)
 
 	addrStr := fmt.Sprintf("%s:%d", host, port)
 	udpAddr, err := net.ResolveUDPAddr("udp", addrStr)
@@ -59,7 +60,7 @@ func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node 
 }
 
 func runNetceptorToUDPInbound(pc *netceptor.PacketConn, uc *net.UDPConn, udpAddr net.Addr, expectedAddr netceptor.Addr) {
-	buf := make([]byte, netceptor.MTU)
+	buf := make([]byte, utils.NormalBufferSize)
 	for {
 		n, addr, err := pc.ReadFrom(buf)
 		if err != nil {
@@ -85,7 +86,7 @@ func runNetceptorToUDPInbound(pc *netceptor.PacketConn, uc *net.UDPConn, udpAddr
 // UDPProxyServiceOutbound listens on the Receptor network and forwards packets via UDP
 func UDPProxyServiceOutbound(s *netceptor.Netceptor, service string, address string) error {
 	connMap := make(map[string]*net.UDPConn)
-	buffer := make([]byte, netceptor.MTU)
+	buffer := make([]byte, utils.NormalBufferSize)
 	udpAddr, err := net.ResolveUDPAddr("udp", address)
 	if err != nil {
 		return fmt.Errorf("could not resolve UDP address %s", address)
@@ -131,7 +132,7 @@ func UDPProxyServiceOutbound(s *netceptor.Netceptor, service string, address str
 }
 
 func runUDPToNetceptorOutbound(uc *net.UDPConn, pc *netceptor.PacketConn, addr net.Addr) {
-	buf := make([]byte, netceptor.MTU)
+	buf := make([]byte, utils.NormalBufferSize)
 	for {
 		n, err := uc.Read(buf)
 		if err != nil {

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -6,6 +6,9 @@ import (
 	"strings"
 )
 
+// NormalBufferSize is the size of buffers used by various processes when copying data between sockets
+const NormalBufferSize = 65536
+
 // BridgeConns bridges two connections, like netcat.
 func BridgeConns(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2Name string) {
 	doneChan := make(chan bool)
@@ -20,7 +23,7 @@ func bridgeHalf(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2N
 	defer func() {
 		done <- true
 	}()
-	buf := make([]byte, 65536)
+	buf := make([]byte, NormalBufferSize)
 	shouldClose := false
 	for {
 		n, err := c1.Read(buf)

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -138,6 +138,18 @@ loop:
 	return nil
 }
 
+func combineParams(baseParams string, userParams string) string {
+	var allParams string
+	if userParams == "" {
+		allParams = baseParams
+	} else if baseParams == "" {
+		allParams = userParams
+	} else {
+		allParams = strings.Join([]string{baseParams, userParams}, " ")
+	}
+	return allParams
+}
+
 // SetFromParams sets the in-memory state from parameters
 func (cw *commandUnit) SetFromParams(params map[string]string) error {
 	cmdParams, ok := params["params"]
@@ -147,15 +159,7 @@ func (cw *commandUnit) SetFromParams(params map[string]string) error {
 	if cmdParams != "" && !cw.allowRuntimeParams {
 		return fmt.Errorf("extra params provided but not allowed")
 	}
-	var allParams string
-	if cmdParams == "" {
-		allParams = cw.baseParams
-	} else if cw.baseParams == "" {
-		allParams = cmdParams
-	} else {
-		allParams = strings.Join([]string{cw.baseParams, cmdParams}, " ")
-	}
-	cw.status.ExtraData.(*commandExtraData).Params = allParams
+	cw.status.ExtraData.(*commandExtraData).Params = combineParams(cw.baseParams, cmdParams)
 	return nil
 }
 

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/randstr"
+	"github.com/project-receptor/receptor/pkg/utils"
 	"io"
 	"io/ioutil"
 	"os"
@@ -378,7 +379,7 @@ func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan str
 					return
 				}
 				var n int
-				buf := make([]byte, netceptor.MTU)
+				buf := make([]byte, utils.NormalBufferSize)
 				n, err = stdout.Read(buf)
 				if n > 0 {
 					filePos += int64(n)

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -154,6 +154,12 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
 func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsclient, ttl string, params map[string]string) (WorkUnit, error) {
+	if tlsclient != "" {
+		_, err := w.nc.GetClientTLSConfig(tlsclient, "testhost")
+		if err != nil {
+			return nil, err
+		}
+	}
 	hasSecrets := false
 	for k := range params {
 		if strings.HasPrefix(strings.ToLower(k), "secret_") {

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -74,7 +74,7 @@ class ReceptorControl:
     def connect(self):
         if self._socket is not None:
             return
-        m = re.compile("(tcp|tls):(//)?([a-zA-Z0-9-]+):([0-9]+)|(unix:(//)?)?([^:]+)").fullmatch(self._socketaddress)
+        m = re.compile("(tcp|tls):(//)?([a-zA-Z0-9-.:]+):([0-9]+)|(unix:(//)?)?([^:]+)").fullmatch(self._socketaddress)
         if m:
             unixsocket = m[7]
             host = m[3]


### PR DESCRIPTION
* Give a warning if the user configures a control socket with Receptor TLS but also configures non-TLS TCP (https://github.com/project-receptor/receptor/issues/246)
* Don't use a whole `select()` just to check `ctx.Err()`
* Make Kubernetes command/params work more like regular command worker (https://github.com/project-receptor/receptor/issues/230) - and also allow passing params to the entrypoint without overriding it
* Fail immediately when remote work submission has a bogus tlsclient (https://github.com/project-receptor/receptor/issues/228)
* Make Netceptor constants configurable (https://github.com/project-receptor/receptor/issues/203) - though note that they are only configurable from code, not from config files