### PR TITLE
[backport] Do not scan for units when listing work units

### DIFF
--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -279,7 +279,6 @@ func (w *Workceptor) StartUnit(unitID string) error {
 
 // ListKnownUnitIDs returns a slice containing the known unit IDs
 func (w *Workceptor) ListKnownUnitIDs() []string {
-	w.scanForUnits()
 	w.activeUnitsLock.RLock()
 	defer w.activeUnitsLock.RUnlock()
 	result := make([]string, 0, len(w.activeUnits))


### PR DESCRIPTION
related https://github.com/ansible/receptor/pull/339