### PR TITLE
Do not scan for units when listing work units

### DIFF
--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -279,7 +279,6 @@ func (w *Workceptor) StartUnit(unitID string) error {
 
 // ListKnownUnitIDs returns a slice containing the known unit IDs
 func (w *Workceptor) ListKnownUnitIDs() []string {
-	w.scanForUnits()
 	w.activeUnitsLock.RLock()
 	defer w.activeUnitsLock.RUnlock()
 	result := make([]string, 0, len(w.activeUnits))


### PR DESCRIPTION
`scanForUnits` is called when receptor first starts, and is what populates the in-memory list of `activeUnits`

This method is called each `work list` is called. This could be an expensive operation if there are a lot of work units on disk. Given we scan at receptor start up, and units are added and removed to `activeUnits` during work submit / release, I believe we are safe to remove this scan in the case of `work list`.