### PR TITLE
Add unit_id option for work list

### DIFF
--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -44,7 +44,7 @@ func (t *workceptorCommandType) InitFromString(params string) (controlsvc.Contro
 		}
 	case "list":
 		if len(tokens) > 1 {
-			return nil, fmt.Errorf("work list does not take parameters")
+			c.params["unitid"] = tokens[1]
 		}
 	case "status", "cancel", "release", "force-release":
 		if len(tokens) < 2 {
@@ -144,6 +144,11 @@ func (t *workceptorCommandType) InitFromJSON(config map[string]interface{}) (con
 		if err != nil {
 			return nil, err
 		}
+	case "list":
+		unitID, err := strFromMap(config, "unitid")
+		if err == nil {
+			c.params["unitid"] = unitID
+		}
 	case "results":
 		c.params["unitid"], err = strFromMap(config, "unitid")
 		if err != nil {
@@ -231,6 +236,10 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		return cfr, nil
 	case "list":
 		unitList := c.w.ListKnownUnitIDs()
+		targetUnitID, ok := c.params["unitid"].(string)
+		if ok {
+			unitList = []string{targetUnitID}
+		}
 		cfr := make(map[string]interface{})
 		for i := range unitList {
 			unitID := unitList[i]

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -235,10 +235,12 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		}
 		return cfr, nil
 	case "list":
-		unitList := c.w.ListKnownUnitIDs()
+		var unitList []string
 		targetUnitID, ok := c.params["unitid"].(string)
 		if ok {
 			unitList = []string{targetUnitID}
+		} else {
+			unitList = c.w.ListKnownUnitIDs()
 		}
 		cfr := make(map[string]interface{})
 		for i := range unitList {

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -238,7 +238,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		var unitList []string
 		targetUnitID, ok := c.params["unitid"].(string)
 		if ok {
-			unitList = []string{targetUnitID}
+			unitList = append(unitList, targetUnitID)
 		} else {
 			unitList = c.w.ListKnownUnitIDs()
 		}

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -223,14 +223,17 @@ def version(ctx):
 @work.command(help="List known units of work.")
 @click.option('--quiet', '-q', is_flag=True, help="Only list unit IDs with no detail")
 @click.option('--node', default=None, type=str, help="Receptor node to list work from. Defaults to the local node.")
+@click.option('--unit_id', type=str, required=False, default="", help="Only show detail for a specific unit id")
 @click.option('--tls-client', 'tlsclient', type=str, default="", help="TLS client config name used when connecting to remote node")
 @click.pass_context
-def list(ctx, node, tlsclient, quiet):
+def list(ctx, unit_id, node, tlsclient, quiet):
     rc = get_rc(ctx)
     if node:
         rc.connect_to_service(node, "control", tlsclient)
         rc.handshake()
-    work = rc.simple_command("work list")
+    if unit_id:
+        unit_id = " " + unit_id
+    work = rc.simple_command("work list" + unit_id)
     if quiet:
         for k in work.keys():
             print(k)


### PR DESCRIPTION
e.g.
`receptorctl work list --unit_id No7OYskk`

If provided, will only return status information for that work unit