### PR TITLE
Allow passing in podspec during runtime

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -110,7 +110,6 @@ func (kw *kubeUnit) createPod(env map[string]string) error {
 		json.Unmarshal([]byte(ked.KubePodSpec), &spec)
 		foundWorker := false
 		for _, container := range spec.Containers {
-			logger.Debug("========= %s ========", container.Name)
 			if container.Name == "worker" {
 				if !container.Stdin {
 					return fmt.Errorf("worker container Stdin must be true")

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -664,11 +664,13 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	if userImage != "" {
 		ked.Image = userImage
 	}
-	if userPodSpec == "" {
-		ked.Params = combineParams(kw.baseParams, userParams)
-	} else {
+	if userPodSpec != "" {
 		ked.KubePodSpec = userPodSpec
+		ked.Image = ""
+		ked.Command = ""
 		kw.baseParams = ""
+	} else {
+		ked.Params = combineParams(kw.baseParams, userParams)
 	}
 	return nil
 }

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -630,7 +630,7 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	userParams := ""
 	userCommand := ""
 	userImage := ""
-	userPodSpec != ""
+	userPodSpec := ""
 	values := []value{
 		{name: "kube_command", permission: kw.allowRuntimeCommand, setter: setString(&userCommand)},
 		{name: "kube_image", permission: kw.allowRuntimeCommand, setter: setString(&userImage)},

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -658,9 +658,13 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	if userPodSpec != "" && (userParams != "" || userCommand != "" || userImage != "") {
 		return fmt.Errorf("params kube_command, kube_image, kube_params not compatible with secret_kube_podspec")
 	}
-	if userPodSpec == "" {
+	if userCommand != "" {
 		ked.Command = userCommand
+	}
+	if userImage != "" {
 		ked.Image = userImage
+	}
+	if userPodSpec == "" {
 		ked.Params = combineParams(kw.baseParams, userParams)
 	} else {
 		ked.KubePodSpec = userPodSpec

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -658,12 +658,12 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	if userPodSpec != "" && (userParams != "" || userCommand != "" || userImage != "") {
 		return fmt.Errorf("params kube_command, kube_image, kube_params not compatible with secret_kube_podspec")
 	}
-	ked.Command = userCommand
-	ked.Image = userImage
-	ked.KubePodSpec = userPodSpec
 	if userPodSpec == "" {
+		ked.Command = userCommand
+		ked.Image = userImage
 		ked.Params = combineParams(kw.baseParams, userParams)
 	} else {
+		ked.KubePodSpec = userPodSpec
 		kw.baseParams = ""
 	}
 	return nil

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -660,7 +660,11 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	ked.Command = userCommand
 	ked.Image = userImage
 	ked.KubePodSpec = userPodSpec
-	ked.Params = combineParams(kw.baseParams, userParams)
+	if userPodSpec == "" {
+		ked.Params = combineParams(kw.baseParams, userParams)
+	} else {
+		kw.baseParams = ""
+	}
 	return nil
 }
 

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -582,6 +582,7 @@ func (kw *kubeUnit) connectToKube() error {
 }
 
 func readFileToString(filename string) (string, error) {
+	// If filename is "", the function returns ""
 	if filename == "" {
 		return "", nil
 	}


### PR DESCRIPTION
e.g. `receptorctl ... --param secret_kube_podspec=@/home/sfoster/sockceptor/podspec`

podspec can be in `yaml` or `json` formats

If podspec is passed in, it will overwrite the `command`, `image` and `params` defined in the `work-kubernetes`.

As such, the `allowruntimecommand` and `allowruntimeparams` must be set to true

```yaml
- work-kubernetes:
    worktype: kubeit
    authmethod: kubeconfig
    namespace: sbf
    allowruntimecommand: true
    allowruntimeparams: true
```

The podspec must specify a container named "worker", with `stdin` and `stdinOnce` set to True. This is the container that we get stdin/stdout to and from.

Podspec can also be a config option

```yaml
- work-kubernetes:
    worktype: kubeit2
    authmethod: kubeconfig
    namespace: default
    podspec: /home/sfoster/sockceptor/podspec.yml
```