### PR TITLE
Obtain status file lock when updating full status

### DIFF
--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -251,6 +251,8 @@ func (sfd *StatusFileData) UpdateFullStatus(filename string, statusFunc func(*St
 // UpdateFullStatus atomically updates the whole status record.  Changes should be made in the callback function.
 // Errors are logged rather than returned.
 func (bwu *BaseWorkUnit) UpdateFullStatus(statusFunc func(*StatusFileData)) {
+	bwu.statusLock.Lock()
+	defer bwu.statusLock.Unlock()
 	err := bwu.status.UpdateFullStatus(bwu.statusFileName, statusFunc)
 	bwu.lastUpdateError = err
 	if err != nil {


### PR DESCRIPTION
We are randomly seeing errors that look like this:

```
2021-05-03 07:59:09,461 ERROR    [a40f6c03679040dc990455ce2422c80c] awx.main.tasks job 111 (running) Exception occurred while running task
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 1427, in run
    res = receptor_job.run()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/awx/main/tasks.py", line 2969, in run
    receptor_ctl.simple_command(f"work release {self.unit_id}")
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/receptorctl/socket_interface.py", line 72, in simple_command
    return self.read_and_parse_json()
  File "/var/lib/awx/venv/awx/lib64/python3.8/site-packages/receptorctl/socket_interface.py", line 51, in read_and_parse_json
    raise RuntimeError(text[7:])
RuntimeError: unlinkat /tmp/receptor/example.com/S4kPB890: directory not empty
```