### PR TITLE
fix hang when getting results for nonexistent work ID

### DIFF
--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -296,7 +296,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		}
 		doneChan := make(chan struct{})
 		defer func() {
-			doneChan <- struct{}{}
+			close(doneChan)
 		}()
 		resultChan, err := c.w.GetResults(unitid, startPos, doneChan)
 		if err != nil {


### PR DESCRIPTION
related https://github.com/project-receptor/receptor/issues/262

If `GetResults` returns with an error, writing to `doneChan` will hang because our only reader is in `GetResults`. Instead I think we can safely close the channel.