### PR TITLE
Fix add work types to service ads

### DIFF
--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -290,7 +290,9 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 	}
 	var li *netceptor.Listener
 	if service != "" {
-		li, err = s.nc.ListenAndAdvertise(service, tlscfg, nil)
+		li, err = s.nc.ListenAndAdvertise(service, tlscfg, map[string]string{
+			"type": "Control Service",
+		})
 		if err != nil {
 			return fmt.Errorf("error opening Unix socket: %s", err)
 		}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -507,11 +507,11 @@ func (s *Netceptor) addLocalServiceAdvertisement(service string, connType byte, 
 		s.serviceAdsReceived[s.nodeID] = n
 	}
 	n[service] = &ServiceAdvertisement{
-		NodeID:       s.nodeID,
-		Service:      service,
-		Time:         time.Now(),
-		ConnType:     connType,
-		Tags:         tags,
+		NodeID:   s.nodeID,
+		Service:  service,
+		Time:     time.Now(),
+		ConnType: connType,
+		Tags:     tags,
 	}
 	s.sendServiceAdsChan <- 0
 }
@@ -566,11 +566,11 @@ func (s *Netceptor) sendServiceAds() {
 	for sn := range s.listenerRegistry {
 		if s.listenerRegistry[sn].advertise {
 			sa := ServiceAdvertisement{
-				NodeID:       s.nodeID,
-				Service:      sn,
-				Time:         time.Now(),
-				ConnType:     s.listenerRegistry[sn].connType,
-				Tags:         s.listenerRegistry[sn].adTags,
+				NodeID:   s.nodeID,
+				Service:  sn,
+				Time:     time.Now(),
+				ConnType: s.listenerRegistry[sn].connType,
+				Tags:     s.listenerRegistry[sn].adTags,
 			}
 			if svcType, ok := sa.Tags["type"]; ok {
 				if svcType == "Control Service" {

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -572,11 +572,9 @@ func (s *Netceptor) sendServiceAds() {
 				ConnType:     s.listenerRegistry[sn].connType,
 				Tags:         s.listenerRegistry[sn].adTags,
 			}
-			if sn == "control" {
-				if ad, ok := s.serviceAdsReceived[s.NodeID()]; ok {
-					if adControl,ok := ad["control"]; ok {
-							sa.WorkCommands = adControl.WorkCommands
-					}
+			if svcType, ok := sa.Tags["type"]; ok {
+				if svcType == "Control Service" {
+					sa.WorkCommands = s.serviceAdsReceived[s.NodeID()][sn].WorkCommands
 				}
 			}
 			ads = append(ads, sa)

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -574,7 +574,11 @@ func (s *Netceptor) sendServiceAds() {
 			}
 			if svcType, ok := sa.Tags["type"]; ok {
 				if svcType == "Control Service" {
-					sa.WorkCommands = s.serviceAdsReceived[s.NodeID()][sn].WorkCommands
+					if ad, ok := s.serviceAdsReceived[s.NodeID()]; ok {
+						if adControl, ok := ad[sn]; ok {
+							sa.WorkCommands = adControl.WorkCommands
+						}
+					}
 				}
 			}
 			ads = append(ads, sa)
@@ -761,7 +765,7 @@ func (s *Netceptor) AddWorkCommand(command string) error {
 	// and only add work command names to that service ad
 	if ad, ok := s.serviceAdsReceived[s.NodeID()]; ok {
 		for serviceName, svc := range ad {
-			for key, _ := range svc.Tags {
+			for key := range svc.Tags {
 				if key == "type" {
 					if svc.Tags["type"] == "Control Service" {
 						ad[serviceName].WorkCommands = append(ad[serviceName].WorkCommands, command)

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -104,7 +104,8 @@ def status(ctx):
     ads = status.pop('Advertisements', None)
     if ads:
         print()
-        print(f"{'Node':<{longest_node}} Service   Type       Last Seen           Tags                            Work Types")
+        print(f"{'Node':<{longest_node}} Service   Type       Last Seen             Tags")
+        workcommands = {}
         for ad in ads:
             time = dateutil.parser.parse(ad['Time'])
             if ad['ConnType'] == 0:
@@ -113,15 +114,27 @@ def status(ctx):
                 conn_type = 'Stream'
             elif ad['ConnType'] == 2:
                 conn_type = 'StreamTLS'
+            last_seen = f"{time:%Y-%m-%d %H:%M:%S}"
+            print(f"{ad['NodeID']:<{longest_node}} {ad['Service']:<9} {conn_type:<10} {last_seen:<21} {'-' if (ad['Tags'] is None) else str(ad['Tags']):<16}")
+
+    if ads:
+        print()
+        print(f"{'Node':<{longest_node}} Work Types")
+        seen_nodes = []
+        for ad in ads:
+            commands = ad['WorkCommands']
+            if not commands:
+                continue
+            node = ad['NodeID']
+            if node in seen_nodes:
+                continue
+            else:
+                seen_nodes.append(node)
+            commands = ', '.join(commands)
             print(
-                f"{ad['NodeID']:<{longest_node}} {ad['Service']:<9} {conn_type:<10} {time:%Y-%m-%d %H:%M:%S} {'-' if (ad['Tags'] is None) else str(ad['Tags']):<32}",
+                f"{ad['NodeID']:<{longest_node}} ",
                 end=""
             )
-            commands = ad['WorkCommands']
-            if commands:
-                commands = ', '.join(commands)
-            else:
-                commands = '-'
             print(commands)
 
     if status:


### PR DESCRIPTION
Somewhere along the way this broke, and we are no longer getting work command names in our `status` command output

- Only append work command names to a "control service". Before it was appending these names to every type of service, which doesn't make sense for things like udp-client, etc.

- control-service by default is called "control", but this isn't required. Therefore, we can use `.Tags` to keep track of which services are control services. Side note, there is probably a case to enforce control-service to be called "control". Remote work submission assumes target node has a "control" service running
https://github.com/fosterseth/sockceptor/blob/e0315e92a2ee99641f633d8a82a881d358d22836/pkg/workceptor/remote_work.go#L54

- the cli.py now prints work commands separately from the service information. Both the Tags and Work Types column can be arbitrarily long, so hard to keep the table columns fixed width. 

e.g. 

```
Node ID: foo
Version: 0.9.8.dev46-0.git20210713.e0315e9
System CPU Count: 8
System Memory MiB: 15876

Connection   Cost
bar          1

Known Node   Known Connections
bar          {'foo': 1}
foo          {'bar': 1}

Route        Via
bar          bar

Node         Service   Type       Last Seen             Tags
foo          control2  Stream     2021-07-13 14:18:46   {'type': 'Control Service'}
foo          control3  Stream     2021-07-13 14:18:46   {'type': 'Control Service'}
bar          control   Stream     2021-07-13 14:18:38   {'type': 'Control Service'}

Node         Work Types
foo          sleepcat, 100cat, testparam, idk, echosleepshort, kubeit, kubeit2, kubernetes-runtime-auth
bar          sleepcat, 100cat, echosleepshort, idk
```