### PR TITLE
Don't run Kubernetes tests during RPM creation

### DIFF
--- a/packaging/rpm/receptor.spec.j2
+++ b/packaging/rpm/receptor.spec.j2
@@ -56,7 +56,7 @@ install -m 0644 -vp receptor.completion %{buildroot}%{_datadir}/bash-completion/
 %if %{with check}
 %check
 export PATH=$PATH:%{buildroot}%{_bindir}
-go test ./... -p 1 -parallel=16 -count=1 -failfast
+SKIP_KUBE=1 go test ./... -p 1 -parallel=16 -count=1 -failfast
 %endif
 
 %files


### PR DESCRIPTION
During RPM build, we run the test suite to verify that the built artifact passes tests.  No Kubernetes infrastructure is expected to be available during this process so we should disable the Kubernetes tests.