### PR TITLE
Allow for passing full Pod definition at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,15 +69,15 @@ build-all:
 	go build --tags no_controlsvc,no_backends,no_services,no_tls_config,no_workceptor cmd/receptor.go && \
 	go build cmd/receptor.go
 
-test: receptor
-	@go test ./... -p 1 -parallel=16 -count=1
-
 RUNTEST ?=
 ifeq ($(RUNTEST),)
 TESTCMD =
 else
 TESTCMD = -run $(RUNTEST)
 endif
+
+test: receptor
+	@go test ./... -p 1 -parallel=16 $(TESTCMD) -count=1
 
 testloop: receptor
 	@i=1; while echo "------ $$i" && \

--- a/packaging/ci-image/Dockerfile
+++ b/packaging/ci-image/Dockerfile
@@ -1,10 +1,11 @@
 FROM fedora:32
+ARG UID=1001
 RUN dnf -y update && \
   dnf -y install git golang python3 python3-pip python3-pyyaml make iproute openssl && \
   dnf clean all
 RUN pip3 install pre-commit
 
-RUN useradd -u 1001 -ms /bin/bash test-user && mkdir /home/test-user/receptor \
+RUN useradd -u $UID -ms /bin/bash test-user && mkdir /home/test-user/receptor \
     && chown test-user /home/test-user/receptor
 
 USER test-user

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -3,22 +3,26 @@
 package workceptor
 
 import (
-	"bytes"
 	"context"
 	"encoding/pem"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+
 	"github.com/google/shlex"
 	"github.com/project-receptor/receptor/pkg/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
-	"io"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -27,11 +31,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
 	watch2 "k8s.io/client-go/tools/watch"
-	"net"
-	"os"
-	"strconv"
-	"strings"
-	"sync"
 )
 
 // kubeUnit implements the WorkUnit interface

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -3,16 +3,17 @@ package mesh
 import (
 	"context"
 	"fmt"
-	_ "github.com/fortytw2/leaktest"
-	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/fortytw2/leaktest"
+	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
+	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 )
 
 func checkSkipKube(t *testing.T) {

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -634,7 +634,7 @@ func TestKubeRuntimeParams(t *testing.T) {
 	nodes := m.Nodes()
 	controller := receptorcontrol.New()
 	err = controller.Connect(nodes["node0"].ControlSocket())
-	command := fmt.Sprintf(`{"command": "work", "subcommand": "submit", "node": "localhost", "worktype": "echo", "secret_kube_podspec": "---\ncontainers:\n- name: worker\n  image: centos:8\n  command:\n  - bash\n  args:\n  - \"-c\"\n  - for i in {1..5}; do echo $i;done\n", "secret_kube_config": "%s"}`, kubeconfig)
+	command := fmt.Sprintf(`{"command": "work", "subcommand": "submit", "node": "localhost", "worktype": "echo", "secret_kube_podspec": "---\napiVersion: v1\nkind: Pod\nspec:\n  containers:\n  - name: worker\n    image: centos:8\n    command:\n    - bash\n    args:\n    - \"-c\"\n    - for i in {1..5}; do echo $i;done\n", "secret_kube_config": "%s"}`, kubeconfig)
 	unitID, err := controller.WorkSubmitJSON(command)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -613,11 +613,11 @@ func TestKubeRuntimeParams(t *testing.T) {
 			},
 			map[interface{}]interface{}{
 				"work-kubernetes": map[interface{}]interface{}{
-					"workType":            "echo",
-					"authmethod":          "runtime",
-					"namespace":           "default",
-					"allowruntimepodspec": true,
-					"allowruntimeauth":    true,
+					"workType":         "echo",
+					"authmethod":       "runtime",
+					"namespace":        "default",
+					"allowruntimepod":  true,
+					"allowruntimeauth": true,
 				},
 			},
 		},
@@ -634,7 +634,7 @@ func TestKubeRuntimeParams(t *testing.T) {
 	nodes := m.Nodes()
 	controller := receptorcontrol.New()
 	err = controller.Connect(nodes["node0"].ControlSocket())
-	command := fmt.Sprintf(`{"command": "work", "subcommand": "submit", "node": "localhost", "worktype": "echo", "secret_kube_podspec": "---\napiVersion: v1\nkind: Pod\nspec:\n  containers:\n  - name: worker\n    image: centos:8\n    command:\n    - bash\n    args:\n    - \"-c\"\n    - for i in {1..5}; do echo $i;done\n", "secret_kube_config": "%s"}`, kubeconfig)
+	command := fmt.Sprintf(`{"command": "work", "subcommand": "submit", "node": "localhost", "worktype": "echo", "secret_kube_pod": "---\napiVersion: v1\nkind: Pod\nspec:\n  containers:\n  - name: worker\n    image: centos:8\n    command:\n    - bash\n    args:\n    - \"-c\"\n    - for i in {1..5}; do echo $i;done\n", "secret_kube_config": "%s"}`, kubeconfig)
 	unitID, err := controller.WorkSubmitJSON(command)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
I should have looked more closely at https://github.com/project-receptor/receptor/pull/276 before we merged it. For the AWX use case we need to be able to pass in a full `Pod` definition, not just the `spec:` field. This was my fault, because I was used the term 'pod spec' when making this request, without knowing that it was its own distinct object type.