### PR TITLE
Fix stdout bug on k8s restart

### DIFF
--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -27,16 +27,7 @@ type stdoutWriter struct {
 
 // newStdoutWriter allocates a new stdoutWriter, which writes to both the stdout and status files
 func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
-	var osFlags int
-	stdoutPath := path.Join(unitdir, "stdout")
-	if _, err := os.Stat(stdoutPath); err == nil {
-		osFlags = os.O_WRONLY + os.O_SYNC
-	} else if os.IsNotExist(err) {
-		osFlags = os.O_CREATE + os.O_WRONLY + os.O_SYNC
-	} else {
-		return nil, err
-	}
-	writer, err := os.OpenFile(stdoutPath, osFlags, 0600)
+	writer, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0600)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -27,7 +27,16 @@ type stdoutWriter struct {
 
 // newStdoutWriter allocates a new stdoutWriter, which writes to both the stdout and status files
 func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
-	writer, err := os.OpenFile(path.Join(unitdir, "stdout"), (os.O_APPEND|os.O_CREATE)+os.O_WRONLY+os.O_SYNC, 0600)
+	var osFlags int
+	stdoutPath := path.Join(unitdir, "stdout")
+	if _, err := os.Stat(stdoutPath); err == nil {
+		osFlags = os.O_WRONLY + os.O_SYNC
+	} else if os.IsNotExist(err) {
+		osFlags = os.O_CREATE + os.O_WRONLY + os.O_SYNC
+	} else {
+		return nil, err
+	}
+	writer, err := os.OpenFile(stdoutPath, osFlags, 0600)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -497,12 +497,12 @@ func TestWork(t *testing.T) {
 				t.Fatal(err)
 			}
 			ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
-			err = controllers["node1"].AssertWorkResults(unitID, expectedResults)
+			err = controllers["node1"].AssertWorkSucceeded(ctx, unitID)
 			if err != nil {
 				t.Fatal(err)
 			}
 			ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
-			err = controllers["node1"].AssertWorkSucceeded(ctx, unitID)
+			err = controllers["node1"].AssertWorkResults(unitID, expectedResults)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -469,6 +469,45 @@ func TestWork(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+		t.Run(testGroup+"/results on restarted node", func(t *testing.T) {
+			t.Parallel()
+			controllers, m, expectedResults := workSetup(t.Name())
+			defer tearDown(controllers, m)
+			nodes := m.Nodes()
+
+			unitID, err := controllers["node1"].WorkSubmit("node3", "echosleeplong")
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+			err = controllers["node1"].AssertWorkRunning(ctx, unitID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			nodes["node3"].Shutdown()
+			nodes["node3"].WaitForShutdown()
+			err = nodes["node3"].Start()
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Wait for node3 to join the mesh again
+			ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
+			err = m.WaitForReady(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
+			err = controllers["node1"].AssertWorkResults(unitID, expectedResults)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
+			err = controllers["node1"].AssertWorkSucceeded(ctx, unitID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+
 	}
 }
 


### PR DESCRIPTION
related https://github.com/project-receptor/receptor/issues/86#issuecomment-732345001

We cannot seek into the logger stream object, so if there is stdout already present (before the restart) we cannot append to the stdout file. Instead, we can rewrite the full k8s output starting from the beginning of the stdout file.