### PR TITLE
Fix bug in slice type conversion

### DIFF
--- a/pkg/cmdline/cmdline.go
+++ b/pkg/cmdline/cmdline.go
@@ -334,7 +334,7 @@ func setValue(field *reflect.Value, value interface{}) error {
 			if !item.Type().ConvertibleTo(fieldType.Elem()) {
 				return fmt.Errorf("invalid value %s: must be type %s", item, fieldType.Elem())
 			}
-			reflect.Append(fieldSlice, item.Convert(fieldType.Elem()))
+			fieldSlice = reflect.Append(fieldSlice, item.Convert(fieldType.Elem()))
 		}
 		field.Set(fieldSlice)
 		return nil


### PR DESCRIPTION
When passed a slice from a yaml config file, we receive a slice of `interface{}`.  In cases where we need a specific type, like a parameter of type `[]string`, we do type conversion to get the `interface{}` to the target type.  Unfortunately this loop was ignoring the result of `reflect.Append`, so we were always returning an empty slice.  See https://github.com/project-receptor/receptor/issues/291.