### PR TITLE
Live reload Backends

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ghjm/cmdline"
@@ -69,7 +70,7 @@ func (cfg nodeCfg) Run() error {
 
 type nullBackendCfg struct{}
 
-// make the nullBackendCfg object be usable as a do-nothing Backend
+// make the nullBackendCfg object be usable as a do-nothing Backend.
 func (cfg nullBackendCfg) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	return make(chan netceptor.BackendSession), nil
 }
@@ -111,6 +112,7 @@ func main() {
 		if dryRun {
 			return cl.ParseAndRun(osArgs, []string{""}, cmdline.ShowHelpIfNoArgs)
 		}
+
 		return cl.ParseAndRun(osArgs, []string{"Reload"}, cmdline.ShowHelpIfNoArgs)
 	}
 

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -37,7 +37,7 @@ func NewTCPDialer(address string, redial bool, tls *tls.Config) (*TCPDialer, err
 	return &td, nil
 }
 
-// Start runs the given session function over this backend service
+// Start runs the given session function over this backend service.
 func (b *TCPDialer) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, wg, b.redial, 5*time.Second,
 		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
@@ -86,7 +86,7 @@ func (b *TCPListener) Addr() net.Addr {
 	return b.li.Addr()
 }
 
-// Start runs the given session function over the TCPListener backend
+// Start runs the given session function over the TCPListener backend.
 func (b *TCPListener) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	sessChan, err := listenerSession(ctx, wg,
 		func() error {

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -39,7 +39,7 @@ func NewUDPDialer(address string, redial bool) (*UDPDialer, error) {
 	return &nd, nil
 }
 
-// Start runs the given session function over this backend service
+// Start runs the given session function over this backend service.
 func (b *UDPDialer) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, wg, b.redial, 5*time.Second,
 		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
@@ -154,7 +154,7 @@ func (b *UDPListener) LocalAddr() net.Addr {
 	return b.conn.LocalAddr()
 }
 
-// Start runs the given session function over the UDPListener backend
+// Start runs the given session function over the UDPListener backend.
 func (b *UDPListener) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	sessChan := make(chan netceptor.BackendSession)
 	wg.Add(1)

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -16,7 +16,7 @@ const (
 
 type dialerFunc func(chan struct{}) (netceptor.BackendSession, error)
 
-// dialerSession is a convenience function for backends that use dial/retry logic
+// dialerSession is a convenience function for backends that use dial/retry logic.
 func dialerSession(ctx context.Context, wg *sync.WaitGroup, redial bool, redialDelay time.Duration,
 	df dialerFunc) (chan netceptor.BackendSession, error) {
 	sessChan := make(chan netceptor.BackendSession)
@@ -80,10 +80,9 @@ type (
 	listenerCancelFunc func()
 )
 
-// listenerSession is a convenience function for backends that use listen/accept logic
+// listenerSession is a convenience function for backends that use listen/accept logic.
 func listenerSession(ctx context.Context, wg *sync.WaitGroup, lf listenFunc, af acceptFunc, lcf listenerCancelFunc) (chan netceptor.BackendSession, error) {
-	err := lf()
-	if err != nil {
+	if err := lf(); err != nil {
 		return nil, err
 	}
 	sessChan := make(chan netceptor.BackendSession)
@@ -126,5 +125,6 @@ func runFuncs(f []func() error) error {
 			return err
 		}
 	}
+
 	return nil
 }

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -50,7 +50,7 @@ func NewWebsocketDialer(address string, tlscfg *tls.Config, extraHeader string, 
 	return &wd, nil
 }
 
-// Start runs the given session function over this backend service
+// Start runs the given session function over this backend service.
 func (b *WebsocketDialer) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, wg, b.redial, 5*time.Second,
 		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
@@ -118,7 +118,7 @@ func (b *WebsocketListener) Path() string {
 	return b.path
 }
 
-// Start runs the given session function over the WebsocketListener backend
+// Start runs the given session function over the WebsocketListener backend.
 func (b *WebsocketListener) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	var err error
 	sessChan := make(chan netceptor.BackendSession)

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -96,6 +96,7 @@ func New(stdServices bool, nc *netceptor.Netceptor) *Server {
 		s.controlTypes["status"] = &statusCommandType{}
 		s.controlTypes["connect"] = &connectCommandType{}
 		s.controlTypes["traceroute"] = &tracerouteCommandType{}
+		s.controlTypes["reload"] = &reloadCommandType{}
 	}
 
 	return s

--- a/pkg/controlsvc/reload.go
+++ b/pkg/controlsvc/reload.go
@@ -2,23 +2,28 @@ package controlsvc
 
 import (
 	"fmt"
+
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
-type reloadCommandType struct{}
-type reloadCommand struct{}
+type (
+	reloadCommandType struct{}
+	reloadCommand     struct{}
+)
 
-// ReloadCL is ParseAndRun closure set with the initial receptor arguments
+// ReloadCL is ParseAndRun closure set with the initial receptor arguments.
 var ReloadCL func(bool) error
 
 func (t *reloadCommandType) InitFromString(params string) (ControlCommand, error) {
 	c := &reloadCommand{}
+
 	return c, nil
 }
 
 func (t *reloadCommandType) InitFromJSON(config map[string]interface{}) (ControlCommand, error) {
 	c := &reloadCommand{}
+
 	return c, nil
 }
 
@@ -33,6 +38,7 @@ func (c *reloadCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOper
 	if err != nil {
 		cfr["Success"] = false
 		cfr["Error"] = err.Error()
+
 		return cfr, err
 	}
 
@@ -42,14 +48,16 @@ func (c *reloadCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOper
 	if err != nil {
 		cfr["Success"] = false
 		cfr["Error"] = err.Error()
+
 		return cfr, err
 	}
 	cfr["Success"] = true
+
 	return cfr, nil
 }
 
 func init() {
 	ReloadCL = func(dryRun bool) error {
-		return fmt.Errorf("Reload function not set")
+		return fmt.Errorf("reload function not set")
 	}
 }

--- a/pkg/controlsvc/reload.go
+++ b/pkg/controlsvc/reload.go
@@ -1,0 +1,55 @@
+package controlsvc
+
+import (
+	"fmt"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+)
+
+type reloadCommandType struct{}
+type reloadCommand struct{}
+
+// ReloadCL is ParseAndRun closure set with the initial receptor arguments
+var ReloadCL func(bool) error
+
+func (t *reloadCommandType) InitFromString(params string) (ControlCommand, error) {
+	c := &reloadCommand{}
+	return c, nil
+}
+
+func (t *reloadCommandType) InitFromJSON(config map[string]interface{}) (ControlCommand, error) {
+	c := &reloadCommand{}
+	return c, nil
+}
+
+func (c *reloadCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+	// Reload command stops all backends, and re-runs the ParseAndRun() on the
+	// initial config file
+	cfr := make(map[string]interface{})
+	logger.Debug("Reloading")
+
+	// Do a quick check to catch any yaml errors before canceling backends
+	err := ReloadCL(true)
+	if err != nil {
+		cfr["Success"] = false
+		cfr["Error"] = err.Error()
+		return cfr, err
+	}
+
+	nc.CancelBackends()
+	// ReloadCL is a ParseAndRun closure, set in receptor.go/main()
+	err = ReloadCL(false)
+	if err != nil {
+		cfr["Success"] = false
+		cfr["Error"] = err.Error()
+		return cfr, err
+	}
+	cfr["Success"] = true
+	return cfr, nil
+}
+
+func init() {
+	ReloadCL = func(dryRun bool) error {
+		return fmt.Errorf("Reload function not set")
+	}
+}

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -151,7 +152,7 @@ func NewExternalBackend() (*ExternalBackend, error) {
 }
 
 // Start launches the backend from Receptor's point of view, and waits for connections to happen.
-func (b *ExternalBackend) Start(ctx context.Context) (chan BackendSession, error) {
+func (b *ExternalBackend) Start(ctx context.Context, wg *sync.WaitGroup) (chan BackendSession, error) {
 	b.ctx, b.cancel = context.WithCancel(ctx)
 	b.ctx = ctx
 	b.sessChan = make(chan BackendSession)

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -66,7 +66,7 @@ func (e *TimeoutError) Temporary() bool { return true }
 
 // Backend is the interface for back-ends that the Receptor network can run over.
 type Backend interface {
-	Start(context.Context) (chan BackendSession, error)
+	Start(context.Context, *sync.WaitGroup) (chan BackendSession, error)
 }
 
 // BackendSession is the interface for a single session of a back-end.
@@ -116,6 +116,7 @@ type Netceptor struct {
 	sendServiceAdsChan     chan time.Duration
 	backendWaitGroup       sync.WaitGroup
 	backendCount           int
+	backendCancel          []context.CancelFunc
 	networkName            string
 	serverTLSConfigs       map[string]*tls.Config
 	clientTLSConfigs       map[string]*tls.Config
@@ -296,6 +297,7 @@ func NewWithConsts(ctx context.Context, nodeID string, allowedPeers []string,
 		sendServiceAdsChan:     nil,
 		backendWaitGroup:       sync.WaitGroup{},
 		backendCount:           0,
+		backendCancel:          nil,
 		networkName:            makeNetworkName(nodeID),
 		clientTLSConfigs:       make(map[string]*tls.Config),
 		serverTLSConfigs:       make(map[string]*tls.Config),
@@ -397,7 +399,10 @@ func (s *Netceptor) MaxConnectionIdleTime() time.Duration {
 
 // AddBackend adds a backend to the Netceptor system.
 func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost map[string]float64) error {
-	sessChan, err := backend.Start(s.context)
+	ctxBackend, cancel := context.WithCancel(s.context)
+	s.backendCancel = append(s.backendCancel, cancel)
+	sessChan, err := backend.Start(ctxBackend, &s.backendWaitGroup)
+
 	if err != nil {
 		return err
 	}
@@ -411,8 +416,8 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost
 				if ok {
 					s.backendWaitGroup.Add(1)
 					go func() {
-						err := s.runProtocol(sess, connectionCost, nodeCost)
-						s.backendWaitGroup.Done()
+						defer s.backendWaitGroup.Done()
+						err := s.runProtocol(ctxBackend, sess, connectionCost, nodeCost)
 						if err != nil {
 							logger.Error("Backend error: %s\n", err)
 						}
@@ -420,7 +425,7 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost
 				} else {
 					return
 				}
-			case <-s.context.Done():
+			case <-ctxBackend.Done():
 				return
 			}
 		}
@@ -434,12 +439,34 @@ func (s *Netceptor) BackendWait() {
 	s.backendWaitGroup.Wait()
 }
 
-// BackendCount returns the number of backends that ever registered with this Netceptor.
+// BackendWaitGroupAdd increments backendWaitGroup counter
+func (s *Netceptor) BackendWaitGroupAdd() {
+	s.backendWaitGroup.Add(1)
+}
+
+// BackendDone calls Done on the backendWaitGroup
+func (s *Netceptor) BackendDone() {
+	s.backendWaitGroup.Done()
+}
+
+// BackendCount returns the number of backends that ever registered with this Netceptor
 func (s *Netceptor) BackendCount() int {
 	return s.backendCount
 }
 
-// Status returns the current state of the Netceptor object.
+// CancelBackends stops all backends by calling a context cancel
+func (s *Netceptor) CancelBackends() {
+	logger.Debug("Canceling backends")
+	for i := range s.backendCancel {
+		// a context cancel function
+		s.backendCancel[i]()
+	}
+	s.BackendWait()
+	s.backendCancel = nil
+	s.backendCount = 0
+}
+
+// Status returns the current state of the Netceptor object
 func (s *Netceptor) Status() Status {
 	s.connLock.RLock()
 	conns := make([]*ConnStatus, 0)
@@ -1501,8 +1528,8 @@ func (s *Netceptor) sendAndLogConnectionRejection(remoteNodeID string, ci *connI
 	return fmt.Errorf("rejected connection with node %s because %s", remoteNodeID, reason)
 }
 
-// Main Netceptor protocol loop.
-func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nodeCost map[string]float64) error {
+// Main Netceptor protocol loop
+func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, connectionCost float64, nodeCost map[string]float64) error {
 	if connectionCost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
 	}
@@ -1521,7 +1548,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 			s.knownNodeLock.Unlock()
 			done := false
 			select {
-			case <-s.context.Done():
+			case <-ctx.Done():
 				done = true
 			default:
 			}
@@ -1536,7 +1563,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 		WriteChan: make(chan []byte),
 		Cost:      connectionCost,
 	}
-	ci.Context, ci.CancelFunc = context.WithCancel(s.context)
+	ci.Context, ci.CancelFunc = context.WithCancel(ctx)
 	go ci.protoReader(sess)
 	go ci.protoWriter(sess)
 	initDoneChan := make(chan bool)
@@ -1655,7 +1682,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					// Establish the connection
 					select {
 					case initDoneChan <- true:
-					case <-s.context.Done():
+					case <-ctx.Done():
 						return nil
 					}
 					logger.Info("Connection established with %s\n", remoteNodeID)
@@ -1677,12 +1704,12 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					s.knownNodeLock.Unlock()
 					select {
 					case s.sendRouteFloodChan <- 0:
-					case <-s.context.Done():
+					case <-ctx.Done():
 						return nil
 					}
 					select {
 					case s.updateRoutingTableChan <- 0:
-					case <-s.context.Done():
+					case <-ctx.Done():
 						return nil
 					}
 					established = true

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -402,7 +402,6 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost
 	ctxBackend, cancel := context.WithCancel(s.context)
 	s.backendCancel = append(s.backendCancel, cancel)
 	sessChan, err := backend.Start(ctxBackend, &s.backendWaitGroup)
-
 	if err != nil {
 		return err
 	}
@@ -439,22 +438,22 @@ func (s *Netceptor) BackendWait() {
 	s.backendWaitGroup.Wait()
 }
 
-// BackendWaitGroupAdd increments backendWaitGroup counter
+// BackendWaitGroupAdd increments backendWaitGroup counter.
 func (s *Netceptor) BackendWaitGroupAdd() {
 	s.backendWaitGroup.Add(1)
 }
 
-// BackendDone calls Done on the backendWaitGroup
+// BackendDone calls Done on the backendWaitGroup.
 func (s *Netceptor) BackendDone() {
 	s.backendWaitGroup.Done()
 }
 
-// BackendCount returns the number of backends that ever registered with this Netceptor
+// BackendCount returns the number of backends that ever registered with this Netceptor.
 func (s *Netceptor) BackendCount() int {
 	return s.backendCount
 }
 
-// CancelBackends stops all backends by calling a context cancel
+// CancelBackends stops all backends by calling a context cancel.
 func (s *Netceptor) CancelBackends() {
 	logger.Debug("Canceling backends")
 	for i := range s.backendCancel {
@@ -466,7 +465,7 @@ func (s *Netceptor) CancelBackends() {
 	s.backendCount = 0
 }
 
-// Status returns the current state of the Netceptor object
+// Status returns the current state of the Netceptor object.
 func (s *Netceptor) Status() Status {
 	s.connLock.RLock()
 	conns := make([]*ConnStatus, 0)
@@ -1528,7 +1527,7 @@ func (s *Netceptor) sendAndLogConnectionRejection(remoteNodeID string, ci *connI
 	return fmt.Errorf("rejected connection with node %s because %s", remoteNodeID, reason)
 }
 
-// Main Netceptor protocol loop
+// Main Netceptor protocol loop.
 func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, connectionCost float64, nodeCost map[string]float64) error {
 	if connectionCost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -162,6 +162,17 @@ def ping(ctx, node, count, delay):
             time.sleep(delay)
 
 
+@cli.command(help="Reload receptor configuration.")
+@click.pass_context
+def reload(ctx):
+    rc = get_rc(ctx)
+    results = rc.simple_command(f"reload")
+    if "Success" in results and results["Success"]:
+        print(f"Reload successful")
+    else:
+        print(f"Error: {results['Error']}")
+
+
 @cli.command(help="Do a traceroute to a Receptor node.")
 @click.pass_context
 @click.argument('node')


### PR DESCRIPTION
Adds ability to add/remove backends from the config file without restarting Receptor

#### Context
We want to be able to add and remove nodes to the mesh without disturbing ongoing receptor functionality, e.g. sending payloads, or streaming playbook results

#### Details
Adds a "reload" service command, which does the following,
- Stop all backends
- Re-run `ParseAndRun()`, but with "Reload" as the input instead of "Init, Prepare, Run"
- `Reload()` is currently only defined for the 6 backend connections (peer and listeners for tcp, udp, websockets), so no other cfg objects will be re-ran on a reload. For now, `cfg.Reload()` simply calls `cfg.Prepare()`, and `cfg.Run()`

#### How to test this PR
save this as controlnode.yml
```
---
- node:
    id: controlnode
    
- log-level: Debug

- control-service:
    service: control
    filename: /tmp/receptor.sock

- tcp-peer:
    address: localhost:2222
```

save this as executionnode.yml
```
---
- node:
    id: executionnode

- log-level: Debug

- tcp-listener:
    port: 2223

- control-service:
    service: control

- work-command:
    workType: echosleep
    command: bash
    params: "-c \"while read -r line; do echo $line; sleep 5; done\""
```

1. `receptor -c controlnode.yml`
2. `receptor -c executionnode.yml`
3. You should see log statements about connections not working. This is because the ports don't match (2222 and 2223)
4. Keep nodes running, and modify controlnode.yml to make the port numbers match
5. `nc -U /tmp/receptor.sock` and type `reload`
6. You should now see the nodes successfully connect and send routing information to each other

More testing,
1. You can use receptorctl to submit work on the executionnode by typing `seq 100 | receptorctl --socket /tmp/receptor.sock work submit echosleep --node executionnode --payload - -f`
2. This will stream the results, a sequence of numbers.
3. While this is running, change the port numbers in the config to "break" the connection and issue reload command.
4. You'll see the work continues to stream, but no results will pop up.
5. Fix the config, and reload once more. The results should resume streaming once more.