### PR TITLE
Switch container & CI images from Fedora to CentOS 8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,16 @@
 # Calculate version number
 # - If we are on an exact Git tag, then this is official and gets a -1 release
 # - If we are not, then this is unofficial and gets a -0.date.gitref release
-OFFICIAL_VERSION = $(shell if VER=`git describe --exact-match --tags 2>/dev/null`; then echo $$VER; else echo ""; fi)
-VERSION = $(shell cd receptorctl && python3 setup.py --version)
+OFFICIAL_VERSION := $(shell if VER=`git describe --exact-match --tags 2>/dev/null`; then echo $$VER; else echo ""; fi)
+VERSION := $(shell cd receptorctl && python3 setup.py --version)
 ifeq ($(OFFICIAL_VERSION),)
-RELEASE = 0.git$(shell date +'%Y%m%d').$(shell git rev-parse --short HEAD)
-OFFICIAL =
-APPVER = $(VERSION)-$(RELEASE)
+RELEASE := 0.git$(shell date +'%Y%m%d').$(shell git rev-parse --short HEAD)
+OFFICIAL :=
+APPVER := $(VERSION)-$(RELEASE)
 else
-RELEASE = 1
-OFFICIAL = yes
-APPVER = $(VERSION)
+RELEASE := 1
+OFFICIAL := yes
+APPVER := $(VERSION)
 endif
 
 # Container command can be docker or podman

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # - If we are on an exact Git tag, then this is official and gets a -1 release
 # - If we are not, then this is unofficial and gets a -0.date.gitref release
 OFFICIAL_VERSION = $(shell if VER=`git describe --exact-match --tags 2>/dev/null`; then echo $$VER; else echo ""; fi)
-VERSION = $(shell cd receptorctl && python setup.py --version)
+VERSION = $(shell cd receptorctl && python3 setup.py --version)
 ifeq ($(OFFICIAL_VERSION),)
 RELEASE = 0.git$(shell date +'%Y%m%d').$(shell git rev-parse --short HEAD)
 OFFICIAL =

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ else
 endif
 
 receptor: $(shell find pkg -type f -name '*.go') cmd/receptor.go
-	go build -ldflags "-X 'github.com/project-receptor/receptor/pkg/version.Version=$(APPVER)'" $(TAGPARAM) cmd/receptor.go
+	CGO_ENABLED=0 go build -ldflags "-X 'github.com/project-receptor/receptor/pkg/version.Version=$(APPVER)'" $(TAGPARAM) cmd/receptor.go
 
 lint:
 	@golint cmd/... pkg/... example/...
@@ -152,7 +152,7 @@ $(RECEPTOR_PYTHON_WORKER_WHEEL): receptor-python-worker/README.md receptor-pytho
 	@cd receptor-python-worker && python3 setup.py bdist_wheel
 
 container: .container-flag-$(VERSION)
-.container-flag-$(VERSION): $(RECEPTORCTL_WHEEL) $(RECEPTOR_PYTHON_WORKER_WHEEL)
+.container-flag-$(VERSION): receptor $(RECEPTORCTL_WHEEL) $(RECEPTOR_PYTHON_WORKER_WHEEL)
 	@tar --exclude-vcs-ignores -czf packaging/container/source.tar.gz .
 	@cp $(RECEPTORCTL_WHEEL) packaging/container
 	@cp $(RECEPTOR_PYTHON_WORKER_WHEEL) packaging/container

--- a/packaging/ci-image/Dockerfile
+++ b/packaging/ci-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:34
 ARG UID=1001
 RUN dnf -y update && \
   dnf -y install git golang python3 python3-pip python3-pyyaml make iproute openssl && \

--- a/packaging/ci-image/Dockerfile
+++ b/packaging/ci-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM centos:8
 ARG UID=1001
 RUN dnf -y update && \
   dnf -y install git golang python3 python3-pip python3-pyyaml make iproute openssl && \

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,12 +1,12 @@
-FROM fedora:32 as builder
+FROM fedora:34 as builder
 
-RUN dnf -y update && dnf install -y golang make
+RUN dnf -y update && dnf install -y golang make python3 python3-pip python3-wheel
 
 ADD source.tar.gz /source
 WORKDIR /source
 RUN make
 
-FROM fedora:32
+FROM fedora:34
 ARG VERSION
 
 LABEL license="ASL2"
@@ -15,7 +15,7 @@ LABEL vendor="project-receptor"
 LABEL version="${VERSION}"
 
 RUN dnf -y update && \
-    dnf -y install dumb-init python3-click python3-pyyaml python3-dateutil python3-pip && \
+    dnf -y install dumb-init python3-click python3-pyyaml python3-dateutil python3-pip python3-wheel && \
     dnf clean all
 
 COPY receptorctl-${VERSION}-py3-none-any.whl /tmp

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:34 as builder
+FROM centos:8 as builder
 
 RUN dnf -y update && dnf install -y golang make python3 python3-pip python3-wheel
 
@@ -6,7 +6,7 @@ ADD source.tar.gz /source
 WORKDIR /source
 RUN make
 
-FROM fedora:34
+FROM centos:8
 ARG VERSION
 
 LABEL license="ASL2"
@@ -15,7 +15,8 @@ LABEL vendor="project-receptor"
 LABEL version="${VERSION}"
 
 RUN dnf -y update && \
-    dnf -y install dumb-init python3-click python3-pyyaml python3-dateutil python3-pip python3-wheel && \
+    dnf -y install epel-release && \
+    dnf -y install tini python3-click python3-pyyaml python3-dateutil python3-pip python3-wheel && \
     dnf clean all
 
 COPY receptorctl-${VERSION}-py3-none-any.whl /tmp
@@ -30,5 +31,5 @@ ENV RECEPTORCTL_SOCKET=/tmp/receptor.sock
 
 EXPOSE 7323
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/tini", "--"]
 CMD ["/usr/bin/receptor", "-c", "/etc/receptor/receptor.conf"]


### PR DESCRIPTION
The Receptor container and CI images are still using Fedora 32, which is EOL.  This PR updates to Fedora 34.