### PR TITLE
Fix bug when releasing pods under worktype w/ "incluster" auth

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -795,7 +795,7 @@ func (kw *kubeUnit) Start() error {
 // Cancel releases resources associated with a job, including cancelling it if running.
 func (kw *kubeUnit) Cancel() error {
 	if kw.pod != nil {
-		err := kw.clientset.CoreV1().Pods(kw.status.ExtraData.(*kubeExtraData).KubeNamespace).Delete(context.Background(), kw.pod.Name, metav1.DeleteOptions{})
+		err := kw.clientset.CoreV1().Pods(kw.pod.Namespace).Delete(context.Background(), kw.pod.Name, metav1.DeleteOptions{})
 		if err != nil {
 			logger.Error("Error deleting pod %s: %s", kw.pod.Name, err)
 		}


### PR DESCRIPTION
Without this, we were seeing:

```
ERROR 2021/03/02 13:35:40 Error deleting pod awx-job-12-8d6fs: an empty namespace may not be set when a resource name is provided
```