### PR TITLE
gitignore: Only ignore top level net folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ receptor
 receptor.exe
 receptor.app
 recepcert
-net
+/net
 receptorctl-test-venv/
 rpmbuild/
 .container-flag*


### PR DESCRIPTION
Currently all net folders are ignored by git. This leads to unexpected
issues. The expected intent was to only ignore the root net file, so
let's do that.