### PR TITLE
Add ability to generate a CSR re-using an existing key

### DIFF
--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -178,7 +178,7 @@ func GenerateCert(name, commonName string, DNSNames, NodeIDs []string) (string, 
 		return "", "", err
 	}
 	// Create certificate request
-	req, key, err := certificates.CreateCertReq(&certificates.CertOptions{
+	req, key, err := certificates.CreateCertReqWithKey(&certificates.CertOptions{
 		CommonName: commonName,
 		Bits:       2048,
 		CertNames: certificates.CertNames{
@@ -225,7 +225,7 @@ func GenerateCertWithCA(name, caKeyPath, caCrtPath, commonName string, DNSNames,
 	keyPath := filepath.Join(dir, name+".key")
 	crtPath := filepath.Join(dir, name+".crt")
 	// Create certificate request
-	req, key, err := certificates.CreateCertReq(&certificates.CertOptions{
+	req, key, err := certificates.CreateCertReqWithKey(&certificates.CertOptions{
 		CommonName: commonName,
 		Bits:       2048,
 		CertNames: certificates.CertNames{


### PR DESCRIPTION
This PR does two things:

* Updates the API and CLI to allow generating and signing a new CSR generated from an already-existing private key (ie, a renewal);
* Adds `--cert-signreq verify=true` to suppress the interactive prompt when signing a certificate through the CLI, for batch mode use.