### PR TITLE
Ensure that status lockfile is closed before trying to release work

### DIFF
--- a/pkg/workceptor/interfaces.go
+++ b/pkg/workceptor/interfaces.go
@@ -1,5 +1,9 @@
 package workceptor
 
+import (
+	"github.com/rogpeppe/go-internal/lockedfile"
+)
+
 // WorkUnit represents a local unit of work
 type WorkUnit interface {
 	ID() string
@@ -31,4 +35,5 @@ type StatusFileData struct {
 	StdoutSize int64
 	WorkType   string
 	ExtraData  interface{}
+	LockFile   *lockedfile.File
 }


### PR DESCRIPTION
For context, see:

- https://github.com/ansible/receptor/pull/319
- https://github.com/ansible/awx/issues/9961