### PR TITLE
Add receptor.service file for use at rpm build time

### DIFF
--- a/packaging/rpm/receptor.conf.example
+++ b/packaging/rpm/receptor.conf.example
@@ -8,10 +8,10 @@
 
 # To create and launch a new systemd-managed Receptor node:
 #
-# 1. Copy this file to /etc/receptor/<some-name>.conf
+# 1. Copy this file to /etc/receptor/receptor.conf
 # 2. chmod 0600 if the new file will contain any passwords or sensitive data
 # 3. Edit the new config file as needed
-# 4. systemctl enable receptor@<some-name> --now
+# 4. systemctl enable receptor --now
 
 
 # Basic properties of the node.  The node ID must be unique.

--- a/packaging/rpm/receptor@.service
+++ b/packaging/rpm/receptor@.service
@@ -2,7 +2,7 @@
 Description=Receptor
 
 [Service]
-ExecStart=/usr/bin/receptor -c /etc/receptor/receptor.conf
+ExecStart=/usr/bin/receptor -c /etc/receptor/%i.conf
 User=receptor
 Group=receptor
 

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -619,7 +619,7 @@ func (s *Netceptor) expireSeenUpdates() {
 	}
 }
 
-// Recalculates the next-hop table based on current knowledge of the network
+// Re-calculates the next-hop table based on current knowledge of the network
 func (s *Netceptor) updateRoutingTable() {
 	s.knownNodeLock.RLock()
 	defer s.knownNodeLock.RUnlock()

--- a/pkg/tickrunner/tickrunner.go
+++ b/pkg/tickrunner/tickrunner.go
@@ -8,7 +8,7 @@ import (
 // Run runs a task at a given periodic interval, or as requested over a channel.
 // If many requests come in close to the same time, only run the task once.
 // Callers can ask for the task to be run within a given amount of time, which
-// overrides defaltReqDelay. Sending a zero to the channel runs it immediately.
+// overrides defaultReqDelay. Sending a zero to the channel runs it immediately.
 func Run(ctx context.Context, f func(), periodicInterval time.Duration, defaultReqDelay time.Duration) chan time.Duration {
 	runChan := make(chan time.Duration)
 	go func() {


### PR DESCRIPTION
Currently, the systemd service file we package with receptor requires you to enable the service with an instance name using `@<some-name>` notation.  This can be useful if a user ever wants to configure 2 separate receptor meshes from a single machine, for example:

```
systemctl enable receptor@controller --now
systemctl enable receptor@custom-user-work --now
```

This PR will make add a standard `receptor.service` file in addition to `receptor@.service` so that a user can enable the service with the default instance name if desired.  In this case, the config file used will be `/etc/receptor/receptor.conf`, which should be the expected place for the config file for most installations.  

```
systemctl enable receptor --now
```