### PR TITLE
Fix issue where releasing a never-started remote job caused a panic

### DIFF
--- a/pkg/utils/job_context.go
+++ b/pkg/utils/job_context.go
@@ -63,8 +63,11 @@ func (mw *JobContext) WorkerDone() {
 }
 
 // Wait waits for the current job to complete, like sync.WaitGroup.Wait().
+// If no job has been started, always just returns.
 func (mw *JobContext) Wait() {
-	mw.wg.Wait()
+	if mw.wg != nil {
+		mw.wg.Wait()
+	}
 }
 
 // Done implements Context.Done()
@@ -87,9 +90,11 @@ func (mw *JobContext) Value(key interface{}) interface{} {
 	return mw.ctx.Value(key)
 }
 
-// Cancel cancels the JobContext's context
+// Cancel cancels the JobContext's context.  If no job has been started, this does nothing.
 func (mw *JobContext) Cancel() {
-	mw.cancel()
+	if mw.cancel != nil {
+		mw.cancel()
+	}
 }
 
 // Running returns true if a job is currently running

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -556,6 +556,7 @@ func (rw *remoteUnit) cancelOrRelease(release bool, force bool) error {
 		if release {
 			return rw.BaseWorkUnit.Release(true)
 		}
+		rw.UpdateBasicStatus(WorkStateFailed, "Locally Cancelled", 0)
 		return nil
 	}
 	if release && force {


### PR DESCRIPTION
See https://github.com/ansible/receptor/issues/317.  What's going on here is:

- Receptor is trying to "restart" a remote job, but has never actually started it.
- A `JobContext` has been created, but `NewJob` has never been called on it.
- Therefore, the fields of the `JobContext` - `ctx`, `cancel`, `wg` etc - are all nil.
- When the user releases the job, it attempts to cancel the context.
- This results in calling a nil function.

The fix is:

- The `JobContext.Cancel()` and `JobContext.Wait()` functions should just be no-ops if `NewJob` was never cancelled.