### PR TITLE
fix space in log output

### DIFF
--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -79,7 +79,7 @@ func Log(level int, format string, v ...interface{}) {
 		Error("Log entry received with invalid level: %s\n", fmt.Sprintf(format, v...))
 		return
 	}
-	prefix = strings.ToUpper(logLevelName)
+	prefix = strings.ToUpper(logLevelName) + " "
 	if logLevel >= level {
 		log.SetPrefix(prefix)
 		log.Printf(format, v...)


### PR DESCRIPTION
add space after the log level

before 

```
DEBUG2021/07/23 16:04:17 Listening on TCP [::]:2222
WARNING2021/07/23 16:04:17 Connection to bar failed with error: context canceled
INFO2021/07/23 16:04:17 Running control service control
```

after
```
DEBUG 2021/07/23 16:04:17 Listening on TCP [::]:2222
WARNING 2021/07/23 16:04:17 Connection to bar failed with error: context canceled
INFO 2021/07/23 16:04:17 Running control service control
```
