### PR TITLE
Add security features

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -18,8 +18,9 @@ import (
 )
 
 type nodeCfg struct {
-	ID      string `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
-	DataDir string `description:"Directory in which to store node data"`
+	ID            string   `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
+	DataDir       string   `description:"Directory in which to store node data"`
+	FirewallRules []string `description:"Firewall Rules (see documentation for syntax)"`
 }
 
 func (cfg nodeCfg) Init() error {
@@ -39,6 +40,16 @@ func (cfg nodeCfg) Init() error {
 		return fmt.Errorf("node ID \"localhost\" is reserved")
 	}
 	netceptor.MainInstance = netceptor.New(context.Background(), cfg.ID)
+	if len(cfg.FirewallRules) > 0 {
+		rules, err := netceptor.ParseFirewallRules(cfg.FirewallRules)
+		if err != nil {
+			return err
+		}
+		err = netceptor.MainInstance.AddFirewallRules(rules, true)
+		if err != nil {
+			return err
+		}
+	}
 	workceptor.MainInstance, err = workceptor.New(context.Background(), netceptor.MainInstance, cfg.DataDir)
 	if err != nil {
 		return err

--- a/example/net.go
+++ b/example/net.go
@@ -21,8 +21,8 @@ func main() {
 	logger.QuietMode()
 
 	// Create two nodes of the Receptor network-layer protocol (Netceptors).
-	n1 := netceptor.New(context.Background(), "node1", nil)
-	n2 := netceptor.New(context.Background(), "node2", nil)
+	n1 := netceptor.New(context.Background(), "node1")
+	n2 := netceptor.New(context.Background(), "node2")
 
 	// Start a TCP listener on the first node
 	b1, err := backends.NewTCPListener("localhost:3333", nil)
@@ -30,7 +30,7 @@ func main() {
 		fmt.Printf("Error listening on TCP: %s\n", err)
 		os.Exit(1)
 	}
-	err = n1.AddBackend(b1, 1.0, nil)
+	err = n1.AddBackend(b1)
 	if err != nil {
 		fmt.Printf("Error starting backend: %s\n", err)
 		os.Exit(1)
@@ -42,7 +42,7 @@ func main() {
 		fmt.Printf("Error dialing on TCP: %s\n", err)
 		os.Exit(1)
 	}
-	err = n2.AddBackend(b2, 1.0, nil)
+	err = n2.AddBackend(b2)
 	if err != nil {
 		fmt.Printf("Error starting backend: %s\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/project-receptor/receptor
 go 1.15
 
 require (
+	github.com/alecthomas/participle/v2 v2.0.0-alpha6
 	github.com/creack/pty v1.1.11
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,10 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/alecthomas/participle/v2 v2.0.0-alpha6 h1:6IeFBBLWi0xcTk4ModH9UKkLBYf5l5OzaYkJOjZW1rg=
+github.com/alecthomas/participle/v2 v2.0.0-alpha6/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -249,10 +249,11 @@ func (ns *UDPListenerSession) Close() error {
 
 // udpListenerCfg is the cmdline configuration object for a UDP listener
 type udpListenerCfg struct {
-	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
-	Port     int                `description:"Local UDP port to listen on" barevalue:"yes" required:"yes"`
-	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
-	NodeCost map[string]float64 `description:"Per-node costs"`
+	BindAddr     string             `description:"Local address to bind to" default:"0.0.0.0"`
+	Port         int                `description:"Local UDP port to listen on" barevalue:"yes" required:"yes"`
+	Cost         float64            `description:"Connection cost (weight)" default:"1.0"`
+	NodeCost     map[string]float64 `description:"Per-node costs"`
+	AllowedPeers []string           `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies the parameters are correct
@@ -276,7 +277,10 @@ func (cfg udpListenerCfg) Run() error {
 		logger.Error("Error creating listener %s: %s\n", address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCost)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendNodeCost(cfg.NodeCost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		logger.Error("Error creating backend for %s: %s\n", address, err)
 		return err
@@ -286,9 +290,10 @@ func (cfg udpListenerCfg) Run() error {
 
 // udpDialerCfg is the cmdline configuration object for a UDP listener
 type udpDialerCfg struct {
-	Address string  `description:"Host:Port to connect to" barevalue:"yes" required:"yes"`
-	Redial  bool    `description:"Keep redialing on lost connection" default:"true"`
-	Cost    float64 `description:"Connection cost (weight)" default:"1.0"`
+	Address      string   `description:"Host:Port to connect to" barevalue:"yes" required:"yes"`
+	Redial       bool     `description:"Keep redialing on lost connection" default:"true"`
+	Cost         float64  `description:"Connection cost (weight)" default:"1.0"`
+	AllowedPeers []string `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies the parameters are correct
@@ -307,7 +312,9 @@ func (cfg udpDialerCfg) Run() error {
 		logger.Error("Error creating peer %s: %s\n", cfg.Address, err)
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, nil)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		logger.Error("Error creating backend for %s: %s\n", cfg.Address, err)
 		return err

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -22,12 +22,12 @@ import (
 func TestWebsocketExternalInterop(t *testing.T) {
 
 	// Create a Netceptor with an external backend
-	n1 := netceptor.New(context.Background(), "node1", nil)
+	n1 := netceptor.New(context.Background(), "node1")
 	b1, err := netceptor.NewExternalBackend()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n1.AddBackend(b1, 1.0, nil)
+	err = n1.AddBackend(b1)
 
 	// Create a server TLS certificate for "localhost"
 	key, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -88,7 +88,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 	}()
 
 	// Create a Netceptor websocket client that connects to our server
-	n2 := netceptor.New(context.Background(), "node2", nil)
+	n2 := netceptor.New(context.Background(), "node2")
 	CAcerts := x509.NewCertPool()
 	CAcerts.AppendCertsFromPEM(certPEM)
 	tls2 := &tls.Config{
@@ -99,7 +99,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n2.AddBackend(b2, 1.0, nil)
+	err = n2.AddBackend(b2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -69,7 +69,7 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 	pc := &PacketConn{
 		s:            s,
 		localService: service,
-		recvChan:     make(chan *messageData),
+		recvChan:     make(chan *MessageData),
 		advertise:    advertise,
 		adTags:       adTags,
 		connType:     connType,

--- a/pkg/netceptor/firewall_rules.go
+++ b/pkg/netceptor/firewall_rules.go
@@ -1,0 +1,206 @@
+package netceptor
+
+import (
+	"fmt"
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer/stateful"
+	"regexp"
+	"strings"
+)
+
+/*
+
+This file provides a parser for firewall rules provided by the CLI.  It takes strings
+and returns rule functions suitable for passing to AddFirewallRules().
+
+The firewall language is as follows:
+
+RULE[, RULE, ...]: ACTION
+
+Each RULE is either the word "all", or an expression of the form field=value or field=/regex/, where field
+can be FromNode, FromService, ToNode or ToService.  Regular expressions must match the whole string, not
+a substring.  A special RULE of "all" matches everything.  ACTION can be one of Accept, Reject or Drop.
+All tokens are case insensitive and all whitespace is optional; field values contents are case sensitive.
+
+Example rules:
+
+all:accept
+  Accepts everything
+
+FromNode=foo, ToNode=bar, ToService=control: drop
+  Silently drops messages from foo to bar's control service
+  Note that "foo", "bar" and "control" are case sensitive
+
+fromnode = /a.*b/ : reject
+  Rejects messages originating from any node whose node ID starts with a and ends with b
+
+TONODE = /(?i)a.*b/ : reject
+  Rejects messages destined for any node whose node ID starts with a or A and ends with b or B
+
+*/
+
+// ParseFirewallRule takes a single string describing a firewall rule, and returns a FirewallRule function
+func ParseFirewallRule(rule string) (FirewallRule, error) {
+	parsedRule := &ruleString{}
+	err := ruleParser.ParseString("rule", rule, parsedRule)
+	if err != nil {
+		return nil, err
+	}
+	comps := make([]compareFunc, 0)
+	for _, pr := range parsedRule.RuleSpec.Rules {
+		if pr.Value.Value != "" {
+			comp, err := stringCompare(pr.Field, pr.Value.Value)
+			if err != nil {
+				return nil, err
+			}
+			comps = append(comps, comp)
+		} else if pr.Value.Regex != "" {
+			comp, err := regexCompare(pr.Field, pr.Value.Regex)
+			if err != nil {
+				return nil, err
+			}
+			comps = append(comps, comp)
+		} else {
+			return nil, fmt.Errorf("no value or regex provided for field %s", pr.Field)
+		}
+	}
+	fwr, err := firewallRule(comps, parsedRule.Action)
+	if err != nil {
+		return nil, err
+	}
+	return fwr, nil
+}
+
+// ParseFirewallRules takes a slice of string describing firewall rules, and returns a slice of FirewallRule functions
+func ParseFirewallRules(rules []string) ([]FirewallRule, error) {
+	results := make([]FirewallRule, 0)
+	for i, rule := range rules {
+		result, err := ParseFirewallRule(rule)
+		if err != nil {
+			return nil, fmt.Errorf("error in rule %d: %s", i, err)
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+type compareFunc func(md *MessageData) bool
+
+func firewallRule(comparers []compareFunc, action string) (FirewallRule, error) {
+	var result FirewallResult
+	switch strings.ToLower(action) {
+	case "accept":
+		result = FirewallResultAccept
+	case "reject":
+		result = FirewallResultReject
+	case "drop":
+		result = FirewallResultDrop
+	default:
+		return nil, fmt.Errorf("unknown action: %s", action)
+	}
+	if len(comparers) == 0 {
+		return func(md *MessageData) FirewallResult {
+			return result
+		}, nil
+	}
+	return func(md *MessageData) FirewallResult {
+		matched := true
+		for _, comp := range comparers {
+			matched = matched && comp(md)
+		}
+		if matched {
+			return result
+		}
+		return FirewallResultContinue
+	}, nil
+}
+
+func stringCompare(field string, value string) (compareFunc, error) {
+	switch strings.ToLower(field) {
+	case "fromnode":
+		return func(md *MessageData) bool {
+			return md.FromNode == value
+		}, nil
+	case "fromservice":
+		return func(md *MessageData) bool {
+			return md.FromService == value
+		}, nil
+	case "tonode":
+		return func(md *MessageData) bool {
+			return md.ToNode == value
+		}, nil
+	case "toservice":
+		return func(md *MessageData) bool {
+			return md.ToService == value
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown field: %s", field)
+}
+
+func regexCompare(field string, value string) (compareFunc, error) {
+	if value[0] != '/' || value[len(value)-1] != '/' {
+		return nil, fmt.Errorf("regex not enclosed in //")
+	}
+	value = fmt.Sprintf("^%s$", value[1:len(value)-1])
+	re, err := regexp.Compile(value)
+	if err != nil {
+		return nil, fmt.Errorf("regex failed to compile: %s", value)
+	}
+	switch strings.ToLower(field) {
+	case "fromnode":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.FromNode)
+		}, nil
+	case "fromservice":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.FromService)
+		}, nil
+	case "tonode":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.ToNode)
+		}, nil
+	case "toservice":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.ToService)
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown field: %s", field)
+}
+
+//goland:noinspection GoVetStructTag
+type ruleString struct {
+	RuleSpec *ruleSpec `@@`
+	Action   string    `":" @Ident`
+}
+
+//goland:noinspection GoVetStructTag
+type ruleSpec struct {
+	All   string  `@"all"`
+	Rules []*rule `| @@ ( "," @@ )*`
+}
+
+//goland:noinspection GoVetStructTag
+type rule struct {
+	Field string     `@Ident`
+	Value *ruleValue `@@`
+}
+
+//goland:noinspection GoVetStructTag
+type ruleValue struct {
+	Value string `"=" (@Ident|@Text)`
+	Regex string `| "=" @Regex`
+}
+
+var (
+	ruleLexer = stateful.MustSimple([]stateful.Rule{
+		{"Ident", `\w+`, nil},
+		{"Regex", `\/((?:[^/\\]|\\.)*)\/`, nil},
+		{"Text", `[^/,:= \t\r\n][^,:= \t\r\n]*`, nil},
+		{"Whitespace", `\s+`, nil},
+		{"Punctuation", `[-[~!@#$%^&*()+_={}\|:;"'<,>.?/]|]`, nil},
+	})
+	ruleParser = participle.MustBuild(&ruleString{},
+		participle.Lexer(ruleLexer),
+		participle.Elide("Whitespace"),
+		participle.UseLookahead(2))
+)

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -1,0 +1,72 @@
+package netceptor
+
+import (
+	"testing"
+)
+
+func TestFirewallRules(t *testing.T) {
+
+	// Rule #1
+	rule, err := ParseFirewallRule("all:accept")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultAccept {
+		t.Fatal("rule #1 did not return Accept")
+	}
+
+	// Rule #2
+	rule, err = ParseFirewallRule("FromNode=foo, ToNode=bar, ToService=control: drop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultContinue {
+		t.Fatal("rule #2 did not return Continue")
+	}
+	if rule(&MessageData{
+		FromNode:  "foo",
+		ToNode:    "bar",
+		ToService: "control",
+	}) != FirewallResultDrop {
+		t.Fatal("rule #2 did not return Drop")
+	}
+
+	// Rule #3
+	rule, err = ParseFirewallRule("fromnode = /a.*b/ : reject")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultContinue {
+		t.Fatal("rule #3 did not return Continue")
+	}
+	if rule(&MessageData{
+		FromNode: "appleb",
+	}) != FirewallResultReject {
+		t.Fatal("rule #3 did not return Reject")
+	}
+	if rule(&MessageData{
+		FromNode: "Appleb",
+	}) != FirewallResultContinue {
+		t.Fatal("rule #3 did not return Continue")
+	}
+
+	// Rule #4
+	rule, err = ParseFirewallRule("TONODE = /(?i)a.*b/ : reject")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultContinue {
+		t.Fatal("rule #4 did not return Continue")
+	}
+	if rule(&MessageData{
+		ToNode: "appleb",
+	}) != FirewallResultReject {
+		t.Fatal("rule #4 did not return Reject")
+	}
+	if rule(&MessageData{
+		ToNode: "Appleb",
+	}) != FirewallResultReject {
+		t.Fatal("rule #4 did not return Reject")
+	}
+
+}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -78,6 +78,21 @@ type BackendSession interface {
 	Close() error
 }
 
+// FirewallRule is a function that takes a message and returns a firewall decision.
+type FirewallRule func(*MessageData) FirewallResult
+
+// FirewallResult enumerates the actions that can be taken as a result of a firewall rule
+type FirewallResult int
+
+const (
+	// FirewallResultAccept accepts the message for normal processing
+	FirewallResultAccept FirewallResult = iota
+	// FirewallResultReject denies the message, sending an unreachable message to the originator
+	FirewallResultReject
+	// FirewallResultDrop denies the message silently, leaving the originator to time out
+	FirewallResultDrop
+)
+
 // Netceptor is the main object of the Receptor mesh network protocol
 type Netceptor struct {
 	nodeID                 string
@@ -109,7 +124,7 @@ type Netceptor struct {
 	cancelFunc             context.CancelFunc
 	hashLock               *sync.RWMutex
 	nameHashes             map[uint64]string
-	reservedServices       map[string]func(*messageData) error
+	reservedServices       map[string]func(*MessageData) error
 	serviceAdsLock         *sync.RWMutex
 	serviceAdsReceived     map[string]map[string]*ServiceAdvertisement
 	sendServiceAdsChan     chan time.Duration
@@ -120,6 +135,8 @@ type Netceptor struct {
 	clientTLSConfigs       map[string]*tls.Config
 	unreachableBroker      *utils.Broker
 	routingUpdateBroker    *utils.Broker
+	firewallLock           *sync.RWMutex
+	firewallRules          []FirewallRule
 }
 
 // ConnStatus holds information about a single connection in the Status struct.
@@ -154,9 +171,12 @@ const (
 	ProblemServiceUnknown = "service unknown"
 	// ProblemExpiredInTransit occurs when a message's HopsToLive expires in transit
 	ProblemExpiredInTransit = "message expired"
+	// ProblemRejected occurs when a packet is rejected by a firewall rule
+	ProblemRejected = "blocked by firewall"
 )
 
-type messageData struct {
+// MessageData contains a single message packet from the network
+type MessageData struct {
 	FromNode    string
 	FromService string
 	ToNode      string
@@ -292,10 +312,11 @@ func NewWithConsts(ctx context.Context, NodeID string, AllowedPeers []string,
 		backendWaitGroup:       sync.WaitGroup{},
 		backendCount:           0,
 		networkName:            makeNetworkName(NodeID),
-		clientTLSConfigs:       make(map[string]*tls.Config),
 		serverTLSConfigs:       make(map[string]*tls.Config),
+		clientTLSConfigs:       make(map[string]*tls.Config),
+		firewallLock:           &sync.RWMutex{},
 	}
-	s.reservedServices = map[string]func(*messageData) error{
+	s.reservedServices = map[string]func(*MessageData) error{
 		"ping":    s.handlePing,
 		"unreach": s.handleUnreachable,
 	}
@@ -488,6 +509,17 @@ func (s *Netceptor) PathCost(nodeID string) (float64, error) {
 		return 0, fmt.Errorf("node not found")
 	}
 	return cost, nil
+}
+
+// AddFirewallRules adds firewall rules, optionally clearing existing rules first.
+func (s *Netceptor) AddFirewallRules(rules []FirewallRule, clearExisting bool) error {
+	s.firewallLock.Lock()
+	defer s.firewallLock.Unlock()
+	if clearExisting {
+		s.firewallRules = nil
+	}
+	s.firewallRules = append(s.firewallRules, rules...)
+	return nil
 }
 
 func (s *Netceptor) addLocalServiceAdvertisement(service string, connType byte, tags map[string]string) {
@@ -930,8 +962,8 @@ func fixedLenBytesFromString(s string, l int) []byte {
 	return bytes
 }
 
-// Translates an incoming message from wire protocol to messageData object.
-func (s *Netceptor) translateDataToMessage(data []byte) (*messageData, error) {
+// Translates an incoming message from wire protocol to MessageData object.
+func (s *Netceptor) translateDataToMessage(data []byte) (*MessageData, error) {
 	if len(data) < 36 {
 		return nil, fmt.Errorf("data too short to be a valid message")
 	}
@@ -945,7 +977,7 @@ func (s *Netceptor) translateDataToMessage(data []byte) (*messageData, error) {
 	}
 	fromService := stringFromFixedLenBytes(data[20:28])
 	toService := stringFromFixedLenBytes(data[28:36])
-	md := &messageData{
+	md := &MessageData{
 		FromNode:    fromNode,
 		FromService: fromService,
 		ToNode:      toNode,
@@ -956,8 +988,8 @@ func (s *Netceptor) translateDataToMessage(data []byte) (*messageData, error) {
 	return md, nil
 }
 
-// Translates an outgoing message from a messageData object to wire protocol.
-func (s *Netceptor) translateDataFromMessage(msg *messageData) ([]byte, error) {
+// Translates an outgoing message from a MessageData object to wire protocol.
+func (s *Netceptor) translateDataFromMessage(msg *MessageData) ([]byte, error) {
 	data := make([]byte, 36+len(msg.Data))
 	data[0] = MsgTypeData
 	data[1] = msg.HopsToLive
@@ -970,7 +1002,7 @@ func (s *Netceptor) translateDataFromMessage(msg *messageData) ([]byte, error) {
 }
 
 // Forwards a message to its next hop
-func (s *Netceptor) forwardMessage(md *messageData) error {
+func (s *Netceptor) forwardMessage(md *MessageData) error {
 	if md.HopsToLive <= 0 {
 		if md.FromService != "unreach" {
 			_ = s.sendUnreachable(md.FromNode, &UnreachableMessage{
@@ -1014,7 +1046,7 @@ func (s *Netceptor) sendMessageWithHopsToLive(fromService string, toNode string,
 	if strings.EqualFold(toNode, "localhost") {
 		toNode = s.nodeID
 	}
-	md := &messageData{
+	md := &MessageData{
 		FromNode:    s.nodeID,
 		FromService: fromService,
 		ToNode:      toNode,
@@ -1229,12 +1261,12 @@ func (s *Netceptor) handleRoutingUpdate(ri *routingUpdate, recvConn string) {
 }
 
 // Handles a ping request
-func (s *Netceptor) handlePing(md *messageData) error {
+func (s *Netceptor) handlePing(md *MessageData) error {
 	return s.sendMessage("ping", md.FromNode, md.FromService, []byte{})
 }
 
 // Handles an unreachable response
-func (s *Netceptor) handleUnreachable(md *messageData) error {
+func (s *Netceptor) handleUnreachable(md *MessageData) error {
 	unrMsg := UnreachableMessage{}
 	err := json.Unmarshal(md.Data, &unrMsg)
 	if err != nil {
@@ -1262,7 +1294,7 @@ func (s *Netceptor) sendUnreachable(ToNode string, message *UnreachableMessage) 
 }
 
 // Dispatches a message to a reserved service.  Returns true if handled, false otherwise.
-func (s *Netceptor) dispatchReservedService(md *messageData) (bool, error) {
+func (s *Netceptor) dispatchReservedService(md *MessageData) (bool, error) {
 	svc, ok := s.reservedServices[md.ToService]
 	if ok {
 		return true, svc(md)
@@ -1271,7 +1303,32 @@ func (s *Netceptor) dispatchReservedService(md *messageData) (bool, error) {
 }
 
 // Handles incoming data and dispatches it to a service listener.
-func (s *Netceptor) handleMessageData(md *messageData) error {
+func (s *Netceptor) handleMessageData(md *MessageData) error {
+
+	// Check firewall rules for this packet
+	s.firewallLock.RLock()
+	for _, rule := range s.firewallRules {
+		switch rule(md) {
+		case FirewallResultAccept:
+			// do nothing
+		case FirewallResultDrop:
+			s.firewallLock.RUnlock()
+			return nil
+		case FirewallResultReject:
+			_ = s.sendUnreachable(md.FromNode, &UnreachableMessage{
+				FromNode:    md.FromNode,
+				ToNode:      md.ToNode,
+				FromService: md.FromService,
+				ToService:   md.ToService,
+				Problem:     ProblemRejected,
+			})
+			s.firewallLock.RUnlock()
+			return nil
+		}
+	}
+	s.firewallLock.RUnlock()
+
+	// If the destination is local, then dispatch the message to a service
 	if md.ToNode == s.nodeID {
 		handled, err := s.dispatchReservedService(md)
 		if err != nil {
@@ -1300,6 +1357,8 @@ func (s *Netceptor) handleMessageData(md *messageData) error {
 		s.listenerLock.RUnlock()
 		return nil
 	}
+
+	// The destination is non-local, so forward the message
 	return s.forwardMessage(md)
 }
 

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -50,21 +50,21 @@ func TestHopCountLimit(t *testing.T) {
 	}()
 
 	// Create two Netceptor nodes using external backends
-	n1 := New(context.Background(), "node1", nil)
+	n1 := New(context.Background(), "node1")
 	b1, err := NewExternalBackend()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n1.AddBackend(b1, 1.0, nil)
+	err = n1.AddBackend(b1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	n2 := New(context.Background(), "node2", nil)
+	n2 := New(context.Background(), "node2")
 	b2, err := NewExternalBackend()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n2.AddBackend(b2, 1.0, nil)
+	err = n2.AddBackend(b2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +86,8 @@ func TestHopCountLimit(t *testing.T) {
 	// Wait for the nodes to establish routing to each other
 	var routes1 map[string]string
 	var routes2 map[string]string
-	timeout, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	for {
 		select {
 		case <-timeout.Done():
@@ -126,7 +127,8 @@ func TestHopCountLimit(t *testing.T) {
 	}
 
 	// If the hop count limit is not working, the connections will never become inactive
-	timeout, _ = context.WithTimeout(context.Background(), 2*time.Second)
+	timeout, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	for {
 		c, ok := n1.connections["node2"]
 		if !ok {
@@ -159,20 +161,20 @@ func TestLotsOfPings(t *testing.T) {
 
 	nodes := make([]*Netceptor, numBackboneNodes)
 	for i := 0; i < numBackboneNodes; i++ {
-		nodes[i] = New(context.Background(), fmt.Sprintf("backbone_%d", i), nil)
+		nodes[i] = New(context.Background(), fmt.Sprintf("backbone_%d", i))
 	}
 	for i := 0; i < numBackboneNodes; i++ {
 		for j := 0; j < i; j++ {
 			b1, err := NewExternalBackend()
 			if err == nil {
-				err = nodes[i].AddBackend(b1, 1.0, nil)
+				err = nodes[i].AddBackend(b1)
 			}
 			if err != nil {
 				t.Fatal(err)
 			}
 			b2, err := NewExternalBackend()
 			if err == nil {
-				err = nodes[j].AddBackend(b2, 1.0, nil)
+				err = nodes[j].AddBackend(b2)
 			}
 			if err != nil {
 				t.Fatal(err)
@@ -190,16 +192,16 @@ func TestLotsOfPings(t *testing.T) {
 		for j := 0; j < numLeafNodesPerBackbone; j++ {
 			b1, err := NewExternalBackend()
 			if err == nil {
-				err = nodes[i].AddBackend(b1, 1.0, nil)
+				err = nodes[i].AddBackend(b1)
 			}
 			if err != nil {
 				t.Fatal(err)
 			}
-			newNode := New(context.Background(), fmt.Sprintf("leaf_%d_%d", i, j), nil)
+			newNode := New(context.Background(), fmt.Sprintf("leaf_%d_%d", i, j))
 			nodes = append(nodes, newNode)
 			b2, err := NewExternalBackend()
 			if err == nil {
-				err = newNode.AddBackend(b2, 1.0, nil)
+				err = newNode.AddBackend(b2)
 			}
 			if err != nil {
 				t.Fatal(err)
@@ -218,6 +220,7 @@ func TestLotsOfPings(t *testing.T) {
 		responses[i] = make([]bool, len(nodes))
 	}
 
+	errorChan := make(chan error)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	wg := sync.WaitGroup{}
 	for i := range nodes {
@@ -226,7 +229,8 @@ func TestLotsOfPings(t *testing.T) {
 			go func(sender *Netceptor, recipient *Netceptor, response *bool) {
 				pc, err := sender.ListenPacket("")
 				if err != nil {
-					t.Fatal(err)
+					errorChan <- err
+					return
 				}
 				go func() {
 					defer wg.Done()
@@ -234,7 +238,8 @@ func TestLotsOfPings(t *testing.T) {
 						buf := make([]byte, 1024)
 						err := pc.SetReadDeadline(time.Now().Add(1 * time.Second))
 						if err != nil {
-							t.Fatalf("error in SetReadDeadline: %s", err)
+							errorChan <- fmt.Errorf("error in SetReadDeadline: %s", err)
+							return
 						}
 						_, addr, err := pc.ReadFrom(buf)
 						if ctx.Err() != nil {
@@ -245,10 +250,12 @@ func TestLotsOfPings(t *testing.T) {
 						}
 						ncAddr, ok := addr.(Addr)
 						if !ok {
-							t.Fatal("addr was not a Netceptor address")
+							errorChan <- fmt.Errorf("addr was not a Netceptor address")
+							return
 						}
 						if ncAddr.node != recipient.nodeID {
-							t.Fatal("Received response from wrong node")
+							errorChan <- fmt.Errorf("received response from wrong node")
+							return
 						}
 						t.Logf("%s received response from %s", sender.nodeID, recipient.nodeID)
 						*response = true
@@ -305,6 +312,8 @@ func TestLotsOfPings(t *testing.T) {
 
 	t.Log("waiting for done")
 	select {
+	case err := <-errorChan:
+		t.Fatal(err)
 	case <-ctx.Done():
 	}
 	t.Log("waiting for waitgroup")
@@ -328,14 +337,14 @@ func TestDuplicateNodeDetection(t *testing.T) {
 	backends := make([]*ExternalBackend, netsize)
 	routingChans := make([]chan map[string]string, netsize)
 	for i := 0; i < netsize; i++ {
-		nodes[i] = New(context.Background(), fmt.Sprintf("node%d", i), nil)
+		nodes[i] = New(context.Background(), fmt.Sprintf("node%d", i))
 		routingChans[i] = nodes[i].SubscribeRoutingUpdates()
 		var err error
 		backends[i], err = NewExternalBackend()
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = nodes[i].AddBackend(backends[i], 1.0, nil)
+		err = nodes[i].AddBackend(backends[i])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -370,7 +379,8 @@ func TestDuplicateNodeDetection(t *testing.T) {
 			}
 		}(i)
 	}
-	timeout, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	for {
 		select {
 		case <-timeout.Done():
@@ -400,13 +410,13 @@ func TestDuplicateNodeDetection(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		// Create and connect a new node with a duplicate name
-		n := New(context.Background(), "node0", nil)
+		n := New(context.Background(), "node0")
 		logger.Info("Duplicate node0 has epoch %d\n", n.epoch)
 		b, err := NewExternalBackend()
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = n.AddBackend(b, 1.0, nil)
+		err = n.AddBackend(b)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -441,4 +451,320 @@ func TestDuplicateNodeDetection(t *testing.T) {
 	for i := 0; i < netsize; i++ {
 		nodes[i].BackendWait()
 	}
+}
+
+func TestFirewalling(t *testing.T) {
+	lw := &logWriter{
+		t: t,
+	}
+	log.SetOutput(lw)
+	logger.SetShowTrace(true)
+	defer func() {
+		log.SetOutput(os.Stdout)
+		logger.SetShowTrace(false)
+	}()
+
+	// Create two Netceptor nodes using external backends
+	n1 := New(context.Background(), "node1")
+	b1, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n1.AddBackend(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2 := New(context.Background(), "node2")
+	b2, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n2.AddBackend(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a firewall to node 1 that rejects messages whose data is "bad"
+	err = n1.AddFirewallRules([]FirewallRule{
+		func(md *MessageData) FirewallResult {
+			if string(md.Data) == "bad" {
+				return FirewallResultReject
+			}
+			return FirewallResultAccept
+		},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a Unix socket pair and use it to connect the backends
+	c1, c2, err := socketpair.New("unix")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for node list updates
+	nCh1 := n1.SubscribeRoutingUpdates()
+	nCh2 := n2.SubscribeRoutingUpdates()
+
+	// Connect the two nodes
+	b1.NewConnection(MessageConnFromNetConn(c1), true)
+	b2.NewConnection(MessageConnFromNetConn(c2), true)
+
+	// Wait for the nodes to establish routing to each other
+	var routes1 map[string]string
+	var routes2 map[string]string
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-timeout.Done():
+			t.Fatal("timed out waiting for nodes to connect")
+		case routes1 = <-nCh1:
+		case routes2 = <-nCh2:
+		}
+		if routes1 != nil && routes2 != nil {
+			_, ok := routes1["node2"]
+			if ok {
+				_, ok := routes2["node1"]
+				if ok {
+					break
+				}
+			}
+		}
+	}
+
+	// Set up packet connection
+	pc1, err := n1.ListenPacket("testsvc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc2, err := n2.ListenPacket("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for unreachable messages
+	unreach2chan := pc2.SubscribeUnreachable()
+
+	// Save received unreachable messages to a variable
+	var lastUnreachMsg *UnreachableNotification
+	go func() {
+		for {
+			select {
+			case <-timeout.Done():
+				return
+			case unreach := <-unreach2chan:
+				lastUnreachMsg = &unreach
+			}
+		}
+	}()
+
+	// Send a good message
+	lastUnreachMsg = nil
+	_, err = pc2.WriteTo([]byte("good"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 256)
+	n, _, err := pc1.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:n]) != "good" {
+		t.Fatal("incorrect message received")
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg != nil {
+		t.Fatalf("unexpected unreachable message received: %v", lastUnreachMsg)
+	}
+
+	// Send a bad message
+	_, err = pc2.WriteTo([]byte("bad"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, _, err = pc1.ReadFrom(buf)
+	if err != ErrTimeout {
+		if err == nil {
+			err = fmt.Errorf("received message that should have been firewalled")
+		}
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg == nil {
+		t.Fatal("did not receive expected unreachable message")
+	}
+
+	// Shut down the network
+	n1.Shutdown()
+	n2.Shutdown()
+	n1.BackendWait()
+	n2.BackendWait()
+}
+
+func TestAllowedPeers(t *testing.T) {
+	lw := &logWriter{
+		t: t,
+	}
+	log.SetOutput(lw)
+	logger.SetShowTrace(true)
+	defer func() {
+		log.SetOutput(os.Stdout)
+		logger.SetShowTrace(false)
+	}()
+
+	// Create two Netceptor nodes using external backends
+	n1 := New(context.Background(), "node1")
+	b1, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n1.AddBackend(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2 := New(context.Background(), "node2")
+	b2, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n2.AddBackend(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a firewall to node 1 that rejects messages whose data is "bad"
+	err = n1.AddFirewallRules([]FirewallRule{
+		func(md *MessageData) FirewallResult {
+			if string(md.Data) == "bad" {
+				return FirewallResultReject
+			}
+			return FirewallResultAccept
+		},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a Unix socket pair and use it to connect the backends
+	c1, c2, err := socketpair.New("unix")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for node list updates
+	nCh1 := n1.SubscribeRoutingUpdates()
+	nCh2 := n2.SubscribeRoutingUpdates()
+
+	// Connect the two nodes
+	b1.NewConnection(MessageConnFromNetConn(c1), true)
+	b2.NewConnection(MessageConnFromNetConn(c2), true)
+
+	// Wait for the nodes to establish routing to each other
+	var routes1 map[string]string
+	var routes2 map[string]string
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-timeout.Done():
+			t.Fatal("timed out waiting for nodes to connect")
+		case routes1 = <-nCh1:
+		case routes2 = <-nCh2:
+		}
+		if routes1 != nil && routes2 != nil {
+			_, ok := routes1["node2"]
+			if ok {
+				_, ok := routes2["node1"]
+				if ok {
+					break
+				}
+			}
+		}
+	}
+
+	// Set up packet connection
+	pc1, err := n1.ListenPacket("testsvc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc2, err := n2.ListenPacket("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for unreachable messages
+	unreach2chan := pc2.SubscribeUnreachable()
+
+	// Save received unreachable messages to a variable
+	var lastUnreachMsg *UnreachableNotification
+	go func() {
+		for {
+			select {
+			case <-timeout.Done():
+				return
+			case unreach := <-unreach2chan:
+				lastUnreachMsg = &unreach
+			}
+		}
+	}()
+
+	// Send a good message
+	lastUnreachMsg = nil
+	_, err = pc2.WriteTo([]byte("good"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 256)
+	n, _, err := pc1.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:n]) != "good" {
+		t.Fatal("incorrect message received")
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg != nil {
+		t.Fatalf("unexpected unreachable message received: %v", lastUnreachMsg)
+	}
+
+	// Send a bad message
+	_, err = pc2.WriteTo([]byte("bad"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, _, err = pc1.ReadFrom(buf)
+	if err != ErrTimeout {
+		if err == nil {
+			err = fmt.Errorf("received message that should have been firewalled")
+		}
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg == nil {
+		t.Fatal("did not receive expected unreachable message")
+	}
+
+	// Shut down the network
+	n1.Shutdown()
+	n2.Shutdown()
+	n1.BackendWait()
+	n2.BackendWait()
 }

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -13,7 +13,7 @@ import (
 type PacketConn struct {
 	s                  *Netceptor
 	localService       string
-	recvChan           chan *messageData
+	recvChan           chan *MessageData
 	readDeadline       time.Time
 	writeDeadline      time.Time
 	advertise          bool
@@ -46,7 +46,7 @@ func (s *Netceptor) ListenPacket(service string) (*PacketConn, error) {
 	pc := &PacketConn{
 		s:            s,
 		localService: service,
-		recvChan:     make(chan *messageData),
+		recvChan:     make(chan *MessageData),
 		advertise:    false,
 		adTags:       nil,
 		connType:     ConnTypeDatagram,
@@ -123,7 +123,7 @@ func (pc *PacketConn) SubscribeUnreachable() chan UnreachableNotification {
 
 // ReadFrom reads a packet from the network and returns its data and address.
 func (pc *PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	var m *messageData
+	var m *MessageData
 	if pc.readDeadline.IsZero() {
 		m = <-pc.recvChan
 	} else {

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -31,7 +31,7 @@ func TestWorkceptorJson(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpdir)
-	nc := netceptor.New(nil, "test", nil)
+	nc := netceptor.New(nil, "test")
 	w, err := New(context.Background(), nc, tmpdir)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -50,7 +50,7 @@ func handleError(err error, fatal bool) {
 
 // NewLibNode builds a node with the name passed as the argument
 func NewLibNode(name string) *LibNode {
-	n1 := netceptor.New(context.Background(), name, nil)
+	n1 := netceptor.New(context.Background(), name)
 	return &LibNode{
 		NetceptorInstance: n1,
 		serverTLSConfigs:  make(map[string]*tls.Config),
@@ -112,7 +112,7 @@ func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]fl
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
 	return err
 }
 
@@ -123,7 +123,7 @@ func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) erro
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
 	return err
 }
 
@@ -135,7 +135,7 @@ func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]fl
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
 	return err
 }
 
@@ -146,7 +146,7 @@ func (n *LibNode) UDPDial(address string, cost float64) error {
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
 	return err
 }
 
@@ -159,7 +159,7 @@ func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[str
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
 	return err
 }
 
@@ -171,7 +171,7 @@ func (n *LibNode) WebsocketDial(address string, cost float64, tlsCfg *tls.Config
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
 	return err
 }
 

--- a/tests/functional/mesh/firewall_test.go
+++ b/tests/functional/mesh/firewall_test.go
@@ -1,0 +1,119 @@
+package mesh
+
+import (
+	"context"
+	_ "github.com/fortytw2/leaktest"
+	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
+	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
+	"testing"
+	"time"
+)
+
+func TestFirewall(t *testing.T) {
+	t.Parallel()
+	testTable := []struct {
+		listener string
+	}{
+		{"tcp-listener"},
+		{"ws-listener"},
+	}
+	for _, data := range testTable {
+		listener := data.listener
+		t.Run(listener, func(t *testing.T) {
+			t.Parallel()
+			// Setup our mesh yaml data
+			data := mesh.YamlData{}
+			data.Nodes = make(map[string]*mesh.YamlNode)
+
+			// Generate a mesh of node1->node2->node3 with firewall rules so node2 can talk to node1 and node3,
+			// but node1 and node3 can't talk to each other because node2 blocks the traffic
+			data.Nodes["node1"] = &mesh.YamlNode{
+				Connections: map[string]mesh.YamlConnection{
+					"node2": mesh.YamlConnection{
+						Index: 0,
+					},
+				},
+				Nodedef: []interface{}{
+					map[interface{}]interface{}{
+						listener: map[interface{}]interface{}{},
+					},
+				},
+			}
+			data.Nodes["node2"] = &mesh.YamlNode{
+				Nodedef: []interface{}{
+					map[interface{}]interface{}{
+						listener: map[interface{}]interface{}{},
+					},
+					map[interface{}]interface{}{
+						"node": map[interface{}]interface{}{
+							"id": "node2",
+							"firewallrules": []interface{}{
+								"FromNode=node2:accept",
+								"ToNode=node3:reject",
+								"ToNode=node1:reject",
+							},
+						},
+					},
+				},
+			}
+			data.Nodes["node3"] = &mesh.YamlNode{
+				Connections: map[string]mesh.YamlConnection{
+					"node2": mesh.YamlConnection{
+						Index: 0,
+					},
+				},
+				Nodedef: []interface{}{
+					map[interface{}]interface{}{
+						listener: map[interface{}]interface{}{},
+					},
+				},
+			}
+			m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer m.WaitForShutdown()
+			defer m.Destroy()
+
+			ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+			err = m.WaitForReady(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Test that node1 and node3 can ping node2
+			for _, nodeSender := range []mesh.Node{m.Nodes()["node1"], m.Nodes()["node3"]} {
+				controller := receptorcontrol.New()
+				err = controller.Connect(nodeSender.ControlSocket())
+				if err != nil {
+					t.Fatal(err)
+				}
+				response, err := controller.Ping("node2")
+				if err != nil {
+					t.Error(err)
+				}
+				t.Logf("%v", response)
+				controller.Close()
+			}
+
+			// Test that node1 and node3 cannot ping each other
+			for strSender, strReceiver := range map[string]string{"node1": "node3", "node3": "node1"} {
+				controller := receptorcontrol.New()
+				err = controller.Connect(m.Nodes()[strSender].ControlSocket())
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err := controller.Ping(strReceiver)
+				if err == nil {
+					t.Error("firewall failed to block ping")
+				} else if err.Error() != "blocked by firewall" {
+					t.Errorf("got wrong error: %s", err)
+				}
+
+				t.Logf("%v", err)
+				controller.Close()
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
This PR adds the following security features to Receptor:

### Firewall rules

The firewall feature for adds a new method `netceptor.AddFirewallRules()`, which attaches a list of rules to this Netceptor instance.  Once attached, the rules are checked for every `MsgTypeData` packet, including both local and to-be-forwarded packets.  Firewall rules are processed just before dispatching the packet to a local service or router.

A firewall rule is simply a Go function that takes a `*MessageData` and returns a decision, which can be `FirewallResultAccept` (allow the packet), `FirewallResultReject` (deny the packet with an unreachable message), or `FirewallResultDrop` (deny the packet silently).

This PR changes the visibility of `MessageData` from private to public, so that it can be passed to firewall functions in other packages.

### Firewall CLI language & parser

A new option `firewallrules` is added to the `node` CLI struct.  This takes a list of strings, each describing a firewall rule to be created.  Rules can match simple strings or regular expressions.  Example strings that define rules:

* `all:accept`
Accepts everything
* `FromNode=foo, ToNode=bar, ToService=control: drop`
Drops traffic from `foo` to `bar`'s control service
* `fromnode = /a.*b/ : reject`
Rejects traffic originating from nodes like abcb, adfb, etc
* `TONODE = /(?i)a.*b/ : reject`
Rejects traffic destined for nodes like abcb, AdfB, etc

### Per-connection AllowedPeers

The existing AllowedPeers command applies to the whole Receptor node, with no regard to which connection a peer is connecting through.  In circumstances where control is desired over the node IDs allowed to connect, it is likely that the user will also want to control which connection they can connect through.

To accomplish this, the `AllowedPeers` parameter is removed from `netceptor.New()` and moved to `AddBackend()`.  **This is a breaking change** because we can't change the signature of these functions without breaking callers.  The `AddBackend()` function is changed to use the modifier pattern, which provides the ability to non-breakingly add more options in future.