### PR TITLE
Retry flock locking calls

### DIFF
--- a/pkg/utils/flock.go
+++ b/pkg/utils/flock.go
@@ -5,6 +5,7 @@ package utils
 import (
 	"fmt"
 	"syscall"
+	"time"
 )
 
 // ErrLocked is returned when the flock is already held
@@ -16,18 +17,28 @@ type FLock struct {
 }
 
 // TryFLock non-blockingly attempts to acquire a lock on the file
-func TryFLock(filename string) (*FLock, error) {
-	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0600)
-	if err != nil {
-		return nil, err
-	}
-	err = syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
-	if err == syscall.EWOULDBLOCK {
-		err = ErrLocked
-	}
-	if err != nil {
-		_ = syscall.Close(fd)
-		return nil, err
+func TryFLock(filename string, retries int, delay time.Duration) (*FLock, error) {
+	remainingRetries := retries
+	var fd int
+	var err error
+	for {
+		fd, err = syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0600)
+		if err == nil {
+			err = syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB)
+			if err == syscall.EWOULDBLOCK {
+				err = ErrLocked
+			}
+			if err == nil {
+				break
+			} else {
+				_ = syscall.Close(fd)
+			}
+		}
+		if remainingRetries <= 0 {
+			return nil, err
+		}
+		remainingRetries--
+		time.Sleep(delay)
 	}
 	return &FLock{fd: fd}, nil
 }

--- a/pkg/utils/flock_windows.go
+++ b/pkg/utils/flock_windows.go
@@ -4,6 +4,7 @@ package utils
 
 import (
 	"fmt"
+	"time"
 )
 
 // ErrLocked is returned when the flock is already held
@@ -14,7 +15,7 @@ type FLock struct {
 }
 
 // TryFLock is not implemented on Windows
-func TryFLock(filename string) (*FLock, error) {
+func TryFLock(filename string, retries int, delay time.Duration) (*FLock, error) {
 	return nil, fmt.Errorf("file locks not implemented on Windows")
 }
 

--- a/pkg/utils/unixsock.go
+++ b/pkg/utils/unixsock.go
@@ -6,11 +6,12 @@ import (
 	"fmt"
 	"net"
 	"os"
+	"time"
 )
 
 // UnixSocketListen listens on a Unix socket, handling file locking and permissions
 func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, *FLock, error) {
-	lock, err := TryFLock(filename + ".lock")
+	lock, err := TryFLock(filename+".lock", 3, 100*time.Millisecond)
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not acquire lock on socket file: %s", err)
 	}


### PR DESCRIPTION
It appears that when the tests very quickly kill and restart Receptor, the call to lock the control socket fails.  This PR adds retry logic so we don't error out immediately in this case.