### PR TITLE
Close logStream if Stdin is not passed correctly, to prevent hang

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -348,6 +348,9 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 				Stdin: stdin,
 				Tty:   false,
 			})
+			if errStdin != nil {
+				logStream.Close()
+			}
 			streamWait.Done()
 		}()
 	}


### PR DESCRIPTION
If `errStdin` is not `nil`, we need to close out of the `io.Copy` go routine. To do this, we can simply close the `logStream` connection.

see https://github.com/project-receptor/receptor/pull/298 for more details about the scenario that causes the hang.