### PR TITLE
Enable golangci-linter and apply their rules

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,71 +1,74 @@
-# TODO: Linters that should immediately added after golangci-lint has been accepted:
-# - thelper
-# - staticcheck
-# - nilerr
-# - ineffassign
-# - govet
-# - gosimple
-# - wastedassign
-# - exhaustive
-# - stylecheck
-# - errorlint
-# - structcheck
-# - unparam
-# - bodyclose
-# - unused
-# - prealloc
-# - errcheck
-# - prealloc
-# - gosec
-# - gofumpt
-# - goimports
-# - gofmt
-# - gocritic
-# - gci
-# - deadcode
-# - makezero
-# - revive
-# - forbidigo
-# - errcheck
-# - forcetypeassert
-# - paralleltest
-
-# TODO: Linters that should be included to improve code quality. Not already added because bigger code changes are required. (Ordered)
-# - wrapcheck: Wrap errors with more context before passing them up to. Helps understanding what happens.
-# - goerr113: No dynamic errors please.
-# - goprintffuncname: Encourage consistent func naming.
-# - nlreturn, whitespace, wsl: Improve readability by forcing new lines at certain places.
-# - godot: Comments are sentences and end with periods.
-# - dupl: Duplicate code bad!
-# - ifshort: Improve readability by encouraging the short if syntax.
-# - goconst: encourage constants.
-# - gochecknoinits: Don't use init().
-# - testpackage: Encourages black box testing.
-# - gochecknoglobals: Dislikes that you create globals.
-# - cyclop, funlen, gocognit, gocyclo, nestif: Low complexity ftw.
-# - exhaustivestruct: Be way too verbose with structs.
-
 linters:
   disable-all: true
   enable:
-    - typecheck
-    - varcheck
     - asciicheck
+    - bodyclose
+    #- cyclop # TODO: Reduce code complexity.
+    - deadcode
     - depguard
     - dogsled
+    #- dupl # TODO: Remove duplicates.
     - durationcheck
+    #- errcheck # TODO: Not all received errors are checked.
+    #- errorlint # TODO: Use errors package.
     - exportloopref
+    #- forcetypeassert # TODO: always assert types when when casting.
+    #- funlen # TODO: Reduce code complexity.
+    - gci
+    #- gochecknoglobals # TODO: Reduce number of globals.
+    #- gochecknoinits # TODO: Maybe not use init().
+    #- gocognit # TODO: Reduce code complexity.
+    - gocritic
+    #- gocyclo # TODO: Reduce code complexity.
+    - godot
+    #- goerr113 # TODO: Please do not use dynamic errors.
+    - gofmt
+    - gofumpt
     - goheader
+    - goimports
     - golint
     - gomoddirectives
     - gomodguard
+    # - goprintffuncname # TODO: logging methods are not named like the ones in `fmt` which could lead to problems.
+    - gosec
+    - gosimple
+    - govet
+    - ifshort
     - importas
+    - ineffassign
+    - makezero
     - misspell
     - nakedret
+    #- nestif # TODO: Reduce code complexity.
+    - nilerr
+    - nlreturn
     - noctx
     - nolintlint
+    #- paralleltest # TODO: missing at some locations
+    - prealloc
     - predeclared
+    - revive
     - rowserrcheck
     - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    #- testpackage # TODO: Put tests in their dedicated test packages.
+    #- thelper # TODO: Requires test refactoring.
     - tparallel
+    - typecheck
     - unconvert
+    #- unparam # TODO: This breaks something, look at it!
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
+    # - wrapcheck # TODO: Errors passed upwards should be wrapped.
+
+issues:
+  exclude:
+    - "lostcancel" # TODO: Context is not canceled on multiple occasions. Needs more detailed work to be fixed.
+    - "SA2002|thelper|testinggoroutine" # TODO: Test interface used outside of its routine, tests need to be rewritten.
+    - "G306" # TODO: Restrict perms of touched files.
+    - "G402|G404" # TODO: Make TLS more secure.
+    - "G204" # gosec is throwing a fit, ignore.

--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -3,6 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/ghjm/cmdline"
 	_ "github.com/project-receptor/receptor/pkg/backends"
 	_ "github.com/project-receptor/receptor/pkg/certificates"
@@ -12,9 +16,6 @@ import (
 	_ "github.com/project-receptor/receptor/pkg/services"
 	_ "github.com/project-receptor/receptor/pkg/version"
 	"github.com/project-receptor/receptor/pkg/workceptor"
-	"os"
-	"strings"
-	"time"
 )
 
 type nodeCfg struct {

--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -67,12 +67,12 @@ func (cfg nodeCfg) Run() error {
 
 type nullBackendCfg struct{}
 
-// make the nullBackendCfg object be usable as a do-nothing Backend
+// make the nullBackendCfg object be usable as a do-nothing Backend.
 func (cfg nullBackendCfg) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	return make(chan netceptor.BackendSession), nil
 }
 
-// Run runs the action, in this case adding a null backend to keep the wait group alive
+// Run runs the action, in this case adding a null backend to keep the wait group alive.
 func (cfg nullBackendCfg) Run() error {
 	err := netceptor.MainInstance.AddBackend(&nullBackendCfg{}, 1.0, nil)
 	if err != nil {

--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -57,11 +57,13 @@ func (cfg nodeCfg) Init() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
 func (cfg nodeCfg) Run() error {
 	workceptor.MainInstance.ListKnownUnitIDs() // Triggers a scan of unit dirs and restarts any that need it
+
 	return nil
 }
 
@@ -78,6 +80,7 @@ func (cfg nullBackendCfg) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/example/net.go
+++ b/example/net.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/backends"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"io"
 	"net"
 	"os"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/backends"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 /*
@@ -140,5 +141,4 @@ func main() {
 	// Gracefully shut down n1
 	n1.Shutdown()
 	n1.BackendWait()
-
 }

--- a/example/net.go
+++ b/example/net.go
@@ -60,6 +60,7 @@ func main() {
 		conn, err := l1.Accept()
 		if err != nil {
 			fmt.Printf("Error accepting connection: %s\n", err)
+
 			return
 		}
 		fmt.Printf("Accepted a connection\n")
@@ -73,6 +74,7 @@ func main() {
 					done = true
 				} else if err != nil {
 					fmt.Printf("Read error in Receptor listener: %s\n", err)
+
 					return
 				}
 				fmt.Printf("Echo server got %d bytes\n", n)
@@ -80,6 +82,7 @@ func main() {
 					_, err := conn.Write(buf[:n])
 					if err != nil {
 						fmt.Printf("Write error in Receptor listener: %s\n", err)
+
 						return
 					}
 				}
@@ -97,8 +100,10 @@ func main() {
 		if err != nil {
 			fmt.Printf("Error dialing on Receptor network: %s\n", err)
 			time.Sleep(1 * time.Second)
+
 			continue
 		}
+
 		break
 	}
 
@@ -116,10 +121,12 @@ func main() {
 			if err == io.EOF {
 				// Shut down the whole Netceptor when any connection closes, because this is just a demo
 				n2.Shutdown()
+
 				return
 			}
 			if err != nil {
 				fmt.Printf("Read error in Receptor dialer: %s\n", err)
+
 				return
 			}
 		}

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -7,15 +7,16 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
 	"github.com/ghjm/cmdline"
 	"github.com/project-receptor/receptor/pkg/framer"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"io"
-	"net"
-	"sync"
-	"time"
 )
 
 // TCPDialer implements Backend for outbound TCP

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -33,6 +33,7 @@ func NewTCPDialer(address string, redial bool, tls *tls.Config) (*TCPDialer, err
 		redial:  redial,
 		tls:     tls,
 	}
+
 	return &td, nil
 }
 
@@ -52,6 +53,7 @@ func (b *TCPDialer) Start(ctx context.Context) (chan netceptor.BackendSession, e
 			if err != nil {
 				return nil, err
 			}
+
 			return newTCPSession(conn, closeChan), nil
 		})
 }
@@ -71,6 +73,7 @@ func NewTCPListener(address string, tls *tls.Config) (*TCPListener, error) {
 		tls:     tls,
 		li:      nil,
 	}
+
 	return &tl, nil
 }
 
@@ -79,6 +82,7 @@ func (b *TCPListener) Addr() net.Addr {
 	if b.li == nil {
 		return nil
 	}
+
 	return b.li.Addr()
 }
 
@@ -105,6 +109,7 @@ func (b *TCPListener) Start(ctx context.Context) (chan netceptor.BackendSession,
 				b.li = tlsLi
 				b.innerLi = tli
 			}
+
 			return nil
 		}, func() (netceptor.BackendSession, error) {
 			var c net.Conn
@@ -125,8 +130,10 @@ func (b *TCPListener) Start(ctx context.Context) (chan netceptor.BackendSession,
 				if err != nil {
 					return nil, err
 				}
+
 				break
 			}
+
 			return newTCPSession(c, nil), nil
 		}, func() {
 			_ = b.li.Close()
@@ -134,6 +141,7 @@ func (b *TCPListener) Start(ctx context.Context) (chan netceptor.BackendSession,
 	if err == nil {
 		logger.Debug("Listening on TCP %s\n", b.Addr().String())
 	}
+
 	return sessChan, err
 }
 
@@ -153,6 +161,7 @@ func newTCPSession(conn net.Conn, closeChan chan struct{}) *TCPSession {
 		closeChan:       closeChan,
 		closeChanCloser: sync.Once{},
 	}
+
 	return ts
 }
 
@@ -166,6 +175,7 @@ func (ns *TCPSession) Send(data []byte) error {
 	if n != len(buf) {
 		return fmt.Errorf("partial data sent")
 	}
+
 	return nil
 }
 
@@ -193,6 +203,7 @@ func (ns *TCPSession) Recv(timeout time.Duration) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return buf, nil
 }
 
@@ -204,6 +215,7 @@ func (ns *TCPSession) Close() error {
 			ns.closeChan = nil
 		})
 	}
+
 	return ns.conn.Close()
 }
 
@@ -230,6 +242,7 @@ func (cfg tcpListenerCfg) Prepare() error {
 			return fmt.Errorf("connection cost must be positive for %s", node)
 		}
 	}
+
 	return nil
 }
 
@@ -243,12 +256,14 @@ func (cfg tcpListenerCfg) Run() error {
 	b, err := NewTCPListener(address, tlscfg)
 	if err != nil {
 		logger.Error("Error creating listener %s: %s\n", address, err)
+
 		return err
 	}
 	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCost)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -265,6 +280,7 @@ func (cfg tcpDialerCfg) Prepare() error {
 	if cfg.Cost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
 	}
+
 	return nil
 }
 
@@ -282,12 +298,14 @@ func (cfg tcpDialerCfg) Run() error {
 	b, err := NewTCPDialer(cfg.Address, cfg.Redial, tlscfg)
 	if err != nil {
 		logger.Error("Error creating peer %s: %s\n", cfg.Address, err)
+
 		return err
 	}
 	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, nil)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -19,14 +19,14 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// TCPDialer implements Backend for outbound TCP
+// TCPDialer implements Backend for outbound TCP.
 type TCPDialer struct {
 	address string
 	redial  bool
 	tls     *tls.Config
 }
 
-// NewTCPDialer instantiates a new TCP backend
+// NewTCPDialer instantiates a new TCP backend.
 func NewTCPDialer(address string, redial bool, tls *tls.Config) (*TCPDialer, error) {
 	td := TCPDialer{
 		address: address,
@@ -36,7 +36,7 @@ func NewTCPDialer(address string, redial bool, tls *tls.Config) (*TCPDialer, err
 	return &td, nil
 }
 
-// Start runs the given session function over this backend service
+// Start runs the given session function over this backend service.
 func (b *TCPDialer) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, b.redial, 5*time.Second,
 		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
@@ -56,7 +56,7 @@ func (b *TCPDialer) Start(ctx context.Context) (chan netceptor.BackendSession, e
 		})
 }
 
-// TCPListener implements Backend for inbound TCP
+// TCPListener implements Backend for inbound TCP.
 type TCPListener struct {
 	address string
 	tls     *tls.Config
@@ -64,7 +64,7 @@ type TCPListener struct {
 	innerLi *net.TCPListener
 }
 
-// NewTCPListener instantiates a new TCPListener backend
+// NewTCPListener instantiates a new TCPListener backend.
 func NewTCPListener(address string, tls *tls.Config) (*TCPListener, error) {
 	tl := TCPListener{
 		address: address,
@@ -74,7 +74,7 @@ func NewTCPListener(address string, tls *tls.Config) (*TCPListener, error) {
 	return &tl, nil
 }
 
-// Addr returns the network address the listener is listening on
+// Addr returns the network address the listener is listening on.
 func (b *TCPListener) Addr() net.Addr {
 	if b.li == nil {
 		return nil
@@ -82,7 +82,7 @@ func (b *TCPListener) Addr() net.Addr {
 	return b.li.Addr()
 }
 
-// Start runs the given session function over the WebsocketListener backend
+// Start runs the given session function over the WebsocketListener backend.
 func (b *TCPListener) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	sessChan, err := listenerSession(ctx,
 		func() error {
@@ -137,7 +137,7 @@ func (b *TCPListener) Start(ctx context.Context) (chan netceptor.BackendSession,
 	return sessChan, err
 }
 
-// TCPSession implements BackendSession for TCP backend
+// TCPSession implements BackendSession for TCP backend.
 type TCPSession struct {
 	conn            net.Conn
 	framer          framer.Framer
@@ -145,7 +145,7 @@ type TCPSession struct {
 	closeChanCloser sync.Once
 }
 
-// newTCPSession allocates a new TCPSession
+// newTCPSession allocates a new TCPSession.
 func newTCPSession(conn net.Conn, closeChan chan struct{}) *TCPSession {
 	ts := &TCPSession{
 		conn:            conn,
@@ -156,7 +156,7 @@ func newTCPSession(conn net.Conn, closeChan chan struct{}) *TCPSession {
 	return ts
 }
 
-// Send sends data over the session
+// Send sends data over the session.
 func (ns *TCPSession) Send(data []byte) error {
 	buf := ns.framer.SendData(data)
 	n, err := ns.conn.Write(buf)
@@ -169,7 +169,7 @@ func (ns *TCPSession) Send(data []byte) error {
 	return nil
 }
 
-// Recv receives data via the session
+// Recv receives data via the session.
 func (ns *TCPSession) Recv(timeout time.Duration) ([]byte, error) {
 	buf := make([]byte, utils.NormalBufferSize)
 	for {
@@ -196,7 +196,7 @@ func (ns *TCPSession) Recv(timeout time.Duration) ([]byte, error) {
 	return buf, nil
 }
 
-// Close closes the session
+// Close closes the session.
 func (ns *TCPSession) Close() error {
 	if ns.closeChan != nil {
 		ns.closeChanCloser.Do(func() {
@@ -211,7 +211,7 @@ func (ns *TCPSession) Close() error {
 // Command line
 // **************************************************************************
 
-// tcpListenerCfg is the cmdline configuration object for a TCP listener
+// tcpListenerCfg is the cmdline configuration object for a TCP listener.
 type tcpListenerCfg struct {
 	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
 	Port     int                `description:"Local TCP port to listen on" barevalue:"yes" required:"yes"`
@@ -220,7 +220,7 @@ type tcpListenerCfg struct {
 	NodeCost map[string]float64 `description:"Per-node costs"`
 }
 
-// Prepare verifies the parameters are correct
+// Prepare verifies the parameters are correct.
 func (cfg tcpListenerCfg) Prepare() error {
 	if cfg.Cost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
@@ -233,7 +233,7 @@ func (cfg tcpListenerCfg) Prepare() error {
 	return nil
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg tcpListenerCfg) Run() error {
 	address := fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.Port)
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
@@ -252,7 +252,7 @@ func (cfg tcpListenerCfg) Run() error {
 	return nil
 }
 
-// tcpDialerCfg is the cmdline configuration object for a TCP dialer
+// tcpDialerCfg is the cmdline configuration object for a TCP dialer.
 type tcpDialerCfg struct {
 	Address string  `description:"Remote address (Host:Port) to connect to" barevalue:"yes" required:"yes"`
 	Redial  bool    `description:"Keep redialing on lost connection" default:"true"`
@@ -260,7 +260,7 @@ type tcpDialerCfg struct {
 	Cost    float64 `description:"Connection cost (weight)" default:"1.0"`
 }
 
-// Prepare verifies the parameters are correct
+// Prepare verifies the parameters are correct.
 func (cfg tcpDialerCfg) Prepare() error {
 	if cfg.Cost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
@@ -268,7 +268,7 @@ func (cfg tcpDialerCfg) Prepare() error {
 	return nil
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg tcpDialerCfg) Run() error {
 	logger.Debug("Running TCP peer connection %s\n", cfg.Address)
 	host, _, err := net.SplitHostPort(cfg.Address)

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -99,7 +99,7 @@ func (b *TCPListener) Start(ctx context.Context) (chan netceptor.BackendSession,
 			var ok bool
 			tli, ok := li.(*net.TCPListener)
 			if !ok {
-				return fmt.Errorf("Listen returned a non-TCP listener")
+				return fmt.Errorf("listen returned a non-TCP listener")
 			}
 			if b.tls == nil {
 				b.li = li

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -6,13 +6,14 @@ package backends
 import (
 	"context"
 	"fmt"
+	"net"
+	"sync"
+	"time"
+
 	"github.com/ghjm/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"net"
-	"sync"
-	"time"
 )
 
 // UDPMaxPacketLen is the maximum size of a message that can be sent over UDP

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -15,7 +15,7 @@ const (
 
 type dialerFunc func(chan struct{}) (netceptor.BackendSession, error)
 
-// dialerSession is a convenience function for backends that use dial/retry logic
+// dialerSession is a convenience function for backends that use dial/retry logic.
 func dialerSession(ctx context.Context, redial bool, redialDelay time.Duration,
 	df dialerFunc) (chan netceptor.BackendSession, error) {
 	sessChan := make(chan netceptor.BackendSession)
@@ -72,7 +72,7 @@ type (
 	listenerCancelFunc func()
 )
 
-// listenerSession is a convenience function for backends that use listen/accept logic
+// listenerSession is a convenience function for backends that use listen/accept logic.
 func listenerSession(ctx context.Context, lf listenFunc, af acceptFunc, lcf listenerCancelFunc) (chan netceptor.BackendSession, error) {
 	err := lf()
 	if err != nil {

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -77,8 +77,7 @@ type (
 
 // listenerSession is a convenience function for backends that use listen/accept logic.
 func listenerSession(ctx context.Context, lf listenFunc, af acceptFunc, lcf listenerCancelFunc) (chan netceptor.BackendSession, error) {
-	err := lf()
-	if err != nil {
+	if err := lf(); err != nil {
 		return nil, err
 	}
 	sessChan := make(chan netceptor.BackendSession)

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -2,10 +2,11 @@ package backends
 
 import (
 	"context"
+	"time"
+
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"time"
 )
 
 const (
@@ -65,9 +66,11 @@ func dialerSession(ctx context.Context, redial bool, redialDelay time.Duration,
 	return sessChan, nil
 }
 
-type listenFunc func() error
-type acceptFunc func() (netceptor.BackendSession, error)
-type listenerCancelFunc func()
+type (
+	listenFunc         func() error
+	acceptFunc         func() (netceptor.BackendSession, error)
+	listenerCancelFunc func()
+)
 
 // listenerSession is a convenience function for backends that use listen/accept logic
 func listenerSession(ctx context.Context, lf listenFunc, af acceptFunc, lcf listenerCancelFunc) (chan netceptor.BackendSession, error) {

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -38,6 +38,7 @@ func dialerSession(ctx context.Context, redial bool, redialDelay time.Duration,
 					// continue
 				case <-ctx.Done():
 					_ = sess.Close()
+
 					return
 				}
 			}
@@ -59,10 +60,12 @@ func dialerSession(ctx context.Context, redial bool, redialDelay time.Duration,
 				} else if ctx.Err() != nil {
 					logger.Error("Backend connection exited\n")
 				}
+
 				return
 			}
 		}
 	}()
+
 	return sessChan, nil
 }
 
@@ -93,6 +96,7 @@ func listenerSession(ctx context.Context, lf listenFunc, af acceptFunc, lcf list
 			}
 			if err != nil {
 				logger.Error("Error accepting connection: %s\n", err)
+
 				return
 			}
 			select {
@@ -102,5 +106,6 @@ func listenerSession(ctx context.Context, lf listenFunc, af acceptFunc, lcf list
 			}
 		}
 	}()
+
 	return sessChan, nil
 }

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -8,19 +8,19 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"github.com/gorilla/websocket"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"math/big"
 	"net"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 // This test verifies that a websockets backend client can connect to an
 // external backend running the websockets protocol.
 func TestWebsocketExternalInterop(t *testing.T) {
-
 	// Create a Netceptor with an external backend
 	n1 := netceptor.New(context.Background(), "node1", nil)
 	b1, err := netceptor.NewExternalBackend()
@@ -61,7 +61,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 		if extra != "SomeData" {
 			t.Fatal("Extra header not passed through")
 		}
-		var upgrader = websocket.Upgrader{}
+		upgrader := websocket.Upgrader{}
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			t.Fatalf("Error upgrading websocket connection: %s", err)

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -65,6 +65,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			t.Fatalf("Error upgrading websocket connection: %s", err)
+
 			return
 		}
 		b1.NewConnection(netceptor.MessageConnFromWebsocketConn(conn), true)

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -28,6 +28,9 @@ func TestWebsocketExternalInterop(t *testing.T) {
 		t.Fatal(err)
 	}
 	err = n1.AddBackend(b1, 1.0, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Create a server TLS certificate for "localhost"
 	key, err := rsa.GenerateKey(rand.Reader, 2048)

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -58,12 +58,12 @@ func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSess
 				TLSClientConfig: b.tlscfg,
 				Proxy:           http.ProxyFromEnvironment,
 			}
-			header := make(http.Header, 0)
+			header := make(http.Header)
 			if b.extraHeader != "" {
 				extraHeaderParts := strings.SplitN(b.extraHeader, ":", 2)
-				header.Add(http.CanonicalHeaderKey(extraHeaderParts[0]), extraHeaderParts[1])
+				header.Add(extraHeaderParts[0], extraHeaderParts[1])
 			}
-			header.Add(http.CanonicalHeaderKey("origin"), b.origin)
+			header.Add("origin", b.origin)
 			conn, resp, err := dialer.DialContext(ctx, b.address, header)
 			if err != nil {
 				return nil, err

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -20,7 +20,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
-// WebsocketDialer implements Backend for outbound Websocket
+// WebsocketDialer implements Backend for outbound Websocket.
 type WebsocketDialer struct {
 	address     string
 	origin      string
@@ -29,7 +29,7 @@ type WebsocketDialer struct {
 	extraHeader string
 }
 
-// NewWebsocketDialer instantiates a new WebsocketDialer backend
+// NewWebsocketDialer instantiates a new WebsocketDialer backend.
 func NewWebsocketDialer(address string, tlscfg *tls.Config, extraHeader string, redial bool) (*WebsocketDialer, error) {
 	addrURL, err := url.Parse(address)
 	if err != nil {
@@ -49,7 +49,7 @@ func NewWebsocketDialer(address string, tlscfg *tls.Config, extraHeader string, 
 	return &wd, nil
 }
 
-// Start runs the given session function over this backend service
+// Start runs the given session function over this backend service.
 func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, b.redial, 5*time.Second,
 		func(closeChan chan struct{}) (netceptor.BackendSession, error) {
@@ -72,7 +72,7 @@ func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSess
 		})
 }
 
-// WebsocketListener implements Backend for inbound Websocket
+// WebsocketListener implements Backend for inbound Websocket.
 type WebsocketListener struct {
 	address string
 	path    string
@@ -81,7 +81,7 @@ type WebsocketListener struct {
 	server  *http.Server
 }
 
-// NewWebsocketListener instantiates a new WebsocketListener backend
+// NewWebsocketListener instantiates a new WebsocketListener backend.
 func NewWebsocketListener(address string, tlscfg *tls.Config) (*WebsocketListener, error) {
 	ul := WebsocketListener{
 		address: address,
@@ -98,7 +98,7 @@ func (b *WebsocketListener) SetPath(path string) {
 	b.path = path
 }
 
-// Addr returns the network address the listener is listening on
+// Addr returns the network address the listener is listening on.
 func (b *WebsocketListener) Addr() net.Addr {
 	if b.li == nil {
 		return nil
@@ -106,12 +106,12 @@ func (b *WebsocketListener) Addr() net.Addr {
 	return b.li.Addr()
 }
 
-// Path returns the URI path the websocket is configured on
+// Path returns the URI path the websocket is configured on.
 func (b *WebsocketListener) Path() string {
 	return b.path
 }
 
-// Start runs the given session function over the WebsocketListener backend
+// Start runs the given session function over the WebsocketListener backend.
 func (b *WebsocketListener) Start(ctx context.Context) (chan netceptor.BackendSession, error) {
 	var err error
 	sessChan := make(chan netceptor.BackendSession)
@@ -154,7 +154,7 @@ func (b *WebsocketListener) Start(ctx context.Context) (chan netceptor.BackendSe
 	return sessChan, nil
 }
 
-// WebsocketSession implements BackendSession for WebsocketDialer and WebsocketListener
+// WebsocketSession implements BackendSession for WebsocketDialer and WebsocketListener.
 type WebsocketSession struct {
 	conn            *websocket.Conn
 	recvChan        chan *recvResult
@@ -192,7 +192,7 @@ func (ns *WebsocketSession) recvChannelizer() {
 	}
 }
 
-// Send sends data over the session
+// Send sends data over the session.
 func (ns *WebsocketSession) Send(data []byte) error {
 	err := ns.conn.WriteMessage(websocket.BinaryMessage, data)
 	if err != nil {
@@ -201,7 +201,7 @@ func (ns *WebsocketSession) Send(data []byte) error {
 	return nil
 }
 
-// Recv receives data via the session
+// Recv receives data via the session.
 func (ns *WebsocketSession) Recv(timeout time.Duration) ([]byte, error) {
 	select {
 	case rr := <-ns.recvChan:
@@ -211,7 +211,7 @@ func (ns *WebsocketSession) Recv(timeout time.Duration) ([]byte, error) {
 	}
 }
 
-// Close closes the session
+// Close closes the session.
 func (ns *WebsocketSession) Close() error {
 	if ns.closeChan != nil {
 		ns.closeChanCloser.Do(func() {
@@ -226,7 +226,7 @@ func (ns *WebsocketSession) Close() error {
 // Command line
 // **************************************************************************
 
-// websocketListenerCfg is the cmdline configuration object for a websocket listener
+// websocketListenerCfg is the cmdline configuration object for a websocket listener.
 type websocketListenerCfg struct {
 	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
 	Port     int                `description:"Local TCP port to run http server on" barevalue:"yes" required:"yes"`
@@ -236,7 +236,7 @@ type websocketListenerCfg struct {
 	NodeCost map[string]float64 `description:"Per-node costs"`
 }
 
-// Prepare verifies the parameters are correct
+// Prepare verifies the parameters are correct.
 func (cfg websocketListenerCfg) Prepare() error {
 	if cfg.Cost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
@@ -249,7 +249,7 @@ func (cfg websocketListenerCfg) Prepare() error {
 	return nil
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg websocketListenerCfg) Run() error {
 	address := fmt.Sprintf("%s:%d", cfg.BindAddr, cfg.Port)
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
@@ -269,7 +269,7 @@ func (cfg websocketListenerCfg) Run() error {
 	return nil
 }
 
-// websocketDialerCfg is the cmdline configuration object for a Websocket listener
+// websocketDialerCfg is the cmdline configuration object for a Websocket listener.
 type websocketDialerCfg struct {
 	Address     string  `description:"URL to connect to" barevalue:"yes" required:"yes"`
 	Redial      bool    `description:"Keep redialing on lost connection" default:"true"`
@@ -278,7 +278,7 @@ type websocketDialerCfg struct {
 	Cost        float64 `description:"Connection cost (weight)" default:"1.0"`
 }
 
-// Prepare verifies that we are reasonably ready to go
+// Prepare verifies that we are reasonably ready to go.
 func (cfg websocketDialerCfg) Prepare() error {
 	if cfg.Cost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
@@ -293,7 +293,7 @@ func (cfg websocketDialerCfg) Prepare() error {
 	return nil
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg websocketDialerCfg) Run() error {
 	logger.Debug("Running Websocket peer connection %s\n", cfg.Address)
 	u, err := url.Parse(cfg.Address)

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -46,6 +46,7 @@ func NewWebsocketDialer(address string, tlscfg *tls.Config, extraHeader string, 
 		tlscfg:      tlscfg,
 		extraHeader: extraHeader,
 	}
+
 	return &wd, nil
 }
 
@@ -68,6 +69,7 @@ func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSess
 				return nil, err
 			}
 			ns := newWebsocketSession(conn, closeChan)
+
 			return ns, nil
 		})
 }
@@ -89,6 +91,7 @@ func NewWebsocketListener(address string, tlscfg *tls.Config) (*WebsocketListene
 		tlscfg:  tlscfg,
 		li:      nil,
 	}
+
 	return &ul, nil
 }
 
@@ -103,6 +106,7 @@ func (b *WebsocketListener) Addr() net.Addr {
 	if b.li == nil {
 		return nil
 	}
+
 	return b.li.Addr()
 }
 
@@ -121,6 +125,7 @@ func (b *WebsocketListener) Start(ctx context.Context) (chan netceptor.BackendSe
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			logger.Error("Error upgrading websocket connection: %s\n", err)
+
 			return
 		}
 		ws := newWebsocketSession(conn, nil)
@@ -151,6 +156,7 @@ func (b *WebsocketListener) Start(ctx context.Context) (chan netceptor.BackendSe
 		_ = b.server.Close()
 	}()
 	logger.Debug("Listening on Websocket %s path %s\n", b.Addr().String(), b.Path())
+
 	return sessChan, nil
 }
 
@@ -175,6 +181,7 @@ func newWebsocketSession(conn *websocket.Conn, closeChan chan struct{}) *Websock
 		closeChanCloser: sync.Once{},
 	}
 	go ws.recvChannelizer()
+
 	return ws
 }
 
@@ -198,6 +205,7 @@ func (ns *WebsocketSession) Send(data []byte) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -219,6 +227,7 @@ func (ns *WebsocketSession) Close() error {
 			ns.closeChan = nil
 		})
 	}
+
 	return ns.conn.Close()
 }
 
@@ -246,6 +255,7 @@ func (cfg websocketListenerCfg) Prepare() error {
 			return fmt.Errorf("connection cost must be positive for %s", node)
 		}
 	}
+
 	return nil
 }
 
@@ -259,6 +269,7 @@ func (cfg websocketListenerCfg) Run() error {
 	b, err := NewWebsocketListener(address, tlscfg)
 	if err != nil {
 		logger.Error("Error creating listener %s: %s\n", address, err)
+
 		return err
 	}
 	b.SetPath(cfg.Path)
@@ -266,6 +277,7 @@ func (cfg websocketListenerCfg) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -290,6 +302,7 @@ func (cfg websocketDialerCfg) Prepare() error {
 	if cfg.ExtraHeader != "" && !strings.Contains(cfg.ExtraHeader, ":") {
 		return fmt.Errorf("extra header must be in the form key:value")
 	}
+
 	return nil
 }
 
@@ -311,12 +324,14 @@ func (cfg websocketDialerCfg) Run() error {
 	b, err := NewWebsocketDialer(cfg.Address, tlscfg, cfg.ExtraHeader, cfg.Redial)
 	if err != nil {
 		logger.Error("Error creating peer %s: %s\n", cfg.Address, err)
+
 		return err
 	}
 	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, nil)
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -64,8 +64,11 @@ func (b *WebsocketDialer) Start(ctx context.Context) (chan netceptor.BackendSess
 				header.Add(http.CanonicalHeaderKey(extraHeaderParts[0]), extraHeaderParts[1])
 			}
 			header.Add(http.CanonicalHeaderKey("origin"), b.origin)
-			conn, _, err := dialer.DialContext(ctx, b.address, header)
+			conn, resp, err := dialer.DialContext(ctx, b.address, header)
 			if err != nil {
+				return nil, err
+			}
+			if resp.Body.Close(); err != nil {
 				return nil, err
 			}
 			ns := newWebsocketSession(conn, closeChan)

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -298,8 +298,7 @@ func (cfg websocketDialerCfg) Prepare() error {
 	if cfg.Cost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")
 	}
-	_, err := url.Parse(cfg.Address)
-	if err != nil {
+	if _, err := url.Parse(cfg.Address); err != nil {
 		return fmt.Errorf("address %s is not a valid URL: %s", cfg.Address, err)
 	}
 	if cfg.ExtraHeader != "" && !strings.Contains(cfg.ExtraHeader, ":") {

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -7,16 +7,17 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/ghjm/cmdline"
-	"github.com/gorilla/websocket"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ghjm/cmdline"
+	"github.com/gorilla/websocket"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 // WebsocketDialer implements Backend for outbound Websocket
@@ -116,7 +117,7 @@ func (b *WebsocketListener) Start(ctx context.Context) (chan netceptor.BackendSe
 	sessChan := make(chan netceptor.BackendSession)
 	mux := http.NewServeMux()
 	mux.HandleFunc(b.path, func(w http.ResponseWriter, r *http.Request) {
-		var upgrader = websocket.Upgrader{}
+		upgrader := websocket.Upgrader{}
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			logger.Error("Error upgrading websocket connection: %s\n", err)

--- a/pkg/certificates/ca.go
+++ b/pkg/certificates/ca.go
@@ -10,12 +10,13 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"io/ioutil"
 	"math/big"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // CertNames lists the subjectAltNames that can be assigned to a certificate or request
@@ -121,7 +122,7 @@ func SaveToPEMFile(filename string, data []interface{}) error {
 			continue
 		}
 	}
-	return ioutil.WriteFile(filename, []byte(strings.Join(content, "\n")), 0600)
+	return ioutil.WriteFile(filename, []byte(strings.Join(content, "\n")), 0o600)
 }
 
 // LoadCertificate loads a single certificate from a file

--- a/pkg/certificates/ca.go
+++ b/pkg/certificates/ca.go
@@ -45,28 +45,29 @@ func LoadFromPEMFile(filename string) ([]interface{}, error) {
 	var block *pem.Block
 	for len(content) > 0 {
 		block, content = pem.Decode(content)
-		if block.Type == "CERTIFICATE" {
+		switch block.Type {
+		case "CERTIFICATE":
 			var cert *x509.Certificate
 			cert, err = x509.ParseCertificate(block.Bytes)
 			if err != nil {
 				return nil, err
 			}
 			results = append(results, cert)
-		} else if block.Type == "CERTIFICATE REQUEST" {
+		case "CERTIFICATE REQUEST":
 			var req *x509.CertificateRequest
 			req, err = x509.ParseCertificateRequest(block.Bytes)
 			if err != nil {
 				return nil, err
 			}
 			results = append(results, req)
-		} else if block.Type == "RSA PRIVATE KEY" {
+		case "RSA PRIVATE KEY":
 			var key *rsa.PrivateKey
 			key, err = x509.ParsePKCS1PrivateKey(block.Bytes)
 			if err != nil {
 				return nil, err
 			}
 			results = append(results, key)
-		} else {
+		default:
 			return nil, fmt.Errorf("unknown block type %s", block.Type)
 		}
 	}

--- a/pkg/certificates/ca.go
+++ b/pkg/certificates/ca.go
@@ -19,7 +19,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// CertNames lists the subjectAltNames that can be assigned to a certificate or request
+// CertNames lists the subjectAltNames that can be assigned to a certificate or request.
 type CertNames struct {
 	DNSNames    []string
 	NodeIDs     []string
@@ -125,7 +125,7 @@ func SaveToPEMFile(filename string, data []interface{}) error {
 	return ioutil.WriteFile(filename, []byte(strings.Join(content, "\n")), 0o600)
 }
 
-// LoadCertificate loads a single certificate from a file
+// LoadCertificate loads a single certificate from a file.
 func LoadCertificate(filename string) (*x509.Certificate, error) {
 	data, err := LoadFromPEMFile(filename)
 	if err != nil {
@@ -141,7 +141,7 @@ func LoadCertificate(filename string) (*x509.Certificate, error) {
 	return cert, nil
 }
 
-// LoadRequest loads a single certificate request from a file
+// LoadRequest loads a single certificate request from a file.
 func LoadRequest(filename string) (*x509.CertificateRequest, error) {
 	data, err := LoadFromPEMFile(filename)
 	if err != nil {
@@ -157,7 +157,7 @@ func LoadRequest(filename string) (*x509.CertificateRequest, error) {
 	return req, nil
 }
 
-// LoadPrivateKey loads a single RSA private key from a file
+// LoadPrivateKey loads a single RSA private key from a file.
 func LoadPrivateKey(filename string) (*rsa.PrivateKey, error) {
 	data, err := LoadFromPEMFile(filename)
 	if err != nil {

--- a/pkg/certificates/ca.go
+++ b/pkg/certificates/ca.go
@@ -70,6 +70,7 @@ func LoadFromPEMFile(filename string) ([]interface{}, error) {
 			return nil, fmt.Errorf("unknown block type %s", block.Type)
 		}
 	}
+
 	return results, nil
 }
 
@@ -91,6 +92,7 @@ func SaveToPEMFile(filename string, data []interface{}) error {
 				return err
 			}
 			content = append(content, certPEM.String())
+
 			continue
 		}
 		var req *x509.CertificateRequest
@@ -105,6 +107,7 @@ func SaveToPEMFile(filename string, data []interface{}) error {
 				return err
 			}
 			content = append(content, reqPEM.String())
+
 			continue
 		}
 		var key *rsa.PrivateKey
@@ -119,9 +122,11 @@ func SaveToPEMFile(filename string, data []interface{}) error {
 				return err
 			}
 			content = append(content, keyPEM.String())
+
 			continue
 		}
 	}
+
 	return ioutil.WriteFile(filename, []byte(strings.Join(content, "\n")), 0o600)
 }
 
@@ -138,6 +143,7 @@ func LoadCertificate(filename string) (*x509.Certificate, error) {
 	if !ok {
 		return nil, fmt.Errorf("certificate file does not contain certificate data")
 	}
+
 	return cert, nil
 }
 
@@ -154,6 +160,7 @@ func LoadRequest(filename string) (*x509.CertificateRequest, error) {
 	if !ok {
 		return nil, fmt.Errorf("certificate request file does not contain certificate request data")
 	}
+
 	return req, nil
 }
 
@@ -170,6 +177,7 @@ func LoadPrivateKey(filename string) (*rsa.PrivateKey, error) {
 	if !ok {
 		return nil, fmt.Errorf("private key file does not contain private key data")
 	}
+
 	return key, nil
 }
 
@@ -239,6 +247,7 @@ func CreateCertReqWithKey(opts *CertOptions) (*x509.CertificateRequest, *rsa.Pri
 	if err != nil {
 		return nil, nil, err
 	}
+
 	return req, key, nil
 }
 
@@ -290,6 +299,7 @@ func GetReqNames(request *x509.CertificateRequest) (*CertNames, error) {
 		NodeIDs:     nodeIDs,
 		IPAddresses: request.IPAddresses,
 	}
+
 	return cn, nil
 }
 
@@ -320,6 +330,7 @@ func SignCertReq(req *x509.CertificateRequest, ca *CA, opts *CertOptions) (*x509
 		if ext.Id.Equal(utils.OIDSubjectAltName) {
 			certTemplate.ExtraExtensions = []pkix.Extension{ext}
 			found = true
+
 			break
 		}
 	}
@@ -336,5 +347,6 @@ func SignCertReq(req *x509.CertificateRequest, ca *CA, opts *CertOptions) (*x509
 	if err != nil {
 		return nil, err
 	}
+
 	return cert, nil
 }

--- a/pkg/certificates/cli.go
+++ b/pkg/certificates/cli.go
@@ -48,6 +48,7 @@ func (ica initCA) Run() error {
 	if err == nil {
 		err = SaveToPEMFile(ica.OutKey, []interface{}{ca.PrivateKey})
 	}
+
 	return err
 }
 
@@ -75,6 +76,7 @@ func (mr makeReq) Prepare() error {
 	if mr.OutKey != "" && mr.Bits == 0 {
 		return fmt.Errorf("must specify key bits when creating a new key")
 	}
+
 	return nil
 }
 
@@ -136,6 +138,7 @@ func (mr makeReq) Run() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -224,6 +227,7 @@ func (sr signReq) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return SaveToPEMFile(sr.OutCert, []interface{}{cert})
 }
 

--- a/pkg/certificates/cli.go
+++ b/pkg/certificates/cli.go
@@ -6,10 +6,11 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
-	"github.com/ghjm/cmdline"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/ghjm/cmdline"
 )
 
 type initCA struct {

--- a/pkg/controlsvc/connect.go
+++ b/pkg/controlsvc/connect.go
@@ -2,16 +2,19 @@ package controlsvc
 
 import (
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"strings"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
-type connectCommandType struct{}
-type connectCommand struct {
-	targetNode    string
-	targetService string
-	tlsConfigName string
-}
+type (
+	connectCommandType struct{}
+	connectCommand     struct {
+		targetNode    string
+		targetService string
+		tlsConfigName string
+	}
+)
 
 func (t *connectCommandType) InitFromString(params string) (ControlCommand, error) {
 	tokens := strings.Split(params, " ")

--- a/pkg/controlsvc/connect.go
+++ b/pkg/controlsvc/connect.go
@@ -33,6 +33,7 @@ func (t *connectCommandType) InitFromString(params string) (ControlCommand, erro
 		targetService: tokens[1],
 		tlsConfigName: tlsConfigName,
 	}
+
 	return c, nil
 }
 
@@ -68,6 +69,7 @@ func (t *connectCommandType) InitFromJSON(config map[string]interface{}) (Contro
 		targetService: targetServiceStr,
 		tlsConfigName: tlsConfigStr,
 	}
+
 	return c, nil
 }
 
@@ -84,5 +86,6 @@ func (c *connectCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOpe
 	if err != nil {
 		return nil, err
 	}
+
 	return nil, nil
 }

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -274,7 +274,7 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 	}
 	var tli net.Listener
 	if TCPListen != "" {
-		listenAddr := ""
+		var listenAddr string
 		if strings.Contains(TCPListen, ":") {
 			listenAddr = TCPListen
 		} else {

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -21,12 +21,12 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// sockControl implements the ControlFuncOperations interface that is passed back to control functions
+// sockControl implements the ControlFuncOperations interface that is passed back to control functions.
 type sockControl struct {
 	conn net.Conn
 }
 
-// BridgeConn bridges the socket to another socket
+// BridgeConn bridges the socket to another socket.
 func (s *sockControl) BridgeConn(message string, bc io.ReadWriteCloser, bcName string) error {
 	if message != "" {
 		_, err := s.conn.Write([]byte(message))
@@ -38,7 +38,7 @@ func (s *sockControl) BridgeConn(message string, bc io.ReadWriteCloser, bcName s
 	return nil
 }
 
-// ReadFromConn copies from the socket to an io.Writer, until EOF
+// ReadFromConn copies from the socket to an io.Writer, until EOF.
 func (s *sockControl) ReadFromConn(message string, out io.Writer) error {
 	if message != "" {
 		_, err := s.conn.Write([]byte(message))
@@ -53,7 +53,7 @@ func (s *sockControl) ReadFromConn(message string, out io.Writer) error {
 	return nil
 }
 
-// WriteToConn writes an initial string, and then messages to a channel, to the connection
+// WriteToConn writes an initial string, and then messages to a channel, to the connection.
 func (s *sockControl) WriteToConn(message string, in chan []byte) error {
 	if message != "" {
 		_, err := s.conn.Write([]byte(message))
@@ -74,7 +74,7 @@ func (s *sockControl) Close() error {
 	return s.conn.Close()
 }
 
-// Server is an instance of a control service
+// Server is an instance of a control service.
 type Server struct {
 	nc              *netceptor.Netceptor
 	controlFuncLock sync.RWMutex
@@ -97,7 +97,7 @@ func New(stdServices bool, nc *netceptor.Netceptor) *Server {
 	return s
 }
 
-// MainInstance is the global instance of the control service instantiated by the command-line main() function
+// MainInstance is the global instance of the control service instantiated by the command-line main() function.
 var MainInstance *Server
 
 // AddControlFunc registers a function that can be used from a control socket.
@@ -112,7 +112,7 @@ func (s *Server) AddControlFunc(name string, cType ControlCommandType) error {
 	return nil
 }
 
-// RunControlSession runs the server protocol on the given connection
+// RunControlSession runs the server protocol on the given connection.
 func (s *Server) RunControlSession(conn net.Conn) {
 	logger.Info("Client connected to control service\n")
 	defer func() {
@@ -244,7 +244,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 	}
 }
 
-// RunControlSvc runs the main accept loop of the control service
+// RunControlSvc runs the main accept loop of the control service.
 func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.Config,
 	unixSocket string, unixSocketPermissions os.FileMode, TCPListen string, tcptls *tls.Config) error {
 	var uli net.Listener
@@ -354,7 +354,7 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 // Command line
 // **************************************************************************
 
-// cmdlineConfigWindows is the cmdline configuration object for a control service on Windows
+// cmdlineConfigWindows is the cmdline configuration object for a control service on Windows.
 type cmdlineConfigWindows struct {
 	Service   string `description:"Receptor service name to listen on" default:"control"`
 	TLS       string `description:"Name of TLS server config for the Receptor listener"`
@@ -362,7 +362,7 @@ type cmdlineConfigWindows struct {
 	TCPTLS    string `description:"Name of TLS server config for the TCP listener"`
 }
 
-// cmdlineConfigUnix is the cmdline configuration object for a control service on Unix
+// cmdlineConfigUnix is the cmdline configuration object for a control service on Unix.
 type cmdlineConfigUnix struct {
 	Service     string `description:"Receptor service name to listen on" default:"control"`
 	Filename    string `description:"Filename of local Unix socket to bind to the service"`
@@ -372,7 +372,7 @@ type cmdlineConfigUnix struct {
 	TCPTLS      string `description:"Name of TLS server config for the TCP listener"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg cmdlineConfigUnix) Run() error {
 	if cfg.TLS != "" && cfg.TCPListen != "" && cfg.TCPTLS == "" {
 		logger.Warning("Control service %s has TLS configured on the Receptor listener but not the TCP listener.", cfg.Service)
@@ -396,7 +396,7 @@ func (cfg cmdlineConfigUnix) Run() error {
 	return nil
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg cmdlineConfigWindows) Run() error {
 	return cmdlineConfigUnix{
 		Service:   cfg.Service,

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -227,24 +227,22 @@ func (s *Server) RunControlSession(conn net.Conn) {
 
 					return
 				}
-			} else {
-				if cfr != nil {
-					rbytes, err := json.Marshal(cfr)
-					if err != nil {
-						_, err = conn.Write([]byte(fmt.Sprintf("ERROR: could not convert response to JSON: %s\n", err)))
-						if err != nil {
-							logger.Error("Write error in control service: %s\n", err)
-
-							return
-						}
-					}
-					rbytes = append(rbytes, '\n')
-					_, err = conn.Write(rbytes)
+			} else if cfr != nil {
+				rbytes, err := json.Marshal(cfr)
+				if err != nil {
+					_, err = conn.Write([]byte(fmt.Sprintf("ERROR: could not convert response to JSON: %s\n", err)))
 					if err != nil {
 						logger.Error("Write error in control service: %s\n", err)
 
 						return
 					}
+				}
+				rbytes = append(rbytes, '\n')
+				_, err = conn.Write(rbytes)
+				if err != nil {
+					logger.Error("Write error in control service: %s\n", err)
+
+					return
 				}
 			}
 		} else {
@@ -260,7 +258,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 
 // RunControlSvc runs the main accept loop of the control service.
 func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.Config,
-	unixSocket string, unixSocketPermissions os.FileMode, TCPListen string, tcptls *tls.Config) error {
+	unixSocket string, unixSocketPermissions os.FileMode, tcpListen string, tcptls *tls.Config) error {
 	var uli net.Listener
 	var lock *utils.FLock
 	var err error
@@ -273,12 +271,12 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 		uli = nil
 	}
 	var tli net.Listener
-	if TCPListen != "" {
+	if tcpListen != "" {
 		var listenAddr string
-		if strings.Contains(TCPListen, ":") {
-			listenAddr = TCPListen
+		if strings.Contains(tcpListen, ":") {
+			listenAddr = tcpListen
 		} else {
-			listenAddr = fmt.Sprintf("0.0.0.0:%s", TCPListen)
+			listenAddr = fmt.Sprintf("0.0.0.0:%s", tcpListen)
 		}
 		tli, err = net.Listen("tcp", listenAddr)
 		if err != nil {

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -47,8 +47,8 @@ func (s *sockControl) ReadFromConn(message string, out io.Writer) error {
 			return err
 		}
 	}
-	_, err := io.Copy(out, s.conn)
-	if err != nil {
+
+	if _, err := io.Copy(out, s.conn); err != nil {
 		return err
 	}
 
@@ -108,8 +108,8 @@ var MainInstance *Server
 func (s *Server) AddControlFunc(name string, cType ControlCommandType) error {
 	s.controlFuncLock.Lock()
 	defer s.controlFuncLock.Unlock()
-	_, ok := s.controlTypes[name]
-	if ok {
+
+	if _, ok := s.controlTypes[name]; ok {
 		return fmt.Errorf("control function named %s already exists", name)
 	}
 	s.controlTypes[name] = cType

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -248,7 +248,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 				}
 			}
 		} else {
-			_, err = conn.Write([]byte(fmt.Sprintf("ERROR: Unknown command\n")))
+			_, err = conn.Write([]byte("ERROR: Unknown command\n"))
 			if err != nil {
 				logger.Error("Write error in control service: %s\n", err)
 
@@ -304,20 +304,16 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 	}
 	logger.Info("Running control service %s\n", service)
 	go func() {
-		select {
-		case <-ctx.Done():
-			if uli != nil {
-				_ = uli.Close()
-				_ = lock.Unlock()
-			}
-			if li != nil {
-				_ = li.Close()
-			}
-			if tli != nil {
-				_ = tli.Close()
-			}
-
-			return
+		<-ctx.Done()
+		if uli != nil {
+			_ = uli.Close()
+			_ = lock.Unlock()
+		}
+		if li != nil {
+			_ = li.Close()
+		}
+		if tli != nil {
+			_ = tli.Close()
 		}
 	}()
 	for _, listener := range []net.Listener{uli, tli, li} {

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -7,10 +7,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"io"
 	"net"
 	"os"
@@ -18,6 +14,11 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/ghjm/cmdline"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // sockControl implements the ControlFuncOperations interface that is passed back to control functions

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -35,6 +35,7 @@ func (s *sockControl) BridgeConn(message string, bc io.ReadWriteCloser, bcName s
 		}
 	}
 	utils.BridgeConns(s.conn, "control service", bc, bcName)
+
 	return nil
 }
 
@@ -50,6 +51,7 @@ func (s *sockControl) ReadFromConn(message string, out io.Writer) error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -67,6 +69,7 @@ func (s *sockControl) WriteToConn(message string, in chan []byte) error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -94,6 +97,7 @@ func New(stdServices bool, nc *netceptor.Netceptor) *Server {
 		s.controlTypes["connect"] = &connectCommandType{}
 		s.controlTypes["traceroute"] = &tracerouteCommandType{}
 	}
+
 	return s
 }
 
@@ -109,6 +113,7 @@ func (s *Server) AddControlFunc(name string, cType ControlCommandType) error {
 		return fmt.Errorf("control function named %s already exists", name)
 	}
 	s.controlTypes[name] = cType
+
 	return nil
 }
 
@@ -125,6 +130,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 	_, err := conn.Write([]byte(fmt.Sprintf("Receptor Control, node %s\n", s.nc.NodeID())))
 	if err != nil {
 		logger.Error("Write error in control service: %s\n", err)
+
 		return
 	}
 	done := false
@@ -138,9 +144,11 @@ func (s *Server) RunControlSession(conn net.Conn) {
 			if err == io.EOF {
 				logger.Info("Control service closed\n")
 				done = true
+
 				break
 			} else if err != nil {
 				logger.Error("Read error in control service: %s\n", err)
+
 				return
 			}
 			if n == 1 {
@@ -175,6 +183,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 				_, err = conn.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
 				if err != nil {
 					logger.Error("Write error in control service: %s\n", err)
+
 					return
 				}
 			}
@@ -192,6 +201,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 		for f := range s.controlTypes {
 			if f == cmd {
 				ct = s.controlTypes[f]
+
 				break
 			}
 		}
@@ -214,6 +224,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 				_, err = conn.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
 				if err != nil {
 					logger.Error("Write error in control service: %s\n", err)
+
 					return
 				}
 			} else {
@@ -223,6 +234,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 						_, err = conn.Write([]byte(fmt.Sprintf("ERROR: could not convert response to JSON: %s\n", err)))
 						if err != nil {
 							logger.Error("Write error in control service: %s\n", err)
+
 							return
 						}
 					}
@@ -230,6 +242,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 					_, err = conn.Write(rbytes)
 					if err != nil {
 						logger.Error("Write error in control service: %s\n", err)
+
 						return
 					}
 				}
@@ -238,6 +251,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 			_, err = conn.Write([]byte(fmt.Sprintf("ERROR: Unknown command\n")))
 			if err != nil {
 				logger.Error("Write error in control service: %s\n", err)
+
 				return
 			}
 		}
@@ -302,6 +316,7 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 			if tli != nil {
 				_ = tli.Close()
 			}
+
 			return
 		}
 	}()
@@ -316,6 +331,7 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 					if err != nil {
 						logger.Error("Error accepting connection: %s. Closing listener.\n", err)
 						_ = listener.Close()
+
 						return
 					}
 					go func() {
@@ -326,18 +342,21 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 							if err != nil {
 								logger.Error("Error setting timeout: %s. Closing socket.\n", err)
 								_ = conn.Close()
+
 								return
 							}
 							err = tlsConn.Handshake()
 							if err != nil {
 								logger.Error("TLS handshake error: %s. Closing socket.\n", err)
 								_ = conn.Close()
+
 								return
 							}
 							err = conn.SetDeadline(time.Time{})
 							if err != nil {
 								logger.Error("Error clearing timeout: %s. Closing socket.\n", err)
 								_ = conn.Close()
+
 								return
 							}
 						}
@@ -347,6 +366,7 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 			}(listener)
 		}
 	}
+
 	return nil
 }
 
@@ -393,6 +413,7 @@ func (cfg cmdlineConfigUnix) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/controlsvc/controlsvc_stub.go
+++ b/pkg/controlsvc/controlsvc_stub.go
@@ -8,17 +8,17 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"net"
 	"os"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 // ErrNotImplemented is returned by most functions in this unit since it is a non-functional stub
 var ErrNotImplemented = fmt.Errorf("not implemented")
 
 // Server is an instance of a control service
-type Server struct {
-}
+type Server struct{}
 
 // New returns a new instance of a control service.
 func New(stdServices bool, nc *netceptor.Netceptor) *Server {

--- a/pkg/controlsvc/interfaces.go
+++ b/pkg/controlsvc/interfaces.go
@@ -6,18 +6,18 @@ import (
 	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
-// ControlCommandType is a type of command that can be run from the control service
+// ControlCommandType is a type of command that can be run from the control service.
 type ControlCommandType interface {
 	InitFromString(string) (ControlCommand, error)
 	InitFromJSON(map[string]interface{}) (ControlCommand, error)
 }
 
-// ControlCommand is an instance of a command that is being run from the control service
+// ControlCommand is an instance of a command that is being run from the control service.
 type ControlCommand interface {
 	ControlFunc(*netceptor.Netceptor, ControlFuncOperations) (map[string]interface{}, error)
 }
 
-// ControlFuncOperations provides callbacks for control services to take actions
+// ControlFuncOperations provides callbacks for control services to take actions.
 type ControlFuncOperations interface {
 	BridgeConn(message string, bc io.ReadWriteCloser, bcName string) error
 	ReadFromConn(message string, out io.Writer) error

--- a/pkg/controlsvc/interfaces.go
+++ b/pkg/controlsvc/interfaces.go
@@ -1,8 +1,9 @@
 package controlsvc
 
 import (
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"io"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 // ControlCommandType is a type of command that can be run from the control service

--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -3,15 +3,18 @@ package controlsvc
 import (
 	"context"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"strings"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
-type pingCommandType struct{}
-type pingCommand struct {
-	target string
-}
+type (
+	pingCommandType struct{}
+	pingCommand     struct {
+		target string
+	}
+)
 
 func (t *pingCommandType) InitFromString(params string) (ControlCommand, error) {
 	if params == "" {

--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -41,7 +41,7 @@ func (t *pingCommandType) InitFromJSON(config map[string]interface{}) (ControlCo
 	return c, nil
 }
 
-// ping is the internal implementation of sending a single ping packet and waiting for a reply or error
+// ping is the internal implementation of sending a single ping packet and waiting for a reply or error.
 func ping(nc *netceptor.Netceptor, target string, hopsToLive byte) (time.Duration, string, error) {
 	pc, err := nc.ListenPacket("")
 	if err != nil {

--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -23,6 +23,7 @@ func (t *pingCommandType) InitFromString(params string) (ControlCommand, error) 
 	c := &pingCommand{
 		target: params,
 	}
+
 	return c, nil
 }
 
@@ -38,6 +39,7 @@ func (t *pingCommandType) InitFromJSON(config map[string]interface{}) (ControlCo
 	c := &pingCommand{
 		target: targetStr,
 	}
+
 	return c, nil
 }
 
@@ -121,5 +123,6 @@ func (c *pingCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperat
 		cfr["Success"] = false
 		cfr["Error"] = err.Error()
 	}
+
 	return cfr, nil
 }

--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -118,7 +118,7 @@ func (c *pingCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperat
 		cfr["Success"] = true
 		cfr["From"] = pingRemote
 		cfr["Time"] = pingTime
-		cfr["TimeStr"] = fmt.Sprintf("%s", pingTime)
+		cfr["TimeStr"] = fmt.Sprint(pingTime)
 	} else {
 		cfr["Success"] = false
 		cfr["Error"] = err.Error()

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -20,6 +20,7 @@ func (t *statusCommandType) InitFromString(params string) (ControlCommand, error
 		return nil, fmt.Errorf("status command does not take parameters")
 	}
 	c := &statusCommand{}
+
 	return c, nil
 }
 
@@ -41,6 +42,7 @@ func (t *statusCommandType) InitFromJSON(config map[string]interface{}) (Control
 	c := &statusCommand{
 		requestedFields: requestedFieldsStr,
 	}
+
 	return c, nil
 }
 
@@ -67,5 +69,6 @@ func (c *statusCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOper
 			cfr[field] = getter()
 		}
 	}
+
 	return cfr, nil
 }

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -2,15 +2,18 @@ package controlsvc
 
 import (
 	"fmt"
+
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
 	"github.com/project-receptor/receptor/pkg/version"
 )
 
-type statusCommandType struct{}
-type statusCommand struct {
-	requestedFields []string
-}
+type (
+	statusCommandType struct{}
+	statusCommand     struct {
+		requestedFields []string
+	}
+)
 
 func (t *statusCommandType) InitFromString(params string) (ControlCommand, error) {
 	if params != "" {

--- a/pkg/controlsvc/traceroute.go
+++ b/pkg/controlsvc/traceroute.go
@@ -21,6 +21,7 @@ func (t *tracerouteCommandType) InitFromString(params string) (ControlCommand, e
 	c := &tracerouteCommand{
 		target: params,
 	}
+
 	return c, nil
 }
 
@@ -36,6 +37,7 @@ func (t *tracerouteCommandType) InitFromJSON(config map[string]interface{}) (Con
 	c := &tracerouteCommand{
 		target: targetStr,
 	}
+
 	return c, nil
 }
 
@@ -55,5 +57,6 @@ func (c *tracerouteCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFunc
 			break
 		}
 	}
+
 	return cfr, nil
 }

--- a/pkg/controlsvc/traceroute.go
+++ b/pkg/controlsvc/traceroute.go
@@ -48,7 +48,7 @@ func (c *tracerouteCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFunc
 		pingTime, pingRemote, err := ping(nc, c.target, byte(i))
 		thisResult["From"] = pingRemote
 		thisResult["Time"] = pingTime
-		thisResult["TimeStr"] = fmt.Sprintf("%s", pingTime)
+		thisResult["TimeStr"] = fmt.Sprint(pingTime)
 		if err != nil && err.Error() != netceptor.ProblemExpiredInTransit {
 			thisResult["Error"] = err.Error()
 		}

--- a/pkg/controlsvc/traceroute.go
+++ b/pkg/controlsvc/traceroute.go
@@ -2,14 +2,17 @@ package controlsvc
 
 import (
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"strconv"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
-type tracerouteCommandType struct{}
-type tracerouteCommand struct {
-	target string
-}
+type (
+	tracerouteCommandType struct{}
+	tracerouteCommand     struct {
+		target string
+	}
+)
 
 func (t *tracerouteCommandType) InitFromString(params string) (ControlCommand, error) {
 	if params == "" {

--- a/pkg/framer/framer.go
+++ b/pkg/framer/framer.go
@@ -25,6 +25,7 @@ func New() Framer {
 		bufLock: &sync.RWMutex{},
 		buffer:  make([]byte, 0),
 	}
+
 	return f
 }
 
@@ -33,6 +34,7 @@ func (f *framer) SendData(data []byte) []byte {
 	buf := make([]byte, len(data)+2)
 	binary.LittleEndian.PutUint16(buf[0:2], uint16(len(data)))
 	copy(buf[2:], data)
+
 	return buf
 }
 
@@ -49,6 +51,7 @@ func (f *framer) messageReady() (int, bool) {
 		return 0, false
 	}
 	msgSize := int(binary.LittleEndian.Uint16(f.buffer[:2]))
+
 	return msgSize, len(f.buffer) >= msgSize+2
 }
 
@@ -57,6 +60,7 @@ func (f *framer) MessageReady() bool {
 	f.bufLock.RLock()
 	defer f.bufLock.RUnlock()
 	_, ready := f.messageReady()
+
 	return ready
 }
 
@@ -70,5 +74,6 @@ func (f *framer) GetMessage() ([]byte, error) {
 	}
 	data := f.buffer[2 : msgSize+2]
 	f.buffer = f.buffer[msgSize+2:]
+
 	return data, nil
 }

--- a/pkg/framer/framer.go
+++ b/pkg/framer/framer.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 )
 
-// Framer provides framing of discrete data entities over a stream connection
+// Framer provides framing of discrete data entities over a stream connection.
 type Framer interface {
 	SendData(data []byte) []byte
 	RecvData(buf []byte)
@@ -19,7 +19,7 @@ type framer struct {
 	buffer  []byte
 }
 
-// New returns a new framer instance
+// New returns a new framer instance.
 func New() Framer {
 	f := &framer{
 		bufLock: &sync.RWMutex{},
@@ -28,7 +28,7 @@ func New() Framer {
 	return f
 }
 
-// SendData takes a data buffer and returns a framed buffer
+// SendData takes a data buffer and returns a framed buffer.
 func (f *framer) SendData(data []byte) []byte {
 	buf := make([]byte, len(data)+2)
 	binary.LittleEndian.PutUint16(buf[0:2], uint16(len(data)))
@@ -36,14 +36,14 @@ func (f *framer) SendData(data []byte) []byte {
 	return buf
 }
 
-// RecvData adds more data to the buffer from the network
+// RecvData adds more data to the buffer from the network.
 func (f *framer) RecvData(buf []byte) {
 	f.bufLock.Lock()
 	defer f.bufLock.Unlock()
 	f.buffer = append(f.buffer, buf...)
 }
 
-// Caller must already hold at least a read lock on f.bufLock
+// Caller must already hold at least a read lock on f.bufLock.
 func (f *framer) messageReady() (int, bool) {
 	if len(f.buffer) < 2 {
 		return 0, false
@@ -52,7 +52,7 @@ func (f *framer) messageReady() (int, bool) {
 	return msgSize, len(f.buffer) >= msgSize+2
 }
 
-// MessageReady returns true if a full framed message is available to read
+// MessageReady returns true if a full framed message is available to read.
 func (f *framer) MessageReady() bool {
 	f.bufLock.RLock()
 	defer f.bufLock.RUnlock()

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -14,7 +14,7 @@ var (
 	showTrace bool
 )
 
-// Log level constants
+// Log level constants.
 const (
 	ErrorLevel = iota + 1
 	WarningLevel
@@ -22,23 +22,23 @@ const (
 	DebugLevel
 )
 
-// QuietMode turns off all log output
+// QuietMode turns off all log output.
 func QuietMode() {
 	logLevel = 0
 }
 
-// SetLogLevel is a helper function for setting logLevel int
+// SetLogLevel is a helper function for setting logLevel int.
 func SetLogLevel(level int) {
 	logLevel = level
 }
 
-// SetShowTrace is a helper function for setting showTrace bool
+// SetShowTrace is a helper function for setting showTrace bool.
 func SetShowTrace(trace bool) {
 	showTrace = trace
 }
 
 // GetLogLevelByName is a helper function for returning level associated with log
-// level string
+// level string.
 func GetLogLevelByName(logName string) (int, error) {
 	var err error
 	if val, hasKey := logLevelMap[strings.ToLower(logName)]; hasKey {
@@ -48,12 +48,12 @@ func GetLogLevelByName(logName string) (int, error) {
 	return 0, err
 }
 
-// GetLogLevel returns current log level
+// GetLogLevel returns current log level.
 func GetLogLevel() int {
 	return logLevel
 }
 
-// LogLevelToName takes an int and returns the corresponding log level name
+// LogLevelToName takes an int and returns the corresponding log level name.
 func LogLevelToName(logLevel int) (string, error) {
 	var err error
 	for k, v := range logLevelMap {
@@ -66,7 +66,7 @@ func LogLevelToName(logLevel int) (string, error) {
 }
 
 // logLevelMap maps strings to log level int
-// allows for --LogLevel Debug at command line
+// allows for --LogLevel Debug at command line.
 var logLevelMap = map[string]int{
 	"error":   ErrorLevel,
 	"warning": WarningLevel,
@@ -74,7 +74,7 @@ var logLevelMap = map[string]int{
 	"debug":   DebugLevel,
 }
 
-// Log sends a log message at a given level
+// Log sends a log message at a given level.
 func Log(level int, format string, v ...interface{}) {
 	var prefix string
 	logLevelName, err := LogLevelToName(level)
@@ -89,27 +89,27 @@ func Log(level int, format string, v ...interface{}) {
 	}
 }
 
-// Error reports unexpected behavior, likely to result in termination
+// Error reports unexpected behavior, likely to result in termination.
 func Error(format string, v ...interface{}) {
 	Log(ErrorLevel, format, v...)
 }
 
-// Warning reports unexpected behavior, not necessarily resulting in termination
+// Warning reports unexpected behavior, not necessarily resulting in termination.
 func Warning(format string, v ...interface{}) {
 	Log(WarningLevel, format, v...)
 }
 
-// Info provides general purpose statements useful to end user
+// Info provides general purpose statements useful to end user.
 func Info(format string, v ...interface{}) {
 	Log(InfoLevel, format, v...)
 }
 
-// Debug contains extra information helpful to developers
+// Debug contains extra information helpful to developers.
 func Debug(format string, v ...interface{}) {
 	Log(DebugLevel, format, v...)
 }
 
-// Trace outputs detailed packet traversal
+// Trace outputs detailed packet traversal.
 func Trace(format string, v ...interface{}) {
 	if showTrace {
 		log.SetPrefix("TRACE ")

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -2,14 +2,17 @@ package logger
 
 import (
 	"fmt"
-	"github.com/ghjm/cmdline"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/ghjm/cmdline"
 )
 
-var logLevel int
-var showTrace bool
+var (
+	logLevel  int
+	showTrace bool
+)
 
 // Log level constants
 const (

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -45,6 +45,7 @@ func GetLogLevelByName(logName string) (int, error) {
 		return val, nil
 	}
 	err = fmt.Errorf("%s is not a valid log level name", logName)
+
 	return 0, err
 }
 
@@ -62,6 +63,7 @@ func LogLevelToName(logLevel int) (string, error) {
 		}
 	}
 	err = fmt.Errorf("%d is not a valid log level", logLevel)
+
 	return "", err
 }
 
@@ -80,6 +82,7 @@ func Log(level int, format string, v ...interface{}) {
 	logLevelName, err := LogLevelToName(level)
 	if err != nil {
 		Error("Log entry received with invalid level: %s\n", fmt.Sprintf(format, v...))
+
 		return
 	}
 	prefix = strings.ToUpper(logLevelName) + " "
@@ -128,6 +131,7 @@ func (cfg loglevelCfg) Init() error {
 		return err
 	}
 	SetLogLevel(val)
+
 	return nil
 }
 
@@ -135,6 +139,7 @@ type traceCfg struct{}
 
 func (cfg traceCfg) Prepare() error {
 	SetShowTrace(true)
+
 	return nil
 }
 

--- a/pkg/netceptor/addr.go
+++ b/pkg/netceptor/addr.go
@@ -2,19 +2,19 @@ package netceptor
 
 import "fmt"
 
-// Addr represents an endpoint address on the Netceptor network
+// Addr represents an endpoint address on the Netceptor network.
 type Addr struct {
 	network string
 	node    string
 	service string
 }
 
-// Network returns the network name
+// Network returns the network name.
 func (a Addr) Network() string {
 	return a.network
 }
 
-// String formats this address as a string
+// String formats this address as a string.
 func (a Addr) String() string {
 	return fmt.Sprintf("%s:%s", a.node, a.service)
 }

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -241,9 +241,8 @@ func (li *Listener) Close() error {
 	li.doneOnce.Do(func() {
 		close(li.doneChan)
 	})
-	qerr := li.ql.Close()
 	perr := li.pc.Close()
-	if qerr != nil {
+	if qerr := li.ql.Close(); qerr != nil {
 		return qerr
 	}
 

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -25,7 +25,7 @@ type acceptResult struct {
 	err  error
 }
 
-// Listener implements the net.Listener interface via the Receptor network
+// Listener implements the net.Listener interface via the Receptor network.
 type Listener struct {
 	s          *Netceptor
 	pc         *PacketConn
@@ -35,7 +35,7 @@ type Listener struct {
 	doneOnce   *sync.Once
 }
 
-// Internal implementation of Listen and ListenAndAdvertise
+// Internal implementation of Listen and ListenAndAdvertise.
 func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Config, advertise bool, adTags map[string]string) (*Listener, error) {
 	if len(service) > 8 {
 		return nil, fmt.Errorf("service name %s too long", service)
@@ -217,7 +217,7 @@ func (li *Listener) acceptLoop() {
 	}
 }
 
-// Accept accepts a connection via the listener
+// Accept accepts a connection via the listener.
 func (li *Listener) Accept() (net.Conn, error) {
 	select {
 	case ar := <-li.acceptChan:
@@ -227,7 +227,7 @@ func (li *Listener) Accept() (net.Conn, error) {
 	}
 }
 
-// Close closes the listener
+// Close closes the listener.
 func (li *Listener) Close() error {
 	li.doneOnce.Do(func() {
 		close(li.doneChan)
@@ -240,12 +240,12 @@ func (li *Listener) Close() error {
 	return perr
 }
 
-// Addr returns the local address of this listener
+// Addr returns the local address of this listener.
 func (li *Listener) Addr() net.Addr {
 	return li.pc.LocalAddr()
 }
 
-// Conn implements the net.Conn interface via the Receptor network
+// Conn implements the net.Conn interface via the Receptor network.
 type Conn struct {
 	s        *Netceptor
 	pc       *PacketConn
@@ -373,22 +373,22 @@ func monitorUnreachable(pc *PacketConn, doneChan chan struct{}, remoteAddr Addr,
 	}
 }
 
-// Read reads data from the connection
+// Read reads data from the connection.
 func (c *Conn) Read(b []byte) (n int, err error) {
 	return c.qs.Read(b)
 }
 
-// CancelRead cancels a pending read operation
+// CancelRead cancels a pending read operation.
 func (c *Conn) CancelRead() {
 	c.qs.CancelRead(499)
 }
 
-// Write writes data to the connection
+// Write writes data to the connection.
 func (c *Conn) Write(b []byte) (n int, err error) {
 	return c.qs.Write(b)
 }
 
-// Close closes the writer side of the connection
+// Close closes the writer side of the connection.
 func (c *Conn) Close() error {
 	c.doneOnce.Do(func() {
 		close(c.doneChan)
@@ -396,27 +396,27 @@ func (c *Conn) Close() error {
 	return c.qs.Close()
 }
 
-// LocalAddr returns the local address of this connection
+// LocalAddr returns the local address of this connection.
 func (c *Conn) LocalAddr() net.Addr {
 	return c.qc.LocalAddr()
 }
 
-// RemoteAddr returns the remote address of this connection
+// RemoteAddr returns the remote address of this connection.
 func (c *Conn) RemoteAddr() net.Addr {
 	return c.qc.RemoteAddr()
 }
 
-// SetDeadline sets both read and write deadlines
+// SetDeadline sets both read and write deadlines.
 func (c *Conn) SetDeadline(t time.Time) error {
 	return c.qs.SetDeadline(t)
 }
 
-// SetReadDeadline sets the read deadline
+// SetReadDeadline sets the read deadline.
 func (c *Conn) SetReadDeadline(t time.Time) error {
 	return c.qs.SetReadDeadline(t)
 }
 
-// SetWriteDeadline sets the write deadline
+// SetWriteDeadline sets the write deadline.
 func (c *Conn) SetWriteDeadline(t time.Time) error {
 	return c.qs.SetWriteDeadline(t)
 }

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -9,14 +9,15 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"github.com/lucas-clemente/quic-go"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"math/big"
 	"net"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/lucas-clemente/quic-go"
+	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 type acceptResult struct {

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -54,6 +54,7 @@ func (mc *netMessageConn) WriteMessage(ctx context.Context, data []byte) error {
 	if n != len(buf) {
 		return fmt.Errorf("partial data sent")
 	}
+
 	return nil
 }
 
@@ -86,6 +87,7 @@ func (mc *netMessageConn) ReadMessage(ctx context.Context, timeout time.Duration
 	if err != nil {
 		return nil, err
 	}
+
 	return buf, nil
 }
 
@@ -116,6 +118,7 @@ func (mc *websocketMessageConn) WriteMessage(ctx context.Context, data []byte) e
 	if ctx.Err() != nil {
 		return fmt.Errorf("session closed: %s", ctx.Err())
 	}
+
 	return mc.conn.WriteMessage(websocket.BinaryMessage, data)
 }
 
@@ -128,6 +131,7 @@ func (mc *websocketMessageConn) ReadMessage(ctx context.Context, timeout time.Du
 	if messageType != websocket.BinaryMessage {
 		return nil, fmt.Errorf("received message of wrong type")
 	}
+
 	return data, err
 }
 
@@ -151,6 +155,7 @@ func (b *ExternalBackend) Start(ctx context.Context) (chan BackendSession, error
 	b.ctx, b.cancel = context.WithCancel(ctx)
 	b.ctx = ctx
 	b.sessChan = make(chan BackendSession)
+
 	return b.sessChan, nil
 }
 
@@ -189,5 +194,6 @@ func (es *ExternalSession) Close() error {
 	if es.shouldClose {
 		err = es.conn.Close()
 	}
+
 	return err
 }

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -19,7 +19,7 @@ type ExternalBackend struct {
 	sessChan chan BackendSession
 }
 
-// MessageConn is an abstract connection that sends and receives whole messages (datagrams)
+// MessageConn is an abstract connection that sends and receives whole messages (datagrams).
 type MessageConn interface {
 	WriteMessage(ctx context.Context, data []byte) error
 	ReadMessage(ctx context.Context, timeout time.Duration) ([]byte, error)
@@ -27,13 +27,13 @@ type MessageConn interface {
 	Close() error
 }
 
-// netMessageConn implements MessageConn for Go net.Conn
+// netMessageConn implements MessageConn for Go net.Conn.
 type netMessageConn struct {
 	conn   net.Conn
 	framer framer.Framer
 }
 
-// MessageConnFromNetConn returns a MessageConnection that wraps a net.Conn
+// MessageConnFromNetConn returns a MessageConnection that wraps a net.Conn.
 func MessageConnFromNetConn(conn net.Conn) MessageConn {
 	return &netMessageConn{
 		conn:   conn,
@@ -41,7 +41,7 @@ func MessageConnFromNetConn(conn net.Conn) MessageConn {
 	}
 }
 
-// WriteMessage writes a message to the connection
+// WriteMessage writes a message to the connection.
 func (mc *netMessageConn) WriteMessage(ctx context.Context, data []byte) error {
 	if ctx.Err() != nil {
 		return fmt.Errorf("session closed: %s", ctx.Err())
@@ -57,7 +57,7 @@ func (mc *netMessageConn) WriteMessage(ctx context.Context, data []byte) error {
 	return nil
 }
 
-// ReadMessage reads a message from the connection
+// ReadMessage reads a message from the connection.
 func (mc *netMessageConn) ReadMessage(ctx context.Context, timeout time.Duration) ([]byte, error) {
 	buf := make([]byte, utils.NormalBufferSize)
 	err := mc.conn.SetReadDeadline(time.Now().Add(timeout))
@@ -89,29 +89,29 @@ func (mc *netMessageConn) ReadMessage(ctx context.Context, timeout time.Duration
 	return buf, nil
 }
 
-// SetReadDeadline sets the deadline by which a message must be read from the connection
+// SetReadDeadline sets the deadline by which a message must be read from the connection.
 func (mc *netMessageConn) SetReadDeadline(t time.Time) error {
 	panic("implement me")
 }
 
-// Close closes the connection
+// Close closes the connection.
 func (mc *netMessageConn) Close() error {
 	return mc.conn.Close()
 }
 
-// websocketMessageConn implements MessageConn for Gorilla websocket.Conn
+// websocketMessageConn implements MessageConn for Gorilla websocket.Conn.
 type websocketMessageConn struct {
 	conn *websocket.Conn
 }
 
-// MessageConnFromWebsocketConn returns a MessageConnection that wraps a Gorilla websocket.Conn
+// MessageConnFromWebsocketConn returns a MessageConnection that wraps a Gorilla websocket.Conn.
 func MessageConnFromWebsocketConn(conn *websocket.Conn) MessageConn {
 	return &websocketMessageConn{
 		conn: conn,
 	}
 }
 
-// WriteMessage writes a message to the connection
+// WriteMessage writes a message to the connection.
 func (mc *websocketMessageConn) WriteMessage(ctx context.Context, data []byte) error {
 	if ctx.Err() != nil {
 		return fmt.Errorf("session closed: %s", ctx.Err())
@@ -119,7 +119,7 @@ func (mc *websocketMessageConn) WriteMessage(ctx context.Context, data []byte) e
 	return mc.conn.WriteMessage(websocket.BinaryMessage, data)
 }
 
-// ReadMessage reads a message from the connection
+// ReadMessage reads a message from the connection.
 func (mc *websocketMessageConn) ReadMessage(ctx context.Context, timeout time.Duration) ([]byte, error) {
 	if ctx.Err() != nil {
 		return nil, fmt.Errorf("session closed: %s", ctx.Err())
@@ -131,17 +131,17 @@ func (mc *websocketMessageConn) ReadMessage(ctx context.Context, timeout time.Du
 	return data, err
 }
 
-// SetReadDeadline sets the deadline by which a message must be read from the connection
+// SetReadDeadline sets the deadline by which a message must be read from the connection.
 func (mc *websocketMessageConn) SetReadDeadline(t time.Time) error {
 	return mc.conn.SetReadDeadline(t)
 }
 
-// Close closes the connection
+// Close closes the connection.
 func (mc *websocketMessageConn) Close() error {
 	return mc.conn.Close()
 }
 
-// NewExternalBackend initializes a new ExternalBackend object
+// NewExternalBackend initializes a new ExternalBackend object.
 func NewExternalBackend() (*ExternalBackend, error) {
 	return &ExternalBackend{}, nil
 }
@@ -172,17 +172,17 @@ func (b *ExternalBackend) NewConnection(conn MessageConn, closeConnWithSession b
 	b.sessChan <- ebs
 }
 
-// Send sends data over the session
+// Send sends data over the session.
 func (es *ExternalSession) Send(data []byte) error {
 	return es.conn.WriteMessage(es.eb.ctx, data)
 }
 
-// Recv receives data via the session
+// Recv receives data via the session.
 func (es *ExternalSession) Recv(timeout time.Duration) ([]byte, error) {
 	return es.conn.ReadMessage(es.eb.ctx, timeout)
 }
 
-// Close closes the session
+// Close closes the session.
 func (es *ExternalSession) Close() error {
 	es.eb.cancel()
 	var err error

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -3,11 +3,12 @@ package netceptor
 import (
 	"context"
 	"fmt"
+	"net"
+	"time"
+
 	"github.com/gorilla/websocket"
 	"github.com/project-receptor/receptor/pkg/framer"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"net"
-	"time"
 )
 
 // ExternalBackend is a backend implementation for the situation when non-Receptor code

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -8,12 +8,6 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	priorityQueue "github.com/jupp0r/go-priority-queue"
-	"github.com/minio/highwayhash"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/randstr"
-	"github.com/project-receptor/receptor/pkg/tickrunner"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"io"
 	"math"
 	"math/rand"
@@ -21,6 +15,13 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	priorityQueue "github.com/jupp0r/go-priority-queue"
+	"github.com/minio/highwayhash"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/randstr"
+	"github.com/project-receptor/receptor/pkg/tickrunner"
+	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // defaultMTU is the largest message sendable over the Netceptor network
@@ -229,10 +230,12 @@ type UnreachableNotification struct {
 	ReceivedFromNode string
 }
 
-var networkNames = make([]string, 0)
-var networkNamesLock = sync.Mutex{}
+var (
+	networkNames     = make([]string, 0)
+	networkNamesLock = sync.Mutex{}
+)
 
-//makeNetworkName returns a network name that is unique within global scope
+// makeNetworkName returns a network name that is unique within global scope
 func makeNetworkName(nodeID string) string {
 	networkNamesLock.Lock()
 	defer networkNamesLock.Unlock()
@@ -537,7 +540,6 @@ func (s *Netceptor) removeLocalServiceAdvertisement(service string) error {
 
 // Send a single service broadcast
 func (s *Netceptor) sendServiceAd(si *ServiceAdvertisement) error {
-
 	logger.Debug("Sending service advertisement: %v\n", si)
 	sf := serviceAdvertisementFull{
 		ServiceAdvertisement: si,
@@ -1401,7 +1403,6 @@ func (ci *connInfo) protoWriter(sess BackendSession) {
 				return
 			}
 		}
-
 	}
 }
 

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -843,7 +843,7 @@ func (s *Netceptor) receptorVerifyFunc(tlscfg *tls.Config, expectedNodeID string
 			opts.Intermediates.AddCert(cert)
 		}
 		var err error
-		verifiedChains, err = certs[0].Verify(opts)
+		_, err = certs[0].Verify(opts)
 		if err != nil {
 			logger.Error("RVF failed verify: %s\nRootCAs: %v\nServerName: %s", err, tlscfg.RootCAs, tlscfg.ServerName)
 

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -246,11 +246,13 @@ func makeNetworkName(nodeID string) string {
 		for i := range networkNames {
 			if networkNames[i] == proposedName {
 				good = false
+
 				break
 			}
 		}
 		if good {
 			networkNames = append(networkNames, proposedName)
+
 			return proposedName
 		}
 		nameCounter++
@@ -329,6 +331,7 @@ func NewWithConsts(ctx context.Context, NodeID string, AllowedPeers []string,
 	}
 	go s.monitorConnectionAging()
 	go s.expireSeenUpdates()
+
 	return &s
 }
 
@@ -422,6 +425,7 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost
 			}
 		}
 	}()
+
 	return nil
 }
 
@@ -473,6 +477,7 @@ func (s *Netceptor) Status() Status {
 		}
 	}
 	s.knownNodeLock.RUnlock()
+
 	return Status{
 		NodeID:               s.nodeID,
 		Connections:          conns,
@@ -490,6 +495,7 @@ func (s *Netceptor) PathCost(nodeID string) (float64, error) {
 	if !ok {
 		return 0, fmt.Errorf("node not found")
 	}
+
 	return cost, nil
 }
 
@@ -535,6 +541,7 @@ func (s *Netceptor) removeLocalServiceAdvertisement(service string) error {
 		return err
 	}
 	s.flood(data, "")
+
 	return nil
 }
 
@@ -550,6 +557,7 @@ func (s *Netceptor) sendServiceAd(si *ServiceAdvertisement) error {
 		return err
 	}
 	s.flood(data, "")
+
 	return nil
 }
 
@@ -661,6 +669,7 @@ func (s *Netceptor) updateRoutingTable() {
 		for {
 			if prev[p] == s.nodeID {
 				s.routingTable[dest] = p
+
 				break
 			} else if prev[p] == "" {
 				break
@@ -687,6 +696,7 @@ func (s *Netceptor) SubscribeRoutingUpdates() chan map[string]string {
 			case msgIf, ok := <-iChan:
 				if !ok {
 					close(uChan)
+
 					return
 				}
 				msg, ok := msgIf.(map[string]string)
@@ -697,14 +707,17 @@ func (s *Netceptor) SubscribeRoutingUpdates() chan map[string]string {
 				case uChan <- msg:
 				case <-s.context.Done():
 					close(uChan)
+
 					return
 				}
 			case <-s.context.Done():
 				close(uChan)
+
 				return
 			}
 		}
 	}()
+
 	return uChan
 }
 
@@ -733,6 +746,7 @@ func (s *Netceptor) GetServerTLSConfig(name string) (*tls.Config, error) {
 	if !ok {
 		return nil, fmt.Errorf("unknown TLS config %s", name)
 	}
+
 	return sc.Clone(), nil
 }
 
@@ -752,6 +766,7 @@ func (s *Netceptor) AddWorkCommand(command string) error {
 	} else {
 		s.workCommands = append(s.workCommands, command)
 	}
+
 	return nil
 }
 
@@ -761,6 +776,7 @@ func (s *Netceptor) SetServerTLSConfig(name string, config *tls.Config) error {
 		return fmt.Errorf("must provide a name")
 	}
 	s.serverTLSConfigs[name] = config
+
 	return nil
 }
 
@@ -779,6 +795,7 @@ func (rce ReceptorCertNameError) Error() string {
 	if len(rce.ValidNodes) > 1 {
 		plural = "s"
 	}
+
 	return fmt.Sprintf("x509: certificate is valid for Receptor node ID%s %s, not %s",
 		plural, strings.Join(rce.ValidNodes, ", "), rce.ExpectedNode)
 }
@@ -799,6 +816,7 @@ func (s *Netceptor) receptorVerifyFunc(tlscfg *tls.Config, expectedNodeID string
 			cert, err := x509.ParseCertificate(asn1Data)
 			if err != nil {
 				logger.Error("RVF failed to parse: %s", err)
+
 				return fmt.Errorf("failed to parse certificate from server: " + err.Error())
 			}
 			certs[i] = cert
@@ -828,25 +846,30 @@ func (s *Netceptor) receptorVerifyFunc(tlscfg *tls.Config, expectedNodeID string
 		verifiedChains, err = certs[0].Verify(opts)
 		if err != nil {
 			logger.Error("RVF failed verify: %s\nRootCAs: %v\nServerName: %s", err, tlscfg.RootCAs, tlscfg.ServerName)
+
 			return err
 		}
 		var receptorNames []string
 		receptorNames, err = utils.ReceptorNames(certs[0].Extensions)
 		if err != nil {
 			logger.Error("RVF failed to get ReceptorNames: %s", err)
+
 			return err
 		}
 		found := false
 		for _, receptorName := range receptorNames {
 			if receptorName == expectedNodeID {
 				found = true
+
 				break
 			}
 		}
 		if !found {
 			logger.Error("RVF ReceptorNameError: %s", err)
+
 			return ReceptorCertNameError{ValidNodes: receptorNames, ExpectedNode: expectedNodeID}
 		}
+
 		return nil
 	}
 }
@@ -870,6 +893,7 @@ func (s *Netceptor) GetClientTLSConfig(name string, expectedHostName string, exp
 	} else {
 		tlscfg.ServerName = expectedHostName
 	}
+
 	return tlscfg, nil
 }
 
@@ -879,6 +903,7 @@ func (s *Netceptor) SetClientTLSConfig(name string, config *tls.Config) error {
 		return fmt.Errorf("must provide a name")
 	}
 	s.clientTLSConfigs[name] = config
+
 	return nil
 }
 
@@ -899,6 +924,7 @@ func (s *Netceptor) addNameHash(name string) uint64 {
 	if !ok {
 		s.nameHashes[hv] = name
 	}
+
 	return hv
 }
 
@@ -910,6 +936,7 @@ func (s *Netceptor) getNameFromHash(namehash uint64) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("hash not found")
 	}
+
 	return name, nil
 }
 
@@ -922,6 +949,7 @@ func stringFromFixedLenBytes(bytes []byte) string {
 	if p < 0 {
 		return ""
 	}
+
 	return string(bytes[:p+1])
 }
 
@@ -929,6 +957,7 @@ func stringFromFixedLenBytes(bytes []byte) string {
 func fixedLenBytesFromString(s string, l int) []byte {
 	bytes := make([]byte, l)
 	copy(bytes, s)
+
 	return bytes
 }
 
@@ -955,6 +984,7 @@ func (s *Netceptor) translateDataToMessage(data []byte) (*messageData, error) {
 		HopsToLive:  data[1],
 		Data:        data[36:],
 	}
+
 	return md, nil
 }
 
@@ -968,6 +998,7 @@ func (s *Netceptor) translateDataFromMessage(msg *messageData) ([]byte, error) {
 	copy(data[20:28], fixedLenBytesFromString(msg.FromService, 8))
 	copy(data[28:36], fixedLenBytesFromString(msg.ToService, 8))
 	copy(data[36:], msg.Data)
+
 	return data, nil
 }
 
@@ -983,6 +1014,7 @@ func (s *Netceptor) forwardMessage(md *messageData) error {
 				Problem:     ProblemExpiredInTransit,
 			})
 		}
+
 		return nil
 	}
 	s.routingTableLock.RLock()
@@ -1005,6 +1037,7 @@ func (s *Netceptor) forwardMessage(md *messageData) error {
 	message[1]--
 	logger.Trace("    Forwarding data length %d via %s\n", len(md.Data), nextHop)
 	c.WriteChan <- message
+
 	return nil
 }
 
@@ -1026,6 +1059,7 @@ func (s *Netceptor) sendMessageWithHopsToLive(fromService string, toNode string,
 	}
 	logger.Trace("--- Sending data length %d from %s:%s to %s:%s\n", len(md.Data),
 		md.FromNode, md.FromService, md.ToNode, md.ToService)
+
 	return s.handleMessageData(md)
 }
 
@@ -1048,6 +1082,7 @@ func (s *Netceptor) getEphemeralService() string {
 		if ok {
 			continue
 		}
+
 		return service
 	}
 }
@@ -1093,6 +1128,7 @@ func (s *Netceptor) makeRoutingUpdate(suspectedDuplicate uint64) *routingUpdate 
 		ForwardingNode:     s.nodeID,
 		SuspectedDuplicate: suspectedDuplicate,
 	}
+
 	return update
 }
 
@@ -1105,6 +1141,7 @@ func (s *Netceptor) translateStructToNetwork(messageType byte, content interface
 	data := make([]byte, len(contentBytes)+1)
 	data[0] = messageType
 	copy(data[1:], contentBytes)
+
 	return data, nil
 }
 
@@ -1144,6 +1181,7 @@ func (s *Netceptor) handleRoutingUpdate(ri *routingUpdate, recvConn string) {
 			// We are the duplicate!
 			logger.Error("We are a duplicate node with ID %s and epoch %d.  Shutting down.\n", s.nodeID, s.epoch)
 			s.Shutdown()
+
 			return
 		}
 		if ri.UpdateEpoch > s.epoch {
@@ -1151,14 +1189,17 @@ func (s *Netceptor) handleRoutingUpdate(ri *routingUpdate, recvConn string) {
 			logger.Error("Duplicate node ID %s detected via %s\n", ri.NodeID, recvConn)
 			// Send routing update noting our suspicion
 			s.sendRoutingUpdate(ri.UpdateEpoch)
+
 			return
 		}
+
 		return
 	}
 	s.seenUpdatesLock.Lock()
 	_, ok := s.seenUpdates[ri.UpdateID]
 	if ok {
 		s.seenUpdatesLock.Unlock()
+
 		return
 	}
 	s.seenUpdates[ri.UpdateID] = time.Now()
@@ -1181,10 +1222,12 @@ func (s *Netceptor) handleRoutingUpdate(ri *routingUpdate, recvConn string) {
 		if ok {
 			if ri.UpdateEpoch < ni.Epoch {
 				s.knownNodeLock.Unlock()
+
 				return
 			}
 			if ri.UpdateEpoch == ni.Epoch && ri.UpdateSequence <= ni.Sequence {
 				s.knownNodeLock.Unlock()
+
 				return
 			}
 		} else {
@@ -1247,6 +1290,7 @@ func (s *Netceptor) handleUnreachable(md *messageData) error {
 		ReceivedFromNode:   md.FromNode,
 	}
 	logger.Warning("Received unreachable message from %s", md.FromNode)
+
 	return s.unreachableBroker.Publish(unrData)
 }
 
@@ -1260,6 +1304,7 @@ func (s *Netceptor) sendUnreachable(ToNode string, message *UnreachableMessage) 
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -1269,6 +1314,7 @@ func (s *Netceptor) dispatchReservedService(md *messageData) (bool, error) {
 	if ok {
 		return true, svc(md)
 	}
+
 	return false, nil
 }
 
@@ -1296,12 +1342,15 @@ func (s *Netceptor) handleMessageData(md *messageData) error {
 				ToService:   md.ToService,
 				Problem:     ProblemServiceUnknown,
 			})
+
 			return nil
 		}
 		pc.recvChan <- md
 		s.listenerLock.RUnlock()
+
 		return nil
 	}
+
 	return s.forwardMessage(md)
 }
 
@@ -1318,6 +1367,7 @@ func (s *Netceptor) GetServiceInfo(NodeID string, Service string) (*ServiceAdver
 		return nil, false
 	}
 	svcCopy := *svc
+
 	return &svcCopy, true
 }
 
@@ -1357,6 +1407,7 @@ func (s *Netceptor) handleServiceAdvertisement(data []byte, receivedFrom string)
 		s.serviceAdsReceived[si.NodeID][si.Service] = si.ServiceAdvertisement
 	}
 	s.flood(data, receivedFrom)
+
 	return nil
 }
 
@@ -1377,6 +1428,7 @@ func (ci *connInfo) protoReader(sess BackendSession) {
 				logger.Error("Backend receiving error %s\n", err)
 			}
 			ci.CancelFunc()
+
 			return
 		}
 		ci.lastReceivedData = time.Now()
@@ -1400,6 +1452,7 @@ func (ci *connInfo) protoWriter(sess BackendSession) {
 					logger.Error("Backend sending error %s\n", err)
 				}
 				ci.CancelFunc()
+
 				return
 			}
 		}
@@ -1413,6 +1466,7 @@ func (s *Netceptor) sendInitialConnectMessage(ci *connInfo, initDoneChan chan bo
 		ri, err := s.translateStructToNetwork(MsgTypeRoute, s.makeRoutingUpdate(0))
 		if err != nil {
 			logger.Error("Error Sending initial connection message: %s\n", err)
+
 			return
 		}
 		logger.Debug("Sending initial connection message\n")
@@ -1421,6 +1475,7 @@ func (s *Netceptor) sendInitialConnectMessage(ci *connInfo, initDoneChan chan bo
 		if count > 10 {
 			logger.Warning("Giving up on connection initialization\n")
 			ci.CancelFunc()
+
 			return
 		}
 		select {
@@ -1430,6 +1485,7 @@ func (s *Netceptor) sendInitialConnectMessage(ci *connInfo, initDoneChan chan bo
 			continue
 		case <-initDoneChan:
 			logger.Debug("Stopping initial updates\n")
+
 			return
 		}
 	}
@@ -1444,6 +1500,7 @@ func (s *Netceptor) sendRejectMessage(writeChan chan []byte) {
 
 func (s *Netceptor) sendAndLogConnectionRejection(remoteNodeID string, ci *connInfo, reason string) error {
 	s.sendRejectMessage(ci.WriteChan)
+
 	return fmt.Errorf("rejected connection with node %s because %s", remoteNodeID, reason)
 }
 
@@ -1496,6 +1553,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					message, err := s.translateDataToMessage(data)
 					if err != nil {
 						logger.Error("Error translating data to message struct: %s\n", err)
+
 						continue
 					}
 					logger.Trace("--- Received data length %d from %s:%s to %s:%s via %s\n", len(message.Data),
@@ -1509,6 +1567,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					err := json.Unmarshal(data[1:], ri)
 					if err != nil {
 						logger.Error("Error unpacking routing update: %s\n", err)
+
 						continue
 					}
 					if ri.ForwardingNode != remoteNodeID {
@@ -1537,10 +1596,12 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					err := s.handleServiceAdvertisement(data, remoteNodeID)
 					if err != nil {
 						logger.Error("Error handling service advertisement: %s\n", err)
+
 						continue
 					}
 				} else if msgType == MsgTypeReject {
 					logger.Warning("Received a rejection message from peer.")
+
 					return fmt.Errorf("remote node rejected the connection")
 				} else {
 					logger.Warning("Unknown message type %d\n", msgType)
@@ -1552,6 +1613,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					err := json.Unmarshal(data[1:], ri)
 					if err != nil {
 						logger.Error("Error unpacking routing update: %s\n", err)
+
 						continue
 					}
 					remoteNodeID = ri.ForwardingNode
@@ -1564,6 +1626,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					for conn := range s.connections {
 						if remoteNodeID == conn {
 							remoteNodeAccepted = false
+
 							break
 						}
 					}
@@ -1576,6 +1639,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 						for i := range s.allowedPeers {
 							if s.allowedPeers[i] == remoteNodeID {
 								remoteNodeAccepted = true
+
 								break
 							}
 						}
@@ -1626,6 +1690,7 @@ func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nod
 					established = true
 				} else if msgType == MsgTypeReject {
 					logger.Warning("Received a rejection message from peer.")
+
 					return fmt.Errorf("remote node rejected the connection")
 				}
 			}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -24,25 +24,25 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// defaultMTU is the largest message sendable over the Netceptor network
+// defaultMTU is the largest message sendable over the Netceptor network.
 const defaultMTU = 16384
 
-// defaultRouteUpdateTime is the interval at which regular route updates will be sent
+// defaultRouteUpdateTime is the interval at which regular route updates will be sent.
 const defaultRouteUpdateTime = 10 * time.Second
 
-// defaultServiceAdTime is the interval at which regular service advertisements will be sent
+// defaultServiceAdTime is the interval at which regular service advertisements will be sent.
 const defaultServiceAdTime = 60 * time.Second
 
-// defaultSeenUpdateExpireTime is the age after which routing update IDs can be discarded
+// defaultSeenUpdateExpireTime is the age after which routing update IDs can be discarded.
 const defaultSeenUpdateExpireTime = 1 * time.Hour
 
-// defaultMaxForwardingHops is the maximum number of times that Netceptor will forward a data packet
+// defaultMaxForwardingHops is the maximum number of times that Netceptor will forward a data packet.
 const defaultMaxForwardingHops = 30
 
-// defaultMaxConnectionIdleTime is the maximum time a connection can go without data before we consider it failed
+// defaultMaxConnectionIdleTime is the maximum time a connection can go without data before we consider it failed.
 const defaultMaxConnectionIdleTime = 2*defaultRouteUpdateTime + 1*time.Second
 
-// MainInstance is the global instance of Netceptor instantiated by the command-line main() function
+// MainInstance is the global instance of Netceptor instantiated by the command-line main() function.
 var MainInstance *Netceptor
 
 // ErrorFunc is a function parameter used to process errors. The boolean parameter
@@ -64,7 +64,7 @@ func (e *TimeoutError) Timeout() bool { return true }
 // Temporary returns true if a retry is likely a good idea.
 func (e *TimeoutError) Temporary() bool { return true }
 
-// Backend is the interface for back-ends that the Receptor network can run over
+// Backend is the interface for back-ends that the Receptor network can run over.
 type Backend interface {
 	Start(context.Context) (chan BackendSession, error)
 }
@@ -79,7 +79,7 @@ type BackendSession interface {
 	Close() error
 }
 
-// Netceptor is the main object of the Receptor mesh network protocol
+// Netceptor is the main object of the Receptor mesh network protocol.
 type Netceptor struct {
 	nodeID                 string
 	mtu                    int
@@ -140,20 +140,20 @@ type Status struct {
 }
 
 const (
-	// MsgTypeData is a normal data-containing message
+	// MsgTypeData is a normal data-containing message.
 	MsgTypeData = 0
-	// MsgTypeRoute is a routing update
+	// MsgTypeRoute is a routing update.
 	MsgTypeRoute = 1
-	// MsgTypeServiceAdvertisement is an advertisement for a service
+	// MsgTypeServiceAdvertisement is an advertisement for a service.
 	MsgTypeServiceAdvertisement = 2
-	// MsgTypeReject indicates a rejection (closure) of a backend connection
+	// MsgTypeReject indicates a rejection (closure) of a backend connection.
 	MsgTypeReject = 3
 )
 
 const (
-	// ProblemServiceUnknown occurs when a message arrives for a non-listening service
+	// ProblemServiceUnknown occurs when a message arrives for a non-listening service.
 	ProblemServiceUnknown = "service unknown"
-	// ProblemExpiredInTransit occurs when a message's HopsToLive expires in transit
+	// ProblemExpiredInTransit occurs when a message's HopsToLive expires in transit.
 	ProblemExpiredInTransit = "message expired"
 )
 
@@ -191,15 +191,15 @@ type routingUpdate struct {
 }
 
 const (
-	// ConnTypeDatagram indicates a packetconn (datagram) service listener
+	// ConnTypeDatagram indicates a packetconn (datagram) service listener.
 	ConnTypeDatagram = 0
-	// ConnTypeStream indicates a conn (stream) service listener, without a user-defined TLS
+	// ConnTypeStream indicates a conn (stream) service listener, without a user-defined TLS.
 	ConnTypeStream = 1
-	// ConnTypeStreamTLS indicates the service listens on a packetconn connection, with a user-defined TLS
+	// ConnTypeStreamTLS indicates the service listens on a packetconn connection, with a user-defined TLS.
 	ConnTypeStreamTLS = 2
 )
 
-// ServiceAdvertisement is the data associated with a service advertisement
+// ServiceAdvertisement is the data associated with a service advertisement.
 type ServiceAdvertisement struct {
 	NodeID       string
 	Service      string
@@ -209,13 +209,13 @@ type ServiceAdvertisement struct {
 	WorkCommands []string
 }
 
-// serviceAdvertisementFull is the whole message from the network
+// serviceAdvertisementFull is the whole message from the network.
 type serviceAdvertisementFull struct {
 	*ServiceAdvertisement
 	Cancel bool
 }
 
-// UnreachableMessage is the on-the-wire data associated with an unreachable message
+// UnreachableMessage is the on-the-wire data associated with an unreachable message.
 type UnreachableMessage struct {
 	FromNode    string
 	ToNode      string
@@ -224,7 +224,7 @@ type UnreachableMessage struct {
 	Problem     string
 }
 
-// UnreachableNotification includes additional information returned from SubscribeUnreachable
+// UnreachableNotification includes additional information returned from SubscribeUnreachable.
 type UnreachableNotification struct {
 	UnreachableMessage
 	ReceivedFromNode string
@@ -235,7 +235,7 @@ var (
 	networkNamesLock = sync.Mutex{}
 )
 
-// makeNetworkName returns a network name that is unique within global scope
+// makeNetworkName returns a network name that is unique within global scope.
 func makeNetworkName(nodeID string) string {
 	networkNamesLock.Lock()
 	defer networkNamesLock.Unlock()
@@ -258,7 +258,7 @@ func makeNetworkName(nodeID string) string {
 	}
 }
 
-// NewWithConsts constructs a new Receptor network protocol instance, specifying operational constants
+// NewWithConsts constructs a new Receptor network protocol instance, specifying operational constants.
 func NewWithConsts(ctx context.Context, NodeID string, AllowedPeers []string,
 	mtu int, routeUpdateTime time.Duration, serviceAdTime time.Duration, seenUpdateExpireTime time.Duration,
 	maxForwardingHops byte, maxConnectionIdleTime time.Duration) *Netceptor {
@@ -332,13 +332,13 @@ func NewWithConsts(ctx context.Context, NodeID string, AllowedPeers []string,
 	return &s
 }
 
-// New constructs a new Receptor network protocol instance
+// New constructs a new Receptor network protocol instance.
 func New(ctx context.Context, NodeID string, AllowedPeers []string) *Netceptor {
 	return NewWithConsts(ctx, NodeID, AllowedPeers, defaultMTU, defaultRouteUpdateTime, defaultServiceAdTime,
 		defaultSeenUpdateExpireTime, defaultMaxForwardingHops, defaultMaxConnectionIdleTime)
 }
 
-// NewAddr generates a Receptor network address from a node ID and service name
+// NewAddr generates a Receptor network address from a node ID and service name.
 func (s *Netceptor) NewAddr(node string, service string) Addr {
 	return Addr{
 		network: s.networkName,
@@ -347,52 +347,52 @@ func (s *Netceptor) NewAddr(node string, service string) Addr {
 	}
 }
 
-// Context returns the context for this Netceptor instance
+// Context returns the context for this Netceptor instance.
 func (s *Netceptor) Context() context.Context {
 	return s.context
 }
 
-// Shutdown shuts down a Netceptor instance
+// Shutdown shuts down a Netceptor instance.
 func (s *Netceptor) Shutdown() {
 	s.cancelFunc()
 }
 
-// NodeID returns the local Node ID of this Netceptor instance
+// NodeID returns the local Node ID of this Netceptor instance.
 func (s *Netceptor) NodeID() string {
 	return s.nodeID
 }
 
-// MTU returns the configured MTU of this Netceptor instance
+// MTU returns the configured MTU of this Netceptor instance.
 func (s *Netceptor) MTU() int {
 	return s.mtu
 }
 
-// RouteUpdateTime returns the configured RouteUpdateTime of this Netceptor instance
+// RouteUpdateTime returns the configured RouteUpdateTime of this Netceptor instance.
 func (s *Netceptor) RouteUpdateTime() time.Duration {
 	return s.routeUpdateTime
 }
 
-// ServiceAdTime returns the configured ServiceAdTime of this Netceptor instance
+// ServiceAdTime returns the configured ServiceAdTime of this Netceptor instance.
 func (s *Netceptor) ServiceAdTime() time.Duration {
 	return s.serviceAdTime
 }
 
-// SeenUpdateExpireTime returns the configured SeenUpdateExpireTime of this Netceptor instance
+// SeenUpdateExpireTime returns the configured SeenUpdateExpireTime of this Netceptor instance.
 func (s *Netceptor) SeenUpdateExpireTime() time.Duration {
 	return s.seenUpdateExpireTime
 }
 
-// MaxForwardingHops returns the configured MaxForwardingHops of this Netceptor instance
+// MaxForwardingHops returns the configured MaxForwardingHops of this Netceptor instance.
 func (s *Netceptor) MaxForwardingHops() byte {
 	return s.maxForwardingHops
 }
 
-// MaxConnectionIdleTime returns the configured MaxConnectionIdleTime of this Netceptor instance
+// MaxConnectionIdleTime returns the configured MaxConnectionIdleTime of this Netceptor instance.
 func (s *Netceptor) MaxConnectionIdleTime() time.Duration {
 	return s.maxConnectionIdleTime
 }
 
-// AddBackend adds a backend to the Netceptor system
+// AddBackend adds a backend to the Netceptor system.
 func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost map[string]float64) error {
 	sessChan, err := backend.Start(s.context)
 	if err != nil {
@@ -425,17 +425,17 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost
 	return nil
 }
 
-// BackendWait waits for the backend wait group
+// BackendWait waits for the backend wait group.
 func (s *Netceptor) BackendWait() {
 	s.backendWaitGroup.Wait()
 }
 
-// BackendCount returns the number of backends that ever registered with this Netceptor
+// BackendCount returns the number of backends that ever registered with this Netceptor.
 func (s *Netceptor) BackendCount() int {
 	return s.backendCount
 }
 
-// Status returns the current state of the Netceptor object
+// Status returns the current state of the Netceptor object.
 func (s *Netceptor) Status() Status {
 	s.connLock.RLock()
 	conns := make([]*ConnStatus, 0)
@@ -538,7 +538,7 @@ func (s *Netceptor) removeLocalServiceAdvertisement(service string) error {
 	return nil
 }
 
-// Send a single service broadcast
+// Send a single service broadcast.
 func (s *Netceptor) sendServiceAd(si *ServiceAdvertisement) error {
 	logger.Debug("Sending service advertisement: %v\n", si)
 	sf := serviceAdvertisementFull{
@@ -553,7 +553,7 @@ func (s *Netceptor) sendServiceAd(si *ServiceAdvertisement) error {
 	return nil
 }
 
-// Send advertisements for all advertised services
+// Send advertisements for all advertised services.
 func (s *Netceptor) sendServiceAds() {
 	ads := make([]ServiceAdvertisement, 0)
 	s.listenerLock.RLock()
@@ -579,7 +579,7 @@ func (s *Netceptor) sendServiceAds() {
 	}
 }
 
-// Watches connections and expires any that haven't seen traffic in too long
+// Watches connections and expires any that haven't seen traffic in too long.
 func (s *Netceptor) monitorConnectionAging() {
 	for {
 		select {
@@ -602,7 +602,7 @@ func (s *Netceptor) monitorConnectionAging() {
 	}
 }
 
-// Expires old updates from the seenUpdates table
+// Expires old updates from the seenUpdates table.
 func (s *Netceptor) expireSeenUpdates() {
 	for {
 		select {
@@ -621,7 +621,7 @@ func (s *Netceptor) expireSeenUpdates() {
 	}
 }
 
-// Re-calculates the next-hop table based on current knowledge of the network
+// Re-calculates the next-hop table based on current knowledge of the network.
 func (s *Netceptor) updateRoutingTable() {
 	s.knownNodeLock.RLock()
 	defer s.knownNodeLock.RUnlock()
@@ -677,7 +677,7 @@ func (s *Netceptor) updateRoutingTable() {
 	s.printRoutingTable()
 }
 
-// SubscribeRoutingUpdates subscribes for messages when the routing table is changed
+// SubscribeRoutingUpdates subscribes for messages when the routing table is changed.
 func (s *Netceptor) SubscribeRoutingUpdates() chan map[string]string {
 	iChan := s.routingUpdateBroker.Subscribe()
 	uChan := make(chan map[string]string)
@@ -708,7 +708,7 @@ func (s *Netceptor) SubscribeRoutingUpdates() chan map[string]string {
 	return uChan
 }
 
-// Forwards a message to all neighbors, possibly excluding one
+// Forwards a message to all neighbors, possibly excluding one.
 func (s *Netceptor) flood(message []byte, excludeConn string) {
 	s.connLock.RLock()
 	writeChans := make([]chan []byte, 0)
@@ -736,7 +736,7 @@ func (s *Netceptor) GetServerTLSConfig(name string) (*tls.Config, error) {
 	return sc.Clone(), nil
 }
 
-// AddWorkCommand records a work command so it can be included in service announcements
+// AddWorkCommand records a work command so it can be included in service announcements.
 func (s *Netceptor) AddWorkCommand(command string) error {
 	if command == "" {
 		return fmt.Errorf("must provide a name")
@@ -755,7 +755,7 @@ func (s *Netceptor) AddWorkCommand(command string) error {
 	return nil
 }
 
-// SetServerTLSConfig stores a server TLS config by name
+// SetServerTLSConfig stores a server TLS config by name.
 func (s *Netceptor) SetServerTLSConfig(name string, config *tls.Config) error {
 	if name == "" {
 		return fmt.Errorf("must provide a name")
@@ -764,7 +764,7 @@ func (s *Netceptor) SetServerTLSConfig(name string, config *tls.Config) error {
 	return nil
 }
 
-// ReceptorCertNameError is the error produced when Receptor certificate name verification fails
+// ReceptorCertNameError is the error produced when Receptor certificate name verification fails.
 type ReceptorCertNameError struct {
 	ValidNodes   []string
 	ExpectedNode string
@@ -784,13 +784,13 @@ func (rce ReceptorCertNameError) Error() string {
 }
 
 const (
-	// VerifyServer indicates we are the client, verifying a server
+	// VerifyServer indicates we are the client, verifying a server.
 	VerifyServer = 1
-	// VerifyClient indicates we are the server, verifying a client
+	// VerifyClient indicates we are the server, verifying a client.
 	VerifyClient = 2
 )
 
-// receptorVerifyFunc generates a function that verifies a Receptor node ID
+// receptorVerifyFunc generates a function that verifies a Receptor node ID.
 func (s *Netceptor) receptorVerifyFunc(tlscfg *tls.Config, expectedNodeID string,
 	VerifyType int) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
@@ -873,7 +873,7 @@ func (s *Netceptor) GetClientTLSConfig(name string, expectedHostName string, exp
 	return tlscfg, nil
 }
 
-// SetClientTLSConfig stores a client TLS config by name
+// SetClientTLSConfig stores a client TLS config by name.
 func (s *Netceptor) SetClientTLSConfig(name string, config *tls.Config) error {
 	if name == "" {
 		return fmt.Errorf("must provide a name")
@@ -882,10 +882,10 @@ func (s *Netceptor) SetClientTLSConfig(name string, config *tls.Config) error {
 	return nil
 }
 
-// All-zero seed for deterministic highwayhash
+// All-zero seed for deterministic highwayhash.
 var zerokey = make([]byte, 32)
 
-// Hash a name and add it to the lookup table
+// Hash a name and add it to the lookup table.
 func (s *Netceptor) addNameHash(name string) uint64 {
 	if strings.EqualFold(name, "localhost") {
 		name = s.nodeID
@@ -902,7 +902,7 @@ func (s *Netceptor) addNameHash(name string) uint64 {
 	return hv
 }
 
-// Looks up a name given a hash received from the network
+// Looks up a name given a hash received from the network.
 func (s *Netceptor) getNameFromHash(namehash uint64) (string, error) {
 	s.hashLock.RLock()
 	defer s.hashLock.RUnlock()
@@ -913,7 +913,7 @@ func (s *Netceptor) getNameFromHash(namehash uint64) (string, error) {
 	return name, nil
 }
 
-// Given a string, returns a fixed-length buffer right-padded with null (0) bytes
+// Given a string, returns a fixed-length buffer right-padded with null (0) bytes.
 func stringFromFixedLenBytes(bytes []byte) string {
 	p := len(bytes) - 1
 	for p >= 0 && bytes[p] == 0 {
@@ -925,7 +925,7 @@ func stringFromFixedLenBytes(bytes []byte) string {
 	return string(bytes[:p+1])
 }
 
-// Given a fixed-length buffer, returns a string excluding any null (0) bytes on the right
+// Given a fixed-length buffer, returns a string excluding any null (0) bytes on the right.
 func fixedLenBytesFromString(s string, l int) []byte {
 	bytes := make([]byte, l)
 	copy(bytes, s)
@@ -971,7 +971,7 @@ func (s *Netceptor) translateDataFromMessage(msg *messageData) ([]byte, error) {
 	return data, nil
 }
 
-// Forwards a message to its next hop
+// Forwards a message to its next hop.
 func (s *Netceptor) forwardMessage(md *messageData) error {
 	if md.HopsToLive <= 0 {
 		if md.FromService != "unreach" {
@@ -1008,7 +1008,7 @@ func (s *Netceptor) forwardMessage(md *messageData) error {
 	return nil
 }
 
-// Generates and sends a message over the Receptor network, specifying HopsToLive
+// Generates and sends a message over the Receptor network, specifying HopsToLive.
 func (s *Netceptor) sendMessageWithHopsToLive(fromService string, toNode string, toService string, data []byte, hopsToLive byte) error {
 	if len(fromService) > 8 || len(toService) > 8 {
 		return fmt.Errorf("service name too long")
@@ -1029,7 +1029,7 @@ func (s *Netceptor) sendMessageWithHopsToLive(fromService string, toNode string,
 	return s.handleMessageData(md)
 }
 
-// Generates and sends a message over the Receptor network
+// Generates and sends a message over the Receptor network.
 func (s *Netceptor) sendMessage(fromService string, toNode string, toService string, data []byte) error {
 	return s.sendMessageWithHopsToLive(fromService, toNode, toService, data, s.maxForwardingHops)
 }
@@ -1075,7 +1075,7 @@ func (s *Netceptor) printRoutingTable() {
 	}
 }
 
-// Constructs a routing update message
+// Constructs a routing update message.
 func (s *Netceptor) makeRoutingUpdate(suspectedDuplicate uint64) *routingUpdate {
 	s.sequence++
 	s.connLock.RLock()
@@ -1096,7 +1096,7 @@ func (s *Netceptor) makeRoutingUpdate(suspectedDuplicate uint64) *routingUpdate 
 	return update
 }
 
-// Translates an arbitrary struct to a network message
+// Translates an arbitrary struct to a network message.
 func (s *Netceptor) translateStructToNetwork(messageType byte, content interface{}) ([]byte, error) {
 	contentBytes, err := json.Marshal(content)
 	if err != nil {
@@ -1230,12 +1230,12 @@ func (s *Netceptor) handleRoutingUpdate(ri *routingUpdate, recvConn string) {
 	s.flood(message, recvConn)
 }
 
-// Handles a ping request
+// Handles a ping request.
 func (s *Netceptor) handlePing(md *messageData) error {
 	return s.sendMessage("ping", md.FromNode, md.FromService, []byte{})
 }
 
-// Handles an unreachable response
+// Handles an unreachable response.
 func (s *Netceptor) handleUnreachable(md *messageData) error {
 	unrMsg := UnreachableMessage{}
 	err := json.Unmarshal(md.Data, &unrMsg)
@@ -1250,7 +1250,7 @@ func (s *Netceptor) handleUnreachable(md *messageData) error {
 	return s.unreachableBroker.Publish(unrData)
 }
 
-// Sends an unreachable response
+// Sends an unreachable response.
 func (s *Netceptor) sendUnreachable(ToNode string, message *UnreachableMessage) error {
 	bytes, err := json.Marshal(message)
 	if err != nil {
@@ -1305,7 +1305,7 @@ func (s *Netceptor) handleMessageData(md *messageData) error {
 	return s.forwardMessage(md)
 }
 
-// GetServiceInfo returns the advertising info, if any, for a service on a node
+// GetServiceInfo returns the advertising info, if any, for a service on a node.
 func (s *Netceptor) GetServiceInfo(NodeID string, Service string) (*ServiceAdvertisement, bool) {
 	s.serviceAdsLock.RLock()
 	defer s.serviceAdsLock.RUnlock()
@@ -1321,7 +1321,7 @@ func (s *Netceptor) GetServiceInfo(NodeID string, Service string) (*ServiceAdver
 	return &svcCopy, true
 }
 
-// Handles an incoming service advertisement
+// Handles an incoming service advertisement.
 func (s *Netceptor) handleServiceAdvertisement(data []byte, receivedFrom string) error {
 	if data[0] != MsgTypeServiceAdvertisement {
 		return fmt.Errorf("message is the wrong type")
@@ -1360,7 +1360,7 @@ func (s *Netceptor) handleServiceAdvertisement(data []byte, receivedFrom string)
 	return nil
 }
 
-// Goroutine to send data from the backend to the connection's ReadChan
+// Goroutine to send data from the backend to the connection's ReadChan.
 func (ci *connInfo) protoReader(sess BackendSession) {
 	for {
 		buf, err := sess.Recv(1 * time.Second)
@@ -1384,7 +1384,7 @@ func (ci *connInfo) protoReader(sess BackendSession) {
 	}
 }
 
-// Goroutine to send data from the connection's WriteChan to the backend
+// Goroutine to send data from the connection's WriteChan to the backend.
 func (ci *connInfo) protoWriter(sess BackendSession) {
 	for {
 		select {
@@ -1406,7 +1406,7 @@ func (ci *connInfo) protoWriter(sess BackendSession) {
 	}
 }
 
-// Continuously sends routing updates to let the other end know who we are on initial connection
+// Continuously sends routing updates to let the other end know who we are on initial connection.
 func (s *Netceptor) sendInitialConnectMessage(ci *connInfo, initDoneChan chan bool) {
 	count := 0
 	for {
@@ -1447,7 +1447,7 @@ func (s *Netceptor) sendAndLogConnectionRejection(remoteNodeID string, ci *connI
 	return fmt.Errorf("rejected connection with node %s because %s", remoteNodeID, reason)
 }
 
-// Main Netceptor protocol loop
+// Main Netceptor protocol loop.
 func (s *Netceptor) runProtocol(sess BackendSession, connectionCost float64, nodeCost map[string]float64) error {
 	if connectionCost <= 0.0 {
 		return fmt.Errorf("connection cost must be positive")

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -26,6 +26,7 @@ func (lw *logWriter) Write(p []byte) (n int, err error) {
 		if !strings.Contains(s, "maximum number of forwarding hops") {
 			fmt.Printf(s)
 			lw.t.Fatal(s)
+
 			return
 		}
 	} else if strings.HasPrefix(s, "TRACE") {
@@ -36,6 +37,7 @@ func (lw *logWriter) Write(p []byte) (n int, err error) {
 		}
 	}
 	lw.t.Log(s)
+
 	return len(p), nil
 }
 
@@ -284,6 +286,7 @@ func TestLotsOfPings(t *testing.T) {
 				for j := range nodes {
 					if !responses[i][j] {
 						good = false
+
 						break
 					}
 				}
@@ -294,6 +297,7 @@ func TestLotsOfPings(t *testing.T) {
 			if good {
 				t.Log("all pings received")
 				cancel()
+
 				return
 			}
 			select {
@@ -383,15 +387,18 @@ func TestDuplicateNodeDetection(t *testing.T) {
 			_, ok := knownRoutes[i][fmt.Sprintf("node%d", peer)]
 			if !ok {
 				knownRoutesLock.RUnlock()
+
 				continue
 			}
 			_, ok = knownRoutes[peer][fmt.Sprintf("node%d", i)]
 			if !ok {
 				knownRoutesLock.RUnlock()
+
 				continue
 			}
 			knownRoutesLock.RUnlock()
 		}
+
 		break
 	}
 
@@ -431,7 +438,6 @@ func TestDuplicateNodeDetection(t *testing.T) {
 
 		// Force close the connection to the connected node
 		_ = c2.Close()
-
 	}
 
 	// Shut down the rest of the network

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -160,9 +160,9 @@ func TestLotsOfPings(t *testing.T) {
 	numBackboneNodes := 3
 	numLeafNodesPerBackbone := 3
 
-	nodes := make([]*Netceptor, numBackboneNodes)
+	nodes := []*Netceptor{}
 	for i := 0; i < numBackboneNodes; i++ {
-		nodes[i] = New(context.Background(), fmt.Sprintf("backbone_%d", i), nil)
+		nodes = append(nodes, New(context.Background(), fmt.Sprintf("backbone_%d", i), nil))
 	}
 	for i := 0; i < numBackboneNodes; i++ {
 		for j := 0; j < i; j++ {

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -3,14 +3,15 @@ package netceptor
 import (
 	"context"
 	"fmt"
-	"github.com/prep/socketpair"
-	"github.com/project-receptor/receptor/pkg/logger"
 	"log"
 	"os"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/prep/socketpair"
+	"github.com/project-receptor/receptor/pkg/logger"
 )
 
 type logWriter struct {
@@ -321,7 +322,6 @@ func TestLotsOfPings(t *testing.T) {
 }
 
 func TestDuplicateNodeDetection(t *testing.T) {
-
 	// Create Netceptor nodes
 	netsize := 4
 	nodes := make([]*Netceptor, netsize)

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -24,7 +24,7 @@ func (lw *logWriter) Write(p []byte) (n int, err error) {
 	s := strings.Trim(string(p), "\n")
 	if strings.HasPrefix(s, "ERROR") {
 		if !strings.Contains(s, "maximum number of forwarding hops") {
-			fmt.Printf(s)
+			fmt.Print(s)
 			lw.t.Fatal(s)
 
 			return

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -309,9 +309,7 @@ func TestLotsOfPings(t *testing.T) {
 	}()
 
 	t.Log("waiting for done")
-	select {
-	case <-ctx.Done():
-	}
+	<-ctx.Done()
 	t.Log("waiting for waitgroup")
 	wg.Wait()
 

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -16,7 +16,6 @@ type PacketConn struct {
 	localService       string
 	recvChan           chan *messageData
 	readDeadline       time.Time
-	writeDeadline      time.Time
 	advertise          bool
 	adTags             map[string]string
 	connType           byte

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -55,6 +55,7 @@ func (s *Netceptor) ListenPacket(service string) (*PacketConn, error) {
 	}
 	pc.startUnreachable()
 	s.listenerRegistry[service] = pc
+
 	return pc, nil
 }
 
@@ -68,6 +69,7 @@ func (s *Netceptor) ListenPacketAndAdvertise(service string, tags map[string]str
 	pc.advertise = true
 	pc.adTags = tags
 	s.addLocalServiceAdvertisement(service, ConnTypeDatagram, tags)
+
 	return pc, nil
 }
 
@@ -106,6 +108,7 @@ func (pc *PacketConn) SubscribeUnreachable() chan UnreachableNotification {
 			case msgIf, ok := <-iChan:
 				if !ok {
 					close(uChan)
+
 					return
 				}
 				msg, ok := msgIf.(UnreachableNotification)
@@ -115,10 +118,12 @@ func (pc *PacketConn) SubscribeUnreachable() chan UnreachableNotification {
 				uChan <- msg
 			case <-pc.context.Done():
 				close(uChan)
+
 				return
 			}
 		}
 	}()
+
 	return uChan
 }
 
@@ -143,6 +148,7 @@ func (pc *PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 		node:    m.FromNode,
 		service: m.FromService,
 	}
+
 	return nCopied, fromAddr, nil
 }
 
@@ -156,6 +162,7 @@ func (pc *PacketConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
 	if err != nil {
 		return 0, err
 	}
+
 	return len(p), nil
 }
 
@@ -193,18 +200,21 @@ func (pc *PacketConn) Close() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
 // SetDeadline sets both the read and write deadlines.
 func (pc *PacketConn) SetDeadline(t time.Time) error {
 	pc.readDeadline = t
+
 	return nil
 }
 
 // SetReadDeadline sets the read deadline.
 func (pc *PacketConn) SetReadDeadline(t time.Time) error {
 	pc.readDeadline = t
+
 	return nil
 }
 

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -3,10 +3,11 @@ package netceptor
 import (
 	"context"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"net"
 	"reflect"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // PacketConn implements the net.PacketConn interface via the Receptor network

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -10,7 +10,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// PacketConn implements the net.PacketConn interface via the Receptor network
+// PacketConn implements the net.PacketConn interface via the Receptor network.
 type PacketConn struct {
 	s                  *Netceptor
 	localService       string
@@ -71,7 +71,7 @@ func (s *Netceptor) ListenPacketAndAdvertise(service string, tags map[string]str
 	return pc, nil
 }
 
-// startUnreachable starts monitoring the netceptor unreachable channel and forwarding relevant messages
+// startUnreachable starts monitoring the netceptor unreachable channel and forwarding relevant messages.
 func (pc *PacketConn) startUnreachable() {
 	pc.context, pc.cancel = context.WithCancel(pc.s.context)
 	pc.unreachableSubs = utils.NewBroker(pc.context, reflect.TypeOf(UnreachableNotification{}))
@@ -96,7 +96,7 @@ func (pc *PacketConn) startUnreachable() {
 	}()
 }
 
-// SubscribeUnreachable subscribes for unreachable messages relevant to this PacketConn
+// SubscribeUnreachable subscribes for unreachable messages relevant to this PacketConn.
 func (pc *PacketConn) SubscribeUnreachable() chan UnreachableNotification {
 	iChan := pc.unreachableSubs.Subscribe()
 	uChan := make(chan UnreachableNotification)

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -6,8 +6,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/ghjm/cmdline"
 	"io/ioutil"
+
+	"github.com/ghjm/cmdline"
 )
 
 // **************************************************************************

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -113,6 +113,7 @@ func (cfg tlsClientConfig) Prepare() error {
 	}
 
 	tlscfg.InsecureSkipVerify = cfg.InsecureSkipVerify
+
 	return MainInstance.SetClientTLSConfig(cfg.Name, tlscfg)
 }
 

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -58,11 +58,12 @@ func (cfg tlsServerCfg) Prepare() error {
 		tlscfg.ClientCAs = clientCAs
 	}
 
-	if cfg.RequireClientCert {
+	switch {
+	case cfg.RequireClientCert:
 		tlscfg.ClientAuth = tls.RequireAndVerifyClientCert
-	} else if cfg.ClientCAs != "" {
+	case cfg.ClientCAs != "":
 		tlscfg.ClientAuth = tls.VerifyClientCertIfGiven
-	} else {
+	default:
 		tlscfg.ClientAuth = tls.NoClientCert
 	}
 

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -20,7 +20,7 @@ var configSection = &cmdline.ConfigSection{
 	Order:       5,
 }
 
-// tlsServerCfg stores the configuration options for a TLS server
+// tlsServerCfg stores the configuration options for a TLS server.
 type tlsServerCfg struct {
 	Name              string `required:"true" description:"Name of this TLS server configuration"`
 	Cert              string `required:"true" description:"Server certificate filename"`
@@ -29,7 +29,7 @@ type tlsServerCfg struct {
 	ClientCAs         string `description:"Filename of CA bundle to verify client certs with"`
 }
 
-// Prepare creates the tls.config and stores it in the global map
+// Prepare creates the tls.config and stores it in the global map.
 func (cfg tlsServerCfg) Prepare() error {
 	tlscfg := &tls.Config{}
 
@@ -69,7 +69,7 @@ func (cfg tlsServerCfg) Prepare() error {
 	return MainInstance.SetServerTLSConfig(cfg.Name, tlscfg)
 }
 
-// tlsClientConfig stores the configuration options for a TLS client
+// tlsClientConfig stores the configuration options for a TLS client.
 type tlsClientConfig struct {
 	Name               string `required:"true" description:"Name of this TLS client configuration"`
 	Cert               string `required:"false" description:"Client certificate filename"`
@@ -78,7 +78,7 @@ type tlsClientConfig struct {
 	InsecureSkipVerify bool   `required:"false" description:"Accept any server cert" default:"false"`
 }
 
-// Prepare creates the tls.config and stores it in the global map
+// Prepare creates the tls.config and stores it in the global map.
 func (cfg tlsClientConfig) Prepare() error {
 	tlscfg := &tls.Config{}
 

--- a/pkg/randstr/randstr.go
+++ b/pkg/randstr/randstr.go
@@ -13,5 +13,6 @@ func RandomString(length int) string {
 		idx, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
 		randbytes = append(randbytes, charset[idx.Int64()])
 	}
+
 	return string(randbytes)
 }

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -24,6 +24,7 @@ func runCommand(qc net.Conn, command string) error {
 		return err
 	}
 	utils.BridgeConns(tty, "external command", qc, "command service")
+
 	return nil
 }
 
@@ -34,12 +35,14 @@ func CommandService(s *netceptor.Netceptor, service string, tlscfg *tls.Config, 
 	})
 	if err != nil {
 		logger.Error("Error listening on Receptor network: %s\n", err)
+
 		return
 	}
 	for {
 		qc, err := qli.Accept()
 		if err != nil {
 			logger.Error("Error accepting connection on Receptor network: %s\n", err)
+
 			return
 		}
 		go func() {
@@ -67,6 +70,7 @@ func (cfg commandSvcCfg) Run() error {
 		return err
 	}
 	go CommandService(netceptor.MainInstance, cfg.Service, tlscfg, cfg.Command)
+
 	return nil
 }
 

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -27,7 +27,7 @@ func runCommand(qc net.Conn, command string) error {
 	return nil
 }
 
-// CommandService listens on the Receptor network and runs a local command
+// CommandService listens on the Receptor network and runs a local command.
 func CommandService(s *netceptor.Netceptor, service string, tlscfg *tls.Config, command string) {
 	qli, err := s.ListenAndAdvertise(service, tlscfg, map[string]string{
 		"type": "Command Service",
@@ -52,14 +52,14 @@ func CommandService(s *netceptor.Netceptor, service string, tlscfg *tls.Config, 
 	}
 }
 
-// commandSvcCfg is the cmdline configuration object for a command service
+// commandSvcCfg is the cmdline configuration object for a command service.
 type commandSvcCfg struct {
 	Service string `required:"true" description:"Receptor service name to bind to"`
 	Command string `required:"true" description:"Command to execute on a connection"`
 	TLS     string `description:"Name of TLS server config"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg commandSvcCfg) Run() error {
 	logger.Info("Running command service %s\n", cfg)
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -5,14 +5,15 @@ package services
 
 import (
 	"crypto/tls"
+	"net"
+	"os/exec"
+	"strings"
+
 	"github.com/creack/pty"
 	"github.com/ghjm/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"net"
-	"os/exec"
-	"strings"
 )
 
 func runCommand(qc net.Conn, command string) error {

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -146,7 +146,7 @@ func (ipr *IPRouterService) reconcileRoutingTable() {
 		found := false
 		for j := range routes {
 			route := routes[j]
-			if bytes.Compare(kr.dest.IP, route.Dst.IP) == 0 && bytes.Compare(kr.dest.Mask, route.Dst.Mask) == 0 {
+			if kr.dest.IP.Equal(route.Dst.IP) && bytes.Equal(kr.dest.Mask, route.Dst.Mask) {
 				found = true
 
 				break
@@ -172,7 +172,7 @@ func (ipr *IPRouterService) reconcileRoutingTable() {
 		found := false
 		for j := range ipr.knownRoutes {
 			kr := ipr.knownRoutes[j]
-			if bytes.Compare(kr.dest.IP, route.Dst.IP) == 0 && bytes.Compare(kr.dest.Mask, route.Dst.Mask) == 0 {
+			if kr.dest.IP.Equal(route.Dst.IP) && bytes.Equal(kr.dest.Mask, route.Dst.Mask) {
 				found = true
 
 				break

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -218,19 +218,20 @@ func (ipr *IPRouterService) runTunToNetceptor() {
 		// Get the destination address from the received packet
 		ipVersion := int(packet[0] >> 4)
 		var destIP net.IP
-		if ipVersion == 4 {
+		switch ipVersion {
+		case 4:
 			header, err := ipv4.ParseHeader(packet)
 			if err != nil {
 				logger.Debug("Malformed ipv4 packet received: %s", err)
 			}
 			destIP = header.Dst
-		} else if ipVersion == 6 {
+		case 6:
 			header, err := ipv6.ParseHeader(packet)
 			if err != nil {
 				logger.Debug("Malformed ipv6 packet received: %s", err)
 			}
 			destIP = header.Dst
-		} else {
+		default:
 			logger.Debug("Packet received with unknown version %d", ipVersion)
 
 			continue

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -29,7 +29,7 @@ type ipRoute struct {
 	via  string
 }
 
-// IPRouterService is an IP router service
+// IPRouterService is an IP router service.
 type IPRouterService struct {
 	nc              *netceptor.Netceptor
 	networkName     string
@@ -349,7 +349,7 @@ func (ipr *IPRouterService) run() error {
 	return nil
 }
 
-// ipRouterCfg is the cmdline configuration object for an IP router
+// ipRouterCfg is the cmdline configuration object for an IP router.
 type ipRouterCfg struct {
 	NetworkName string `required:"true" description:"Name of this network and service."`
 	Interface   string `description:"Name of the local tun interface"`
@@ -357,7 +357,7 @@ type ipRouterCfg struct {
 	Routes      string `description:"Comma separated list of CIDR subnets to advertise"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg ipRouterCfg) Run() error {
 	logger.Debug("Running tun router service %s\n", cfg)
 	_, err := NewIPRouter(netceptor.MainInstance, cfg.NetworkName, cfg.Interface, cfg.LocalNet, cfg.Routes)

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -6,6 +6,12 @@ package services
 import (
 	"bytes"
 	"fmt"
+	"math"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/ghjm/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
@@ -14,11 +20,6 @@ import (
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
-	"math"
-	"net"
-	"strings"
-	"sync"
-	"time"
 )
 
 const adTypeIPRouter = "IP Router"

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -82,6 +82,7 @@ func NewIPRouter(nc *netceptor.Netceptor, networkName string, tunInterface strin
 	if err != nil {
 		return nil, err
 	}
+
 	return ipr, nil
 }
 
@@ -126,6 +127,7 @@ func (ipr *IPRouterService) reconcileRoutingTable() {
 	routes, err := netlink.RouteList(ipr.link, netlink.FAMILY_ALL)
 	if err != nil {
 		logger.Error("error retrieving kernel routes list: %s", err)
+
 		return
 	}
 
@@ -146,6 +148,7 @@ func (ipr *IPRouterService) reconcileRoutingTable() {
 			route := routes[j]
 			if bytes.Compare(kr.dest.IP, route.Dst.IP) == 0 && bytes.Compare(kr.dest.Mask, route.Dst.Mask) == 0 {
 				found = true
+
 				break
 			}
 		}
@@ -171,6 +174,7 @@ func (ipr *IPRouterService) reconcileRoutingTable() {
 			kr := ipr.knownRoutes[j]
 			if bytes.Compare(kr.dest.IP, route.Dst.IP) == 0 && bytes.Compare(kr.dest.Mask, route.Dst.Mask) == 0 {
 				found = true
+
 				break
 			}
 		}
@@ -206,6 +210,7 @@ func (ipr *IPRouterService) runTunToNetceptor() {
 		n, err := ipr.tunIf.Read(buf)
 		if err != nil {
 			logger.Error("Error reading from tun device: %s\n", err)
+
 			continue
 		}
 		packet := buf[:n]
@@ -227,6 +232,7 @@ func (ipr *IPRouterService) runTunToNetceptor() {
 			destIP = header.Dst
 		} else {
 			logger.Debug("Packet received with unknown version %d", ipVersion)
+
 			continue
 		}
 
@@ -270,6 +276,7 @@ func (ipr *IPRouterService) runNetceptorToTun() {
 		n, addr, err := ipr.nConn.ReadFrom(buf)
 		if err != nil {
 			logger.Error("Error reading from Receptor: %s\n", err)
+
 			continue
 		}
 		logger.Trace("    Forwarding data length %d from %s to %s\n", n,
@@ -291,6 +298,7 @@ func (ipr *IPRouterService) addRoute(route *net.IPNet) error {
 	if err != nil {
 		return fmt.Errorf("error adding route to interface: %s", err)
 	}
+
 	return nil
 }
 
@@ -346,6 +354,7 @@ func (ipr *IPRouterService) run() error {
 	go ipr.runAdvertisingWatcher()
 	go ipr.runTunToNetceptor()
 	go ipr.runNetceptorToTun()
+
 	return nil
 }
 
@@ -364,6 +373,7 @@ func (cfg ipRouterCfg) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -30,16 +30,19 @@ func TCPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, tlsSe
 			tc, err := tli.Accept()
 			if err != nil {
 				logger.Error("Error accepting TCP connection: %s\n", err)
+
 				return
 			}
 			qc, err := s.Dial(node, rservice, tlsClient)
 			if err != nil {
 				logger.Error("Error connecting on Receptor network: %s\n", err)
+
 				continue
 			}
 			go utils.BridgeConns(tc, "tcp service", qc, "receptor connection")
 		}
 	}()
+
 	return nil
 }
 
@@ -58,6 +61,7 @@ func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *
 			qc, err := qli.Accept()
 			if err != nil {
 				logger.Error("Error accepting connection on Receptor network: %s\n", err)
+
 				return
 			}
 			var tc net.Conn
@@ -68,11 +72,13 @@ func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *
 			}
 			if err != nil {
 				logger.Error("Error connecting via TCP: %s\n", err)
+
 				continue
 			}
 			go utils.BridgeConns(qc, "receptor service", tc, "tcp connection")
 		}
 	}()
+
 	return nil
 }
 
@@ -97,6 +103,7 @@ func (cfg tcpProxyInboundCfg) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return TCPProxyServiceInbound(netceptor.MainInstance, cfg.BindAddr, cfg.Port, tlsServerCfg,
 		cfg.RemoteNode, cfg.RemoteService, tlsClientCfg)
 }
@@ -124,6 +131,7 @@ func (cfg tcpProxyOutboundCfg) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return TCPProxyServiceOutbound(netceptor.MainInstance, cfg.Service, tlsServerCfg, cfg.Address, tlsClientCfg)
 }
 

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -15,7 +15,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// TCPProxyServiceInbound listens on a TCP port and forwards the connection over the Receptor network
+// TCPProxyServiceInbound listens on a TCP port and forwards the connection over the Receptor network.
 func TCPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, tlsServer *tls.Config,
 	node string, rservice string, tlsClient *tls.Config) error {
 	tli, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
@@ -43,7 +43,7 @@ func TCPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, tlsSe
 	return nil
 }
 
-// TCPProxyServiceOutbound listens on the Receptor network and forwards the connection via TCP
+// TCPProxyServiceOutbound listens on the Receptor network and forwards the connection via TCP.
 func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *tls.Config,
 	address string, tlsClient *tls.Config) error {
 	qli, err := s.ListenAndAdvertise(service, tlsServer, map[string]string{
@@ -76,7 +76,7 @@ func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *
 	return nil
 }
 
-// tcpProxyInboundCfg is the cmdline configuration object for a TCP inbound proxy
+// tcpProxyInboundCfg is the cmdline configuration object for a TCP inbound proxy.
 type tcpProxyInboundCfg struct {
 	Port          int    `required:"true" description:"Local TCP port to bind to"`
 	BindAddr      string `description:"Address to bind TCP listener to" default:"0.0.0.0"`
@@ -86,7 +86,7 @@ type tcpProxyInboundCfg struct {
 	TLSClient     string `description:"Name of TLS client config for the Receptor connection"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg tcpProxyInboundCfg) Run() error {
 	logger.Debug("Running TCP inbound proxy service %v\n", cfg)
 	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, cfg.RemoteNode, "receptor")
@@ -101,7 +101,7 @@ func (cfg tcpProxyInboundCfg) Run() error {
 		cfg.RemoteNode, cfg.RemoteService, tlsClientCfg)
 }
 
-// tcpProxyOutboundCfg is the cmdline configuration object for a TCP outbound proxy
+// tcpProxyOutboundCfg is the cmdline configuration object for a TCP outbound proxy.
 type tcpProxyOutboundCfg struct {
 	Service   string `required:"true" description:"Receptor service name to bind to"`
 	Address   string `required:"true" description:"Address for outbound TCP connection"`
@@ -109,7 +109,7 @@ type tcpProxyOutboundCfg struct {
 	TLSClient string `description:"Name of TLS client config for the TCP connection"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg tcpProxyOutboundCfg) Run() error {
 	logger.Debug("Running TCP inbound proxy service %s\n", cfg)
 	tlsServerCfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLSServer)

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -6,12 +6,13 @@ package services
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
+	"strconv"
+
 	"github.com/ghjm/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"net"
-	"strconv"
 )
 
 // TCPProxyServiceInbound listens on a TCP port and forwards the connection over the Receptor network

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -5,11 +5,12 @@ package services
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/ghjm/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"net"
 )
 
 // UDPProxyServiceInbound listens on a UDP port and forwards packets to a remote Receptor service

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -36,6 +36,7 @@ func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node 
 			n, addr, err := uc.ReadFrom(buffer)
 			if err != nil {
 				logger.Error("Error reading from UDP: %s\n", err)
+
 				return
 			}
 			raddrStr := addr.String()
@@ -44,6 +45,7 @@ func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node 
 				pc, err = s.ListenPacket("")
 				if err != nil {
 					logger.Error("Error listening on Receptor network: %s\n", err)
+
 					return
 				}
 				logger.Debug("Received new UDP connection from %s\n", raddrStr)
@@ -53,14 +55,17 @@ func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node 
 			wn, err := pc.WriteTo(buffer[:n], ncAddr)
 			if err != nil {
 				logger.Error("Error sending packet on Receptor network: %s\n", err)
+
 				continue
 			}
 			if wn != n {
 				logger.Debug("Not all bytes written on Receptor network\n")
+
 				continue
 			}
 		}
 	}()
+
 	return nil
 }
 
@@ -70,19 +75,23 @@ func runNetceptorToUDPInbound(pc *netceptor.PacketConn, uc *net.UDPConn, udpAddr
 		n, addr, err := pc.ReadFrom(buf)
 		if err != nil {
 			logger.Error("Error reading from Receptor network: %s\n", err)
+
 			continue
 		}
 		if addr != expectedAddr {
 			logger.Debug("Received packet from unexpected source %s\n", addr)
+
 			continue
 		}
 		wn, err := uc.WriteTo(buf[:n], udpAddr)
 		if err != nil {
 			logger.Error("Error sending packet via UDP: %s\n", err)
+
 			continue
 		}
 		if wn != n {
 			logger.Debug("Not all bytes written via UDP\n")
+
 			continue
 		}
 	}
@@ -108,6 +117,7 @@ func UDPProxyServiceOutbound(s *netceptor.Netceptor, service string, address str
 			n, addr, err := pc.ReadFrom(buffer)
 			if err != nil {
 				logger.Error("Error reading from Receptor network: %s\n", err)
+
 				return
 			}
 			raddrStr := addr.String()
@@ -116,6 +126,7 @@ func UDPProxyServiceOutbound(s *netceptor.Netceptor, service string, address str
 				uc, err = net.DialUDP("udp", nil, udpAddr)
 				if err != nil {
 					logger.Error("Error connecting via UDP: %s\n", err)
+
 					return
 				}
 				logger.Debug("Opened new UDP connection to %s\n", raddrStr)
@@ -125,14 +136,17 @@ func UDPProxyServiceOutbound(s *netceptor.Netceptor, service string, address str
 			wn, err := uc.Write(buffer[:n])
 			if err != nil {
 				logger.Error("Error writing to UDP: %s\n", err)
+
 				continue
 			}
 			if wn != n {
 				logger.Debug("Not all bytes written to UDP\n")
+
 				continue
 			}
 		}
 	}()
+
 	return nil
 }
 
@@ -142,15 +156,18 @@ func runUDPToNetceptorOutbound(uc *net.UDPConn, pc *netceptor.PacketConn, addr n
 		n, err := uc.Read(buf)
 		if err != nil {
 			logger.Error("Error reading from UDP: %s\n", err)
+
 			return
 		}
 		wn, err := pc.WriteTo(buf[:n], addr)
 		if err != nil {
 			logger.Error("Error writing to the Receptor network: %s\n", err)
+
 			continue
 		}
 		if wn != n {
 			logger.Debug("Not all bytes written to the Netceptor network\n")
+
 			continue
 		}
 	}
@@ -167,6 +184,7 @@ type udpProxyInboundCfg struct {
 // Run runs the action.
 func (cfg udpProxyInboundCfg) Run() error {
 	logger.Debug("Running UDP inbound proxy service %v\n", cfg)
+
 	return UDPProxyServiceInbound(netceptor.MainInstance, cfg.BindAddr, cfg.Port, cfg.RemoteNode, cfg.RemoteService)
 }
 
@@ -179,6 +197,7 @@ type udpProxyOutboundCfg struct {
 // Run runs the action.
 func (cfg udpProxyOutboundCfg) Run() error {
 	logger.Debug("Running UDP outbound proxy service %s\n", cfg)
+
 	return UDPProxyServiceOutbound(netceptor.MainInstance, cfg.Service, cfg.Address)
 }
 

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// UDPProxyServiceInbound listens on a UDP port and forwards packets to a remote Receptor service
+// UDPProxyServiceInbound listens on a UDP port and forwards packets to a remote Receptor service.
 func UDPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, node string, service string) error {
 	connMap := make(map[string]*netceptor.PacketConn)
 	buffer := make([]byte, utils.NormalBufferSize)
@@ -88,7 +88,7 @@ func runNetceptorToUDPInbound(pc *netceptor.PacketConn, uc *net.UDPConn, udpAddr
 	}
 }
 
-// UDPProxyServiceOutbound listens on the Receptor network and forwards packets via UDP
+// UDPProxyServiceOutbound listens on the Receptor network and forwards packets via UDP.
 func UDPProxyServiceOutbound(s *netceptor.Netceptor, service string, address string) error {
 	connMap := make(map[string]*net.UDPConn)
 	buffer := make([]byte, utils.NormalBufferSize)
@@ -156,7 +156,7 @@ func runUDPToNetceptorOutbound(uc *net.UDPConn, pc *netceptor.PacketConn, addr n
 	}
 }
 
-// udpProxyInboundCfg is the cmdline configuration object for a UDP inbound proxy
+// udpProxyInboundCfg is the cmdline configuration object for a UDP inbound proxy.
 type udpProxyInboundCfg struct {
 	Port          int    `required:"true" description:"Local UDP port to bind to"`
 	BindAddr      string `description:"Address to bind UDP listener to" default:"0.0.0.0"`
@@ -164,19 +164,19 @@ type udpProxyInboundCfg struct {
 	RemoteService string `required:"true" description:"Receptor service name to connect to"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg udpProxyInboundCfg) Run() error {
 	logger.Debug("Running UDP inbound proxy service %v\n", cfg)
 	return UDPProxyServiceInbound(netceptor.MainInstance, cfg.BindAddr, cfg.Port, cfg.RemoteNode, cfg.RemoteService)
 }
 
-// udpProxyOutboundCfg is the cmdline configuration object for a UDP outbound proxy
+// udpProxyOutboundCfg is the cmdline configuration object for a UDP outbound proxy.
 type udpProxyOutboundCfg struct {
 	Service string `required:"true" description:"Receptor service name to bind to"`
 	Address string `required:"true" description:"Address for outbound UDP connection"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg udpProxyOutboundCfg) Run() error {
 	logger.Debug("Running UDP outbound proxy service %s\n", cfg)
 	return UDPProxyServiceOutbound(netceptor.MainInstance, cfg.Service, cfg.Address)

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -29,18 +29,21 @@ func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permission
 			uc, err := uli.Accept()
 			if err != nil {
 				logger.Error("Error accepting Unix socket connection: %s", err)
+
 				return
 			}
 			go func() {
 				qc, err := s.Dial(node, rservice, tlscfg)
 				if err != nil {
 					logger.Error("Error connecting on Receptor network: %s", err)
+
 					return
 				}
 				utils.BridgeConns(uc, "unix socket service", qc, "receptor connection")
 			}()
 		}
 	}()
+
 	return nil
 }
 
@@ -58,17 +61,19 @@ func UnixProxyServiceOutbound(s *netceptor.Netceptor, service string, tlscfg *tl
 			qc, err := qli.Accept()
 			if err != nil {
 				logger.Error("Error accepting connection on Receptor network: %s\n", err)
-				return
 
+				return
 			}
 			uc, err := net.Dial("unix", filename)
 			if err != nil {
 				logger.Error("Error connecting via Unix socket: %s\n", err)
+
 				continue
 			}
 			go utils.BridgeConns(qc, "receptor service", uc, "unix socket connection")
 		}
 	}()
+
 	return nil
 }
 
@@ -88,6 +93,7 @@ func (cfg unixProxyInboundCfg) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return UnixProxyServiceInbound(netceptor.MainInstance, cfg.Filename, os.FileMode(cfg.Permissions),
 		cfg.RemoteNode, cfg.RemoteService, tlscfg)
 }
@@ -106,6 +112,7 @@ func (cfg unixProxyOutboundCfg) Run() error {
 	if err != nil {
 		return err
 	}
+
 	return UnixProxyServiceOutbound(netceptor.MainInstance, cfg.Service, tlscfg, cfg.Filename)
 }
 

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// UnixProxyServiceInbound listens on a Unix socket and forwards connections over the Receptor network
+// UnixProxyServiceInbound listens on a Unix socket and forwards connections over the Receptor network.
 func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permissions os.FileMode,
 	node string, rservice string, tlscfg *tls.Config) error {
 	uli, lock, err := utils.UnixSocketListen(filename, permissions)
@@ -44,7 +44,7 @@ func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permission
 	return nil
 }
 
-// UnixProxyServiceOutbound listens on the Receptor network and forwards the connection via a Unix socket
+// UnixProxyServiceOutbound listens on the Receptor network and forwards the connection via a Unix socket.
 func UnixProxyServiceOutbound(s *netceptor.Netceptor, service string, tlscfg *tls.Config, filename string) error {
 	qli, err := s.ListenAndAdvertise(service, tlscfg, map[string]string{
 		"type":     "Unix Proxy",
@@ -72,7 +72,7 @@ func UnixProxyServiceOutbound(s *netceptor.Netceptor, service string, tlscfg *tl
 	return nil
 }
 
-// unixProxyInboundCfg is the cmdline configuration object for a Unix socket inbound proxy
+// unixProxyInboundCfg is the cmdline configuration object for a Unix socket inbound proxy.
 type unixProxyInboundCfg struct {
 	Filename      string `required:"true" description:"Socket filename, which will be overwritten"`
 	Permissions   int    `description:"Socket file permissions" default:"0600"`
@@ -81,7 +81,7 @@ type unixProxyInboundCfg struct {
 	TLS           string `description:"Name of TLS client config for the Receptor connection"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg unixProxyInboundCfg) Run() error {
 	logger.Debug("Running Unix socket inbound proxy service %v\n", cfg)
 	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, cfg.RemoteNode, "receptor")
@@ -92,14 +92,14 @@ func (cfg unixProxyInboundCfg) Run() error {
 		cfg.RemoteNode, cfg.RemoteService, tlscfg)
 }
 
-// unixProxyOutboundCfg is the cmdline configuration object for a Unix socket outbound proxy
+// unixProxyOutboundCfg is the cmdline configuration object for a Unix socket outbound proxy.
 type unixProxyOutboundCfg struct {
 	Service  string `required:"true" description:"Receptor service name to bind to"`
 	Filename string `required:"true" description:"Socket filename, which must already exist"`
 	TLS      string `description:"Name of TLS server config for the Receptor connection"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg unixProxyOutboundCfg) Run() error {
 	logger.Debug("Running Unix socket inbound proxy service %s\n", cfg)
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -6,13 +6,14 @@ package services
 import (
 	"crypto/tls"
 	"fmt"
+	"net"
+	"os"
+	"runtime"
+
 	"github.com/ghjm/cmdline"
 	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 	"github.com/project-receptor/receptor/pkg/utils"
-	"net"
-	"os"
-	"runtime"
 )
 
 // UnixProxyServiceInbound listens on a Unix socket and forwards connections over the Receptor network

--- a/pkg/tickrunner/tickrunner.go
+++ b/pkg/tickrunner/tickrunner.go
@@ -33,5 +33,6 @@ func Run(ctx context.Context, f func(), periodicInterval time.Duration, defaultR
 			}
 		}
 	}()
+
 	return runChan
 }

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -49,6 +49,7 @@ func bridgeHalf(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2N
 		if shouldClose {
 			logger.Trace("    Stopping bridge %s to %s\n", c1Name, c2Name)
 			_ = c2.Close()
+
 			return
 		}
 	}

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -7,7 +7,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/logger"
 )
 
-// NormalBufferSize is the size of buffers used by various processes when copying data between sockets
+// NormalBufferSize is the size of buffers used by various processes when copying data between sockets.
 const NormalBufferSize = 65536
 
 // BridgeConns bridges two connections, like netcat.

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"github.com/project-receptor/receptor/pkg/logger"
 	"io"
 	"strings"
+
+	"github.com/project-receptor/receptor/pkg/logger"
 )
 
 // NormalBufferSize is the size of buffers used by various processes when copying data between sockets

--- a/pkg/utils/broker.go
+++ b/pkg/utils/broker.go
@@ -28,6 +28,7 @@ func NewBroker(ctx context.Context, msgType reflect.Type) *Broker {
 		unsubCh:   make(chan chan interface{}),
 	}
 	go b.start()
+
 	return b
 }
 
@@ -40,6 +41,7 @@ func (b *Broker) start() {
 			for ch := range subs {
 				close(ch)
 			}
+
 			return
 		case msgCh := <-b.subCh:
 			subs[msgCh] = struct{}{}
@@ -66,8 +68,10 @@ func (b *Broker) Subscribe() chan interface{} {
 	if b.ctx.Err() == nil {
 		msgCh := make(chan interface{}, 1)
 		b.subCh <- msgCh
+
 		return msgCh
 	}
+
 	return nil
 }
 
@@ -87,5 +91,6 @@ func (b *Broker) Publish(msg interface{}) error {
 	if b.ctx.Err() == nil {
 		b.publishCh <- msg
 	}
+
 	return nil
 }

--- a/pkg/utils/broker.go
+++ b/pkg/utils/broker.go
@@ -9,7 +9,7 @@ import (
 // Broker code adapted from https://stackoverflow.com/questions/36417199/how-to-broadcast-message-using-channel
 // which is licensed under Creative Commons CC BY-SA 4.0.
 
-// Broker implements a simple pub-sub broadcast system
+// Broker implements a simple pub-sub broadcast system.
 type Broker struct {
 	ctx       context.Context
 	msgType   reflect.Type
@@ -18,7 +18,7 @@ type Broker struct {
 	unsubCh   chan chan interface{}
 }
 
-// NewBroker allocates a new Broker object
+// NewBroker allocates a new Broker object.
 func NewBroker(ctx context.Context, msgType reflect.Type) *Broker {
 	b := &Broker{
 		ctx:       ctx,
@@ -31,7 +31,7 @@ func NewBroker(ctx context.Context, msgType reflect.Type) *Broker {
 	return b
 }
 
-// start starts the broker goroutine
+// start starts the broker goroutine.
 func (b *Broker) start() {
 	subs := map[chan interface{}]struct{}{}
 	for {
@@ -58,7 +58,7 @@ func (b *Broker) start() {
 	}
 }
 
-// Subscribe registers to receive messages from the broker
+// Subscribe registers to receive messages from the broker.
 func (b *Broker) Subscribe() chan interface{} {
 	if b == nil || b.ctx == nil {
 		fmt.Printf("foo\n")
@@ -71,7 +71,7 @@ func (b *Broker) Subscribe() chan interface{} {
 	return nil
 }
 
-// Unsubscribe de-registers a message receiver
+// Unsubscribe de-registers a message receiver.
 func (b *Broker) Unsubscribe(msgCh chan interface{}) {
 	if b.ctx.Err() == nil {
 		b.unsubCh <- msgCh
@@ -79,7 +79,7 @@ func (b *Broker) Unsubscribe(msgCh chan interface{}) {
 	close(msgCh)
 }
 
-// Publish sends a message to all subscribers
+// Publish sends a message to all subscribers.
 func (b *Broker) Publish(msg interface{}) error {
 	if reflect.TypeOf(msg) != b.msgType {
 		return fmt.Errorf("messages to broker must be of type %s", b.msgType.String())

--- a/pkg/utils/cancel_with_err_context.go
+++ b/pkg/utils/cancel_with_err_context.go
@@ -54,12 +54,12 @@ func (cwe *CancelWithErrContext) closeDoneChan() {
 	})
 }
 
-// Done implements Context.Done()
+// Done implements Context.Done().
 func (cwe *CancelWithErrContext) Done() <-chan struct{} {
 	return cwe.doneChan
 }
 
-// Err implements Context.Err()
+// Err implements Context.Err().
 func (cwe *CancelWithErrContext) Err() error {
 	if cwe.err != nil {
 		return cwe.err
@@ -67,12 +67,12 @@ func (cwe *CancelWithErrContext) Err() error {
 	return cwe.parentCtx.Err()
 }
 
-// Deadline implements Context.Deadline()
+// Deadline implements Context.Deadline().
 func (cwe *CancelWithErrContext) Deadline() (time time.Time, ok bool) {
 	return cwe.parentCtx.Deadline()
 }
 
-// Value implements Context.Value()
+// Value implements Context.Value().
 func (cwe *CancelWithErrContext) Value(key interface{}) interface{} {
 	return cwe.parentCtx.Value(key)
 }

--- a/pkg/utils/cancel_with_err_context.go
+++ b/pkg/utils/cancel_with_err_context.go
@@ -32,16 +32,19 @@ func ContextWithCancelWithErr(parent context.Context) (*CancelWithErrContext, Ca
 			select {
 			case <-parent.Done():
 				cwe.closeDoneChan()
+
 				return
 			case err := <-cwe.errChan:
 				cwe.err = err
 				if err != nil {
 					cwe.closeDoneChan()
+
 					return
 				}
 			}
 		}
 	}()
+
 	return cwe, func(err error) {
 		cwe.err = err
 		cwe.closeDoneChan()
@@ -64,6 +67,7 @@ func (cwe *CancelWithErrContext) Err() error {
 	if cwe.err != nil {
 		return cwe.err
 	}
+
 	return cwe.parentCtx.Err()
 }
 

--- a/pkg/utils/error_kind.go
+++ b/pkg/utils/error_kind.go
@@ -2,18 +2,18 @@ package utils
 
 import "fmt"
 
-// ErrorWithKind represents an error wrapped with a designation of what kind of error it is
+// ErrorWithKind represents an error wrapped with a designation of what kind of error it is.
 type ErrorWithKind struct {
 	err  error
 	kind string
 }
 
-// Error returns the error text as a string
+// Error returns the error text as a string.
 func (ek ErrorWithKind) Error() string {
 	return fmt.Sprintf("%s error: %s", ek.kind, ek.err)
 }
 
-// WrapErrorWithKind creates an ErrorWithKind that wraps an underlying error
+// WrapErrorWithKind creates an ErrorWithKind that wraps an underlying error.
 func WrapErrorWithKind(err error, kind string) ErrorWithKind {
 	return ErrorWithKind{
 		err:  err,
@@ -21,7 +21,7 @@ func WrapErrorWithKind(err error, kind string) ErrorWithKind {
 	}
 }
 
-// ErrorIsKind returns true if err is an ErrorWithKind of the specified kind, or false otherwise (including if nil)
+// ErrorIsKind returns true if err is an ErrorWithKind of the specified kind, or false otherwise (including if nil).
 func ErrorIsKind(err error, kind string) bool {
 	ek, ok := err.(ErrorWithKind)
 	if !ok {

--- a/pkg/utils/error_kind.go
+++ b/pkg/utils/error_kind.go
@@ -27,5 +27,6 @@ func ErrorIsKind(err error, kind string) bool {
 	if !ok {
 		return false
 	}
+
 	return ek.kind == kind
 }

--- a/pkg/utils/flock.go
+++ b/pkg/utils/flock.go
@@ -7,15 +7,15 @@ import (
 	"syscall"
 )
 
-// ErrLocked is returned when the flock is already held
+// ErrLocked is returned when the flock is already held.
 var ErrLocked = fmt.Errorf("fslock is already locked")
 
-// FLock represents a file lock
+// FLock represents a file lock.
 type FLock struct {
 	fd int
 }
 
-// TryFLock non-blockingly attempts to acquire a lock on the file
+// TryFLock non-blockingly attempts to acquire a lock on the file.
 func TryFLock(filename string) (*FLock, error) {
 	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0o600)
 	if err != nil {
@@ -32,7 +32,7 @@ func TryFLock(filename string) (*FLock, error) {
 	return &FLock{fd: fd}, nil
 }
 
-// Unlock unlocks the file lock
+// Unlock unlocks the file lock.
 func (lock *FLock) Unlock() error {
 	return syscall.Close(lock.fd)
 }

--- a/pkg/utils/flock.go
+++ b/pkg/utils/flock.go
@@ -17,7 +17,7 @@ type FLock struct {
 
 // TryFLock non-blockingly attempts to acquire a lock on the file
 func TryFLock(filename string) (*FLock, error) {
-	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0600)
+	fd, err := syscall.Open(filename, syscall.O_CREAT|syscall.O_RDONLY|syscall.O_CLOEXEC, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/flock.go
+++ b/pkg/utils/flock.go
@@ -27,8 +27,10 @@ func TryFLock(filename string) (*FLock, error) {
 	}
 	if err != nil {
 		_ = syscall.Close(fd)
+
 		return nil, err
 	}
+
 	return &FLock{fd: fd}, nil
 }
 

--- a/pkg/utils/flock_windows.go
+++ b/pkg/utils/flock_windows.go
@@ -10,8 +10,7 @@ import (
 var ErrLocked = fmt.Errorf("fslock is already locked")
 
 // FLock represents a Unix file lock, but is not usable on Windows
-type FLock struct {
-}
+type FLock struct{}
 
 // TryFLock is not implemented on Windows
 func TryFLock(filename string) (*FLock, error) {

--- a/pkg/utils/incremental_duration.go
+++ b/pkg/utils/incremental_duration.go
@@ -36,5 +36,6 @@ func (ID *IncrementalDuration) increaseDuration() {
 func (ID *IncrementalDuration) NextTimeout() <-chan time.Time {
 	ch := time.After(ID.duration)
 	ID.increaseDuration()
+
 	return ch
 }

--- a/pkg/utils/incremental_duration.go
+++ b/pkg/utils/incremental_duration.go
@@ -24,18 +24,18 @@ func NewIncrementalDuration(duration, maxDuration time.Duration, multiplier floa
 }
 
 // Reset sets current duration to initial duration.
-func (ID *IncrementalDuration) Reset() {
-	ID.duration = ID.initialDuration
+func (id *IncrementalDuration) Reset() {
+	id.duration = id.initialDuration
 }
 
-func (ID *IncrementalDuration) increaseDuration() {
-	ID.duration = time.Duration(math.Min(ID.multiplier*float64(ID.duration), float64(ID.maxDuration)))
+func (id *IncrementalDuration) increaseDuration() {
+	id.duration = time.Duration(math.Min(id.multiplier*float64(id.duration), float64(id.maxDuration)))
 }
 
 // NextTimeout returns a timeout channel based on current duration.
-func (ID *IncrementalDuration) NextTimeout() <-chan time.Time {
-	ch := time.After(ID.duration)
-	ID.increaseDuration()
+func (id *IncrementalDuration) NextTimeout() <-chan time.Time {
+	ch := time.After(id.duration)
+	id.increaseDuration()
 
 	return ch
 }

--- a/pkg/utils/incremental_duration.go
+++ b/pkg/utils/incremental_duration.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-// IncrementalDuration handles a time.Duration with max limits
+// IncrementalDuration handles a time.Duration with max limits.
 type IncrementalDuration struct {
 	duration        time.Duration
 	initialDuration time.Duration
@@ -13,7 +13,7 @@ type IncrementalDuration struct {
 	multiplier      float64
 }
 
-// NewIncrementalDuration returns an IncrementalDuration object with initialized values
+// NewIncrementalDuration returns an IncrementalDuration object with initialized values.
 func NewIncrementalDuration(duration, maxDuration time.Duration, multiplier float64) *IncrementalDuration {
 	return &IncrementalDuration{
 		duration:        duration,
@@ -23,7 +23,7 @@ func NewIncrementalDuration(duration, maxDuration time.Duration, multiplier floa
 	}
 }
 
-// Reset sets current duration to initial duration
+// Reset sets current duration to initial duration.
 func (ID *IncrementalDuration) Reset() {
 	ID.duration = ID.initialDuration
 }
@@ -32,7 +32,7 @@ func (ID *IncrementalDuration) increaseDuration() {
 	ID.duration = time.Duration(math.Min(ID.multiplier*float64(ID.duration), float64(ID.maxDuration)))
 }
 
-// NextTimeout returns a timeout channel based on current duration
+// NextTimeout returns a timeout channel based on current duration.
 func (ID *IncrementalDuration) NextTimeout() <-chan time.Time {
 	ch := time.After(ID.duration)
 	ID.increaseDuration()

--- a/pkg/utils/incremental_duration_test.go
+++ b/pkg/utils/incremental_duration_test.go
@@ -10,9 +10,7 @@ func TestIncrementalDuration(t *testing.T) {
 	if delay.duration != 1*time.Second {
 		t.Fail()
 	}
-	select {
-	case <-delay.NextTimeout():
-	}
+	<-delay.NextTimeout()
 	if delay.duration != 2*time.Second {
 		t.Fail()
 	}

--- a/pkg/utils/job_context.go
+++ b/pkg/utils/job_context.go
@@ -70,22 +70,22 @@ func (mw *JobContext) Wait() {
 	}
 }
 
-// Done implements Context.Done()
+// Done implements Context.Done().
 func (mw *JobContext) Done() <-chan struct{} {
 	return mw.ctx.Done()
 }
 
-// Err implements Context.Err()
+// Err implements Context.Err().
 func (mw *JobContext) Err() error {
 	return mw.ctx.Err()
 }
 
-// Deadline implements Context.Deadline()
+// Deadline implements Context.Deadline().
 func (mw *JobContext) Deadline() (time time.Time, ok bool) {
 	return mw.ctx.Deadline()
 }
 
-// Value implements Context.Value()
+// Value implements Context.Value().
 func (mw *JobContext) Value(key interface{}) interface{} {
 	return mw.ctx.Value(key)
 }
@@ -97,7 +97,7 @@ func (mw *JobContext) Cancel() {
 	}
 }
 
-// Running returns true if a job is currently running
+// Running returns true if a job is currently running.
 func (mw *JobContext) Running() bool {
 	mw.runningLock.Lock()
 	defer mw.runningLock.Unlock()

--- a/pkg/utils/job_context.go
+++ b/pkg/utils/job_context.go
@@ -34,6 +34,7 @@ func (mw *JobContext) NewJob(ctx context.Context, workers int, returnIfRunning b
 	for mw.running {
 		if returnIfRunning {
 			mw.runningLock.Unlock()
+
 			return false
 		}
 		mw.cancel()
@@ -54,6 +55,7 @@ func (mw *JobContext) NewJob(ctx context.Context, workers int, returnIfRunning b
 		mw.cancel()
 		mw.runningLock.Unlock()
 	}()
+
 	return true
 }
 
@@ -101,5 +103,6 @@ func (mw *JobContext) Cancel() {
 func (mw *JobContext) Running() bool {
 	mw.runningLock.Lock()
 	defer mw.runningLock.Unlock()
+
 	return mw.running
 }

--- a/pkg/utils/other_name.go
+++ b/pkg/utils/other_name.go
@@ -7,19 +7,19 @@ import (
 )
 
 var (
-	// OIDSubjectAltName is the OID for subjectAltName
+	// OIDSubjectAltName is the OID for subjectAltName.
 	OIDSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
-	// OIDReceptorName is the OID for a Receptor node ID
+	// OIDReceptorName is the OID for a Receptor node ID.
 	OIDReceptorName = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 2312, 19, 1}
 )
 
-// OtherNameDecode is used for decoding the OtherName field type of an x.509 subjectAltName
+// OtherNameDecode is used for decoding the OtherName field type of an x.509 subjectAltName.
 type OtherNameDecode struct {
 	ID    asn1.ObjectIdentifier
 	Value asn1.RawValue
 }
 
-// ReceptorNames returns a list of Receptor node IDs found in the subjectAltName field of an x.509 certificate
+// ReceptorNames returns a list of Receptor node IDs found in the subjectAltName field of an x.509 certificate.
 func ReceptorNames(extensions []pkix.Extension) ([]string, error) {
 	names := make([]string, 0)
 	for _, extension := range extensions {
@@ -51,33 +51,33 @@ func ReceptorNames(extensions []pkix.Extension) ([]string, error) {
 	return names, nil
 }
 
-// UTFString is used for encoding a UTF-8 string
+// UTFString is used for encoding a UTF-8 string.
 type UTFString struct {
 	A string `asn1:"utf8"`
 }
 
-// DNSNameEncode is used for encoding the OtherName field of an x.509 subjectAltName
+// DNSNameEncode is used for encoding the OtherName field of an x.509 subjectAltName.
 type DNSNameEncode struct {
 	Value string `asn1:"tag:2"`
 }
 
-// IPAddressEncode is used for encoding the OtherName field of an x.509 subjectAltName
+// IPAddressEncode is used for encoding the OtherName field of an x.509 subjectAltName.
 type IPAddressEncode struct {
 	Value []byte `asn1:"tag:7"`
 }
 
-// OtherNameEncode is used for encoding the OtherName field of an x.509 subjectAltName
+// OtherNameEncode is used for encoding the OtherName field of an x.509 subjectAltName.
 type OtherNameEncode struct {
 	OID   asn1.ObjectIdentifier
 	Value UTFString `asn1:"tag:0"`
 }
 
-// GeneralNameEncode is used for encoding a GeneralName in an x.509 certificate
+// GeneralNameEncode is used for encoding a GeneralName in an x.509 certificate.
 type GeneralNameEncode struct {
 	Names []interface{} `asn1:"tag:0"`
 }
 
-// MakeReceptorSAN generates a subjectAltName extension, optionally containing Receptor names
+// MakeReceptorSAN generates a subjectAltName extension, optionally containing Receptor names.
 func MakeReceptorSAN(DNSNames []string, IPAddresses []net.IP, NodeIDs []string) (*pkix.Extension, error) {
 	var rawValues []asn1.RawValue
 	for _, name := range DNSNames {

--- a/pkg/utils/other_name.go
+++ b/pkg/utils/other_name.go
@@ -79,19 +79,19 @@ type GeneralNameEncode struct {
 }
 
 // MakeReceptorSAN generates a subjectAltName extension, optionally containing Receptor names.
-func MakeReceptorSAN(DNSNames []string, IPAddresses []net.IP, NodeIDs []string) (*pkix.Extension, error) {
+func MakeReceptorSAN(dnsNames []string, ipAddresses []net.IP, nodeIDs []string) (*pkix.Extension, error) {
 	rawValues := []asn1.RawValue{}
-	for _, name := range DNSNames {
+	for _, name := range dnsNames {
 		rawValues = append(rawValues, asn1.RawValue{Tag: 2, Class: 2, Bytes: []byte(name)})
 	}
-	for _, rawIP := range IPAddresses {
+	for _, rawIP := range ipAddresses {
 		ip := rawIP.To4()
 		if ip == nil {
 			ip = rawIP
 		}
 		rawValues = append(rawValues, asn1.RawValue{Tag: 7, Class: 2, Bytes: ip})
 	}
-	for _, nodeID := range NodeIDs {
+	for _, nodeID := range nodeIDs {
 		var err error
 		var asnOtherName []byte
 		asnOtherName, err = asn1.Marshal(OtherNameEncode{

--- a/pkg/utils/other_name.go
+++ b/pkg/utils/other_name.go
@@ -48,6 +48,7 @@ func ReceptorNames(extensions []pkix.Extension) ([]string, error) {
 			}
 		}
 	}
+
 	return names, nil
 }
 
@@ -111,5 +112,6 @@ func MakeReceptorSAN(DNSNames []string, IPAddresses []net.IP, NodeIDs []string) 
 		Critical: false,
 		Value:    sanBytes,
 	}
+
 	return &sanExt, nil
 }

--- a/pkg/utils/other_name.go
+++ b/pkg/utils/other_name.go
@@ -80,7 +80,7 @@ type GeneralNameEncode struct {
 
 // MakeReceptorSAN generates a subjectAltName extension, optionally containing Receptor names.
 func MakeReceptorSAN(DNSNames []string, IPAddresses []net.IP, NodeIDs []string) (*pkix.Extension, error) {
-	var rawValues []asn1.RawValue
+	rawValues := []asn1.RawValue{}
 	for _, name := range DNSNames {
 		rawValues = append(rawValues, asn1.RawValue{Tag: 2, Class: 2, Bytes: []byte(name)})
 	}

--- a/pkg/utils/sysinfo.go
+++ b/pkg/utils/sysinfo.go
@@ -1,8 +1,9 @@
 package utils
 
 import (
-	"github.com/pbnjay/memory"
 	"runtime"
+
+	"github.com/pbnjay/memory"
 )
 
 // GetSysCPUCount returns number of logical CPU cores on the system

--- a/pkg/utils/sysinfo.go
+++ b/pkg/utils/sysinfo.go
@@ -6,12 +6,12 @@ import (
 	"github.com/pbnjay/memory"
 )
 
-// GetSysCPUCount returns number of logical CPU cores on the system
+// GetSysCPUCount returns number of logical CPU cores on the system.
 func GetSysCPUCount() int {
 	return runtime.NumCPU()
 }
 
-// GetSysMemoryMiB returns the capacity (in mebibytes) of the physical memory installed on the system
+// GetSysMemoryMiB returns the capacity (in mebibytes) of the physical memory installed on the system.
 func GetSysMemoryMiB() uint64 {
 	return memory.TotalMemory() / 1048576 // bytes to MiB
 }

--- a/pkg/utils/unixsock.go
+++ b/pkg/utils/unixsock.go
@@ -8,7 +8,7 @@ import (
 	"os"
 )
 
-// UnixSocketListen listens on a Unix socket, handling file locking and permissions
+// UnixSocketListen listens on a Unix socket, handling file locking and permissions.
 func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, *FLock, error) {
 	lock, err := TryFLock(filename + ".lock")
 	if err != nil {

--- a/pkg/utils/unixsock.go
+++ b/pkg/utils/unixsock.go
@@ -17,18 +17,22 @@ func UnixSocketListen(filename string, permissions os.FileMode) (net.Listener, *
 	err = os.RemoveAll(filename)
 	if err != nil {
 		_ = lock.Unlock()
+
 		return nil, nil, fmt.Errorf("could not overwrite socket file: %s", err)
 	}
 	uli, err := net.Listen("unix", filename)
 	if err != nil {
 		_ = lock.Unlock()
+
 		return nil, nil, fmt.Errorf("could not listen on socket file: %s", err)
 	}
 	err = os.Chmod(filename, permissions)
 	if err != nil {
 		_ = uli.Close()
 		_ = lock.Unlock()
+
 		return nil, nil, fmt.Errorf("error setting socket file permissions: %s", err)
 	}
+
 	return uli, lock, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+
 	"github.com/ghjm/cmdline"
 )
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,13 +6,13 @@ import (
 	"github.com/ghjm/cmdline"
 )
 
-// Version is receptor app version
+// Version is receptor app version.
 var Version string
 
-// cmdlineCfg is a cmdline-compatible struct for a --version command
+// cmdlineCfg is a cmdline-compatible struct for a --version command.
 type cmdlineCfg struct{}
 
-// Run runs the action
+// Run runs the action.
 func (cfg cmdlineCfg) Run() error {
 	if Version == "" {
 		fmt.Printf("Version unknown\n")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -19,6 +19,7 @@ func (cfg cmdlineCfg) Run() error {
 	} else {
 		fmt.Printf("%s\n", Version)
 	}
+
 	return nil
 }
 

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -4,9 +4,6 @@ package workceptor
 
 import (
 	"fmt"
-	"github.com/ghjm/cmdline"
-	"github.com/google/shlex"
-	"github.com/project-receptor/receptor/pkg/logger"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -14,6 +11,10 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/ghjm/cmdline"
+	"github.com/google/shlex"
+	"github.com/project-receptor/receptor/pkg/logger"
 )
 
 // commandUnit implements the WorkUnit interface for the Receptor command worker plugin
@@ -76,7 +77,7 @@ func commandRunner(command string, params string, unitdir string) error {
 		return err
 	}
 	cmd.Stdin = stdin
-	stdout, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0600)
+	stdout, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -70,7 +70,7 @@ func commandRunner(command string, params string, unitdir string) error {
 		}
 		cmd = exec.Command(command, paramList...)
 	}
-	termChan := make(chan os.Signal)
+	termChan := make(chan os.Signal, 1)
 	signal.Notify(termChan, syscall.SIGINT, syscall.SIGTERM)
 	stdin, err := os.Open(path.Join(unitdir, "stdin"))
 	if err != nil {

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -185,8 +185,7 @@ func (cw *commandUnit) runCommand(cmd *exec.Cmd) error {
 	cw.done = false
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
-	err := cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		cw.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Failed to start command runner: %s", err), 0)
 
 		return err
@@ -226,8 +225,7 @@ func (cw *commandUnit) Start() error {
 
 // Restart resumes monitoring a job after a Receptor restart.
 func (cw *commandUnit) Restart() error {
-	err := cw.Load()
-	if err != nil {
+	if err := cw.Load(); err != nil {
 		return err
 	}
 	state := cw.Status().State

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -23,7 +23,6 @@ type commandUnit struct {
 	command            string
 	baseParams         string
 	allowRuntimeParams bool
-	cmdParams          string
 	done               bool
 }
 

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -134,11 +134,12 @@ loop:
 
 func combineParams(baseParams string, userParams string) string {
 	var allParams string
-	if userParams == "" {
+	switch {
+	case userParams == "":
 		allParams = baseParams
-	} else if baseParams == "" {
+	case baseParams == "":
 		allParams = userParams
-	} else {
+	default:
 		allParams = strings.Join([]string{baseParams, userParams}, " ")
 	}
 

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -106,7 +106,6 @@ loop:
 			if err != nil {
 				logger.Error("Error updating status file %s: %s", statusFilename, err)
 			}
-
 		}
 	}
 	if err != nil {
@@ -114,6 +113,7 @@ loop:
 		if err != nil {
 			logger.Error("Error updating status file %s: %s", statusFilename, err)
 		}
+
 		return err
 	}
 	if cmd.ProcessState.Success() {
@@ -128,6 +128,7 @@ loop:
 		}
 	}
 	os.Exit(cmd.ProcessState.ExitCode())
+
 	return nil
 }
 
@@ -140,6 +141,7 @@ func combineParams(baseParams string, userParams string) string {
 	} else {
 		allParams = strings.Join([]string{baseParams, userParams}, " ")
 	}
+
 	return allParams
 }
 
@@ -153,6 +155,7 @@ func (cw *commandUnit) SetFromParams(params map[string]string) error {
 		return fmt.Errorf("extra params provided but not allowed")
 	}
 	cw.status.ExtraData.(*commandExtraData).Params = combineParams(cw.baseParams, cmdParams)
+
 	return nil
 }
 
@@ -171,6 +174,7 @@ func (cw *commandUnit) UnredactedStatus() *StatusFileData {
 		edCopy := *ed
 		status.ExtraData = &edCopy
 	}
+
 	return status
 }
 
@@ -183,6 +187,7 @@ func (cw *commandUnit) runCommand(cmd *exec.Cmd) error {
 	err := cmd.Start()
 	if err != nil {
 		cw.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Failed to start command runner: %s", err), 0)
+
 		return err
 	}
 	cw.UpdateFullStatus(func(status *StatusFileData) {
@@ -201,6 +206,7 @@ func (cw *commandUnit) runCommand(cmd *exec.Cmd) error {
 	}()
 	go cmdWaiter(cmd, doneChan)
 	go cw.monitorLocalStatus()
+
 	return nil
 }
 
@@ -213,6 +219,7 @@ func (cw *commandUnit) Start() error {
 		fmt.Sprintf("command=%s", cw.command),
 		fmt.Sprintf("params=%s", cw.Status().ExtraData.(*commandExtraData).Params),
 		fmt.Sprintf("unitdir=%s", cw.UnitDir()))
+
 	return cw.runCommand(cmd)
 }
 
@@ -232,6 +239,7 @@ func (cw *commandUnit) Restart() error {
 		cw.UpdateBasicStatus(WorkStateFailed, "Pending at restart", stdoutSize(cw.UnitDir()))
 	}
 	go cw.monitorLocalStatus()
+
 	return nil
 }
 
@@ -253,10 +261,12 @@ func (cw *commandUnit) Cancel() error {
 		if strings.Contains(err.Error(), "already finished") {
 			return nil
 		}
+
 		return err
 	}
 
 	proc.Wait()
+
 	return nil
 }
 
@@ -266,6 +276,7 @@ func (cw *commandUnit) Release(force bool) error {
 	if err != nil && !force {
 		return err
 	}
+
 	return cw.BaseWorkUnit.Release(force)
 }
 
@@ -293,12 +304,14 @@ func (cfg commandCfg) newWorker(w *Workceptor, unitID string, workType string) W
 		allowRuntimeParams: cfg.AllowRuntimeParams,
 	}
 	cw.BaseWorkUnit.Init(w, unitID, workType)
+
 	return cw
 }
 
 // Run runs the action.
 func (cfg commandCfg) Run() error {
 	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker)
+
 	return err
 }
 
@@ -323,6 +336,7 @@ func (cfg commandRunnerCfg) Run() error {
 	} else {
 		os.Exit(0)
 	}
+
 	return nil
 }
 

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -17,7 +17,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/logger"
 )
 
-// commandUnit implements the WorkUnit interface for the Receptor command worker plugin
+// commandUnit implements the WorkUnit interface for the Receptor command worker plugin.
 type commandUnit struct {
 	BaseWorkUnit
 	command            string
@@ -27,7 +27,7 @@ type commandUnit struct {
 	done               bool
 }
 
-// commandExtraData is the content of the ExtraData JSON field for a command worker
+// commandExtraData is the content of the ExtraData JSON field for a command worker.
 type commandExtraData struct {
 	Pid    int
 	Params string
@@ -51,7 +51,7 @@ func cmdWaiter(cmd *exec.Cmd, doneChan chan bool) {
 	doneChan <- true
 }
 
-// commandRunner is run in a separate process, to monitor the subprocess and report back metadata
+// commandRunner is run in a separate process, to monitor the subprocess and report back metadata.
 func commandRunner(command string, params string, unitdir string) error {
 	status := StatusFileData{}
 	status.ExtraData = &commandExtraData{}
@@ -143,7 +143,7 @@ func combineParams(baseParams string, userParams string) string {
 	return allParams
 }
 
-// SetFromParams sets the in-memory state from parameters
+// SetFromParams sets the in-memory state from parameters.
 func (cw *commandUnit) SetFromParams(params map[string]string) error {
 	cmdParams, ok := params["params"]
 	if !ok {
@@ -156,12 +156,12 @@ func (cw *commandUnit) SetFromParams(params map[string]string) error {
 	return nil
 }
 
-// Status returns a copy of the status currently loaded in memory
+// Status returns a copy of the status currently loaded in memory.
 func (cw *commandUnit) Status() *StatusFileData {
 	return cw.UnredactedStatus()
 }
 
-// UnredactedStatus returns a copy of the status currently loaded in memory, including secrets
+// UnredactedStatus returns a copy of the status currently loaded in memory, including secrets.
 func (cw *commandUnit) UnredactedStatus() *StatusFileData {
 	cw.statusLock.RLock()
 	defer cw.statusLock.RUnlock()
@@ -216,7 +216,7 @@ func (cw *commandUnit) Start() error {
 	return cw.runCommand(cmd)
 }
 
-// Restart resumes monitoring a job after a Receptor restart
+// Restart resumes monitoring a job after a Receptor restart.
 func (cw *commandUnit) Restart() error {
 	err := cw.Load()
 	if err != nil {
@@ -273,7 +273,7 @@ func (cw *commandUnit) Release(force bool) error {
 // Command line
 // **************************************************************************
 
-// commandCfg is the cmdline configuration object for a worker that runs a command
+// commandCfg is the cmdline configuration object for a worker that runs a command.
 type commandCfg struct {
 	WorkType           string `required:"true" description:"Name for this worker type"`
 	Command            string `required:"true" description:"Command to run to process units of work"`
@@ -296,20 +296,20 @@ func (cfg commandCfg) newWorker(w *Workceptor, unitID string, workType string) W
 	return cw
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg commandCfg) Run() error {
 	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker)
 	return err
 }
 
-// commandRunnerCfg is a hidden command line option for a command runner process
+// commandRunnerCfg is a hidden command line option for a command runner process.
 type commandRunnerCfg struct {
 	Command string `required:"true"`
 	Params  string `required:"true"`
 	UnitDir string `required:"true"`
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg commandRunnerCfg) Run() error {
 	err := commandRunner(cfg.Command, cfg.Params, cfg.UnitDir)
 	if err != nil {

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -252,7 +252,7 @@ func (cw *commandUnit) Cancel() error {
 	}
 	proc, err := os.FindProcess(ced.Pid)
 	if err != nil {
-		return nil
+		return err
 	}
 	defer proc.Release()
 	err = proc.Signal(os.Interrupt)

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -4,12 +4,13 @@ package workceptor
 
 import (
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"os"
 	"path"
 	"strconv"
 	"strings"
+
+	"github.com/project-receptor/receptor/pkg/controlsvc"
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 type workceptorCommandType struct {
@@ -205,7 +206,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if err != nil {
 			return nil, err
 		}
-		stdin, err := os.OpenFile(path.Join(worker.UnitDir(), "stdin"), os.O_CREATE+os.O_WRONLY, 0600)
+		stdin, err := os.OpenFile(path.Join(worker.UnitDir(), "stdin"), os.O_CREATE+os.O_WRONLY, 0o600)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -76,7 +76,7 @@ func (t *workceptorCommandType) InitFromString(params string) (controlsvc.Contro
 	return c, nil
 }
 
-// strFromMap extracts a string from a map[string]interface{}, handling errors
+// strFromMap extracts a string from a map[string]interface{}, handling errors.
 func strFromMap(config map[string]interface{}, name string) (string, error) {
 	value, ok := config[name]
 	if !ok {
@@ -89,7 +89,7 @@ func strFromMap(config map[string]interface{}, name string) (string, error) {
 	return valueStr, nil
 }
 
-// intFromMap extracts an int64 from a map[string]interface{}, handling errors
+// intFromMap extracts an int64 from a map[string]interface{}, handling errors.
 func intFromMap(config map[string]interface{}, name string) (int64, error) {
 	value, ok := config[name]
 	if !ok {
@@ -163,7 +163,7 @@ func (t *workceptorCommandType) InitFromJSON(config map[string]interface{}) (con
 	return c, nil
 }
 
-// Worker function called by the control service to process a "work" command
+// Worker function called by the control service to process a "work" command.
 func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.ControlFuncOperations) (map[string]interface{}, error) {
 	switch c.subcommand {
 	case "submit":

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -109,7 +109,7 @@ func intFromMap(config map[string]interface{}, name string) (int64, error) {
 	if ok {
 		valueInt, err := strconv.ParseInt(valueStr, 10, 64)
 		if err != nil {
-			return valueInt, nil
+			return valueInt, err
 		}
 	}
 

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -73,6 +73,7 @@ func (t *workceptorCommandType) InitFromString(params string) (controlsvc.Contro
 			c.params["startpos"] = int64(0)
 		}
 	}
+
 	return c, nil
 }
 
@@ -86,6 +87,7 @@ func strFromMap(config map[string]interface{}, name string) (string, error) {
 	if !ok {
 		return "", fmt.Errorf("field %s must be a string", name)
 	}
+
 	return valueStr, nil
 }
 
@@ -110,6 +112,7 @@ func intFromMap(config map[string]interface{}, name string) (int64, error) {
 			return valueInt, nil
 		}
 	}
+
 	return 0, fmt.Errorf("field %s value %s is not convertible to an int", name, value)
 }
 
@@ -160,6 +163,7 @@ func (t *workceptorCommandType) InitFromJSON(config map[string]interface{}) (con
 			return nil, err
 		}
 	}
+
 	return c, nil
 }
 
@@ -214,17 +218,20 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		err = cfo.ReadFromConn(fmt.Sprintf("Work unit created with ID %s. Send stdin data and EOF.\n", worker.ID()), stdin)
 		if err != nil {
 			worker.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Error reading input data: %s", err), 0)
+
 			return nil, err
 		}
 		err = stdin.Close()
 		if err != nil {
 			worker.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Error reading input data: %s", err), 0)
+
 			return nil, err
 		}
 		worker.UpdateBasicStatus(WorkStatePending, "Starting Worker", 0)
 		err = worker.Start()
 		if err != nil && !IsPending(err) {
 			worker.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Error starting worker: %s", err), 0)
+
 			return nil, err
 		}
 		cfr := make(map[string]interface{})
@@ -234,6 +241,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		} else {
 			cfr["result"] = "Job Started"
 		}
+
 		return cfr, nil
 	case "list":
 		var unitList []string
@@ -252,6 +260,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 			}
 			cfr[unitID] = status
 		}
+
 		return cfr, nil
 	case "status":
 		unitid, err := strFromMap(c.params, "unitid")
@@ -262,6 +271,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if err != nil {
 			return nil, err
 		}
+
 		return cfr, nil
 	case "cancel", "release", "force-release":
 		unitid, err := strFromMap(c.params, "unitid")
@@ -296,6 +306,7 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 				cfr[completeMsg] = unitid
 			}
 		}
+
 		return cfr, nil
 	case "results":
 		unitid, err := strFromMap(c.params, "unitid")
@@ -322,7 +333,9 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if err != nil {
 			return nil, err
 		}
+
 		return nil, nil
 	}
+
 	return nil, fmt.Errorf("bad command")
 }

--- a/pkg/workceptor/interfaces.go
+++ b/pkg/workceptor/interfaces.go
@@ -1,6 +1,6 @@
 package workceptor
 
-// WorkUnit represents a local unit of work
+// WorkUnit represents a local unit of work.
 type WorkUnit interface {
 	ID() string
 	UnitDir() string
@@ -20,7 +20,7 @@ type WorkUnit interface {
 	Release(force bool) error
 }
 
-// NewWorkerFunc represents a factory of WorkUnit instances
+// NewWorkerFunc represents a factory of WorkUnit instances.
 type NewWorkerFunc func(w *Workceptor, unitID string, workType string) WorkUnit
 
 // StatusFileData is the structure of the JSON data saved to a status file.

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -33,7 +33,7 @@ func TestWorkceptorJson(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpdir)
-	nc := netceptor.New(nil, "test", nil)
+	nc := netceptor.New(context.Background(), "test", nil)
 	w, err := New(context.Background(), nc, tmpdir)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -4,10 +4,11 @@ package workceptor
 
 import (
 	"context"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 func newCommandWorker(w *Workceptor, unitID string, workType string) WorkUnit {

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -23,6 +23,7 @@ func newCommandWorker(w *Workceptor, unitID string, workType string) WorkUnit {
 		allowRuntimeParams: true,
 	}
 	cw.BaseWorkUnit.Init(w, unitID, workType)
+
 	return cw
 }
 

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -128,7 +128,7 @@ func (kw *kubeUnit) createPod(env map[string]string) error {
 			}
 		}
 		if !foundWorker {
-			return fmt.Errorf("At least one container must be named worker")
+			return fmt.Errorf("at least one container must be named worker")
 		}
 		spec.RestartPolicy = corev1.RestartPolicyNever
 		userNamespace := pod.ObjectMeta.Namespace

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -34,7 +34,7 @@ import (
 	watch2 "k8s.io/client-go/tools/watch"
 )
 
-// kubeUnit implements the WorkUnit interface
+// kubeUnit implements the WorkUnit interface.
 type kubeUnit struct {
 	BaseWorkUnit
 	authMethod          string
@@ -53,7 +53,7 @@ type kubeUnit struct {
 	podPendingTimeout   time.Duration
 }
 
-// kubeExtraData is the content of the ExtraData JSON field for a Kubernetes worker
+// kubeExtraData is the content of the ExtraData JSON field for a Kubernetes worker.
 type kubeExtraData struct {
 	Image         string
 	Command       string
@@ -66,10 +66,10 @@ type kubeExtraData struct {
 	PodName       string
 }
 
-// ErrPodCompleted is returned when pod has already completed before we could attach
+// ErrPodCompleted is returned when pod has already completed before we could attach.
 var ErrPodCompleted = fmt.Errorf("pod ran to completion")
 
-// podRunningAndReady is a completion criterion for pod ready to be attached to
+// podRunningAndReady is a completion criterion for pod ready to be attached to.
 func podRunningAndReady(event watch.Event) (bool, error) {
 	switch event.Type {
 	case watch.Deleted:
@@ -649,7 +649,7 @@ func readFileToString(filename string) (string, error) {
 	return string(content), nil
 }
 
-// SetFromParams sets the in-memory state from parameters
+// SetFromParams sets the in-memory state from parameters.
 func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	ked := kw.status.ExtraData.(*kubeExtraData)
 	type value struct {
@@ -747,7 +747,7 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	return nil
 }
 
-// Status returns a copy of the status currently loaded in memory
+// Status returns a copy of the status currently loaded in memory.
 func (kw *kubeUnit) Status() *StatusFileData {
 	status := kw.UnredactedStatus()
 	ed, ok := status.ExtraData.(*kubeExtraData)
@@ -758,7 +758,7 @@ func (kw *kubeUnit) Status() *StatusFileData {
 	return status
 }
 
-// Status returns a copy of the status currently loaded in memory
+// Status returns a copy of the status currently loaded in memory.
 func (kw *kubeUnit) UnredactedStatus() *StatusFileData {
 	kw.statusLock.RLock()
 	defer kw.statusLock.RUnlock()
@@ -771,7 +771,7 @@ func (kw *kubeUnit) UnredactedStatus() *StatusFileData {
 	return status
 }
 
-// startOrRestart is a shared implementation of Start() and Restart()
+// startOrRestart is a shared implementation of Start() and Restart().
 func (kw *kubeUnit) startOrRestart() error {
 	// Connect to the Kubernetes API
 	err := kw.connectToKube()
@@ -789,7 +789,7 @@ func (kw *kubeUnit) startOrRestart() error {
 	return nil
 }
 
-// Restart resumes monitoring a job after a Receptor restart
+// Restart resumes monitoring a job after a Receptor restart.
 func (kw *kubeUnit) Restart() error {
 	status := kw.Status()
 	ked := status.ExtraData.(*kubeExtraData)
@@ -852,7 +852,7 @@ func (kw *kubeUnit) Release(force bool) error {
 // Command line
 // **************************************************************************
 
-// workKubeCfg is the cmdline configuration object for a Kubernetes worker plugin
+// workKubeCfg is the cmdline configuration object for a Kubernetes worker plugin.
 type workKubeCfg struct {
 	WorkType            string `required:"true" description:"Name for this worker type"`
 	Namespace           string `description:"Kubernetes namespace to create pods in"`
@@ -873,7 +873,7 @@ type workKubeCfg struct {
 	StreamMethod        string `description:"Method for connecting to worker pods: logger or tcp" default:"logger"`
 }
 
-// newWorker is a factory to produce worker instances
+// newWorker is a factory to produce worker instances.
 func (cfg workKubeCfg) newWorker(w *Workceptor, unitID string, workType string) WorkUnit {
 	ku := &kubeUnit{
 		BaseWorkUnit: BaseWorkUnit{
@@ -904,7 +904,7 @@ func (cfg workKubeCfg) newWorker(w *Workceptor, unitID string, workType string) 
 	return ku
 }
 
-// Prepare inspects the configuration for validity
+// Prepare inspects the configuration for validity.
 func (cfg workKubeCfg) Prepare() error {
 	lcAuth := strings.ToLower(cfg.AuthMethod)
 	if lcAuth != "kubeconfig" && lcAuth != "incluster" && lcAuth != "runtime" {
@@ -941,7 +941,7 @@ func (cfg workKubeCfg) Prepare() error {
 	return nil
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg workKubeCfg) Run() error {
 	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker)
 	return err

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -93,6 +93,7 @@ func podRunningAndReady(event watch.Event) (bool, error) {
 			}
 		}
 	}
+
 	return false, nil
 }
 
@@ -123,6 +124,7 @@ func (kw *kubeUnit) createPod(env map[string]string) error {
 				spec.Containers[i].Stdin = true
 				spec.Containers[i].StdinOnce = true
 				foundWorker = true
+
 				break
 			}
 		}
@@ -197,10 +199,12 @@ func (kw *kubeUnit) createPod(env map[string]string) error {
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
+
 			return kw.clientset.CoreV1().Pods(ked.KubeNamespace).List(kw.ctx, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
+
 			return kw.clientset.CoreV1().Pods(ked.KubeNamespace).Watch(kw.ctx, options)
 		},
 	}
@@ -223,6 +227,7 @@ func (kw *kubeUnit) createPod(env map[string]string) error {
 		if cstat.State.Terminated != nil && cstat.State.Terminated.ExitCode != 0 {
 			return fmt.Errorf("container failed with exit code %d: %s", cstat.State.Terminated.ExitCode, cstat.State.Terminated.Message)
 		}
+
 		return err
 	} else if err != nil {
 		kw.Cancel()
@@ -231,11 +236,13 @@ func (kw *kubeUnit) createPod(env map[string]string) error {
 				return fmt.Errorf("%s, %s", err.Error(), kw.pod.Status.ContainerStatuses[0].State.Waiting.Reason)
 			}
 		}
+
 		return err
 	}
 	if ev == nil {
 		return fmt.Errorf("pod disappeared during watch")
 	}
+
 	return nil
 }
 
@@ -263,6 +270,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 	if errMsg != "" {
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 		logger.Error(errMsg)
+
 		return
 	}
 
@@ -276,6 +284,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 		errMsg := fmt.Sprintf("Error opening pod stream: %s", err)
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 		logger.Error(errMsg)
+
 		return
 	}
 	defer logStream.Close()
@@ -298,6 +307,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 		exec, err = remotecommand.NewSPDYExecutor(kw.config, "POST", req.URL())
 		if err != nil {
 			kw.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Error attaching to pod: %s", err), 0)
+
 			return
 		}
 	}
@@ -306,6 +316,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 	select {
 	case <-kw.ctx.Done():
 		kw.UpdateBasicStatus(WorkStateFailed, "Cancelled", 0)
+
 		return
 	default:
 	}
@@ -317,6 +328,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 			errMsg := fmt.Sprintf("Error opening stdin file: %s", err)
 			logger.Error(errMsg)
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
+
 			return
 		}
 	}
@@ -327,6 +339,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 		errMsg := fmt.Sprintf("Error opening stdout file: %s", err)
 		logger.Error(errMsg)
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
+
 		return
 	}
 
@@ -390,6 +403,7 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 			errDetail = fmt.Sprintf("stdin: %s, stdout: %s", errStdin, errStdout)
 		}
 		kw.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Stream error running pod: %s", errDetail), stdout.Size())
+
 		return
 	}
 	kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", stdout.Size())
@@ -417,6 +431,7 @@ func getDefaultInterface() (string, error) {
 			}
 		}
 	}
+
 	return "", fmt.Errorf("could not determine local address")
 }
 
@@ -443,6 +458,7 @@ func (kw *kubeUnit) runWorkUsingTCP() {
 		errMsg := fmt.Sprintf("Error listening: %s", err)
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 		logger.Error(errMsg)
+
 		return
 	}
 
@@ -467,6 +483,7 @@ func (kw *kubeUnit) runWorkUsingTCP() {
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 			logger.Error(errMsg)
 			cancel()
+
 			return
 		}
 		connChan <- tcpConn
@@ -479,6 +496,7 @@ func (kw *kubeUnit) runWorkUsingTCP() {
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 		logger.Error(errMsg)
 		cancel()
+
 		return
 	}
 
@@ -498,6 +516,7 @@ func (kw *kubeUnit) runWorkUsingTCP() {
 		logger.Error(errMsg)
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 		cancel()
+
 		return
 	}
 
@@ -508,6 +527,7 @@ func (kw *kubeUnit) runWorkUsingTCP() {
 		logger.Error(errMsg)
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 		cancel()
+
 		return
 	}
 
@@ -525,6 +545,7 @@ func (kw *kubeUnit) runWorkUsingTCP() {
 			logger.Error(errMsg)
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 			cancel()
+
 			return
 		}
 	}()
@@ -556,6 +577,7 @@ func (kw *kubeUnit) runWorkUsingTCP() {
 		logger.Error(errMsg)
 		kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
 		cancel()
+
 		return
 	}
 
@@ -606,6 +628,7 @@ func (kw *kubeUnit) connectUsingKubeconfig() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -615,6 +638,7 @@ func (kw *kubeUnit) connectUsingIncluster() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -634,6 +658,7 @@ func (kw *kubeUnit) connectToKube() error {
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -646,6 +671,7 @@ func readFileToString(filename string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(content), nil
 }
 
@@ -660,8 +686,10 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	setString := func(target *string) func(string) error {
 		ssf := func(value string) error {
 			*target = value
+
 			return nil
 		}
+
 		return ssf
 	}
 	setBool := func(target *bool) func(string) error {
@@ -671,8 +699,10 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 				return err
 			}
 			*target = bv
+
 			return nil
 		}
+
 		return ssf
 	}
 
@@ -725,6 +755,7 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 		podPendingTimeout, err := time.ParseDuration(podPendingTimeoutString)
 		if err != nil {
 			logger.Error("Failed to parse pod_pending_timeout -- valid examples include '1.5h', '30m', '30m10s'")
+
 			return err
 		}
 		kw.podPendingTimeout = podPendingTimeout
@@ -744,6 +775,7 @@ func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	} else {
 		ked.Params = combineParams(kw.baseParams, userParams)
 	}
+
 	return nil
 }
 
@@ -755,6 +787,7 @@ func (kw *kubeUnit) Status() *StatusFileData {
 		ed.KubeConfig = ""
 		ed.KubePod = ""
 	}
+
 	return status
 }
 
@@ -768,6 +801,7 @@ func (kw *kubeUnit) UnredactedStatus() *StatusFileData {
 		kedCopy := *ked
 		status.ExtraData = &kedCopy
 	}
+
 	return status
 }
 
@@ -815,12 +849,14 @@ func (kw *kubeUnit) Restart() error {
 	if isTCP {
 		return fmt.Errorf("restart not implemented for streammethod tcp")
 	}
+
 	return fmt.Errorf("work unit is not in running state, cannot be restarted")
 }
 
 // Start launches a job with given parameters.
 func (kw *kubeUnit) Start() error {
 	kw.UpdateBasicStatus(WorkStatePending, "Connecting to Kubernetes", 0)
+
 	return kw.startOrRestart()
 }
 
@@ -836,6 +872,7 @@ func (kw *kubeUnit) Cancel() error {
 	if kw.cancel != nil {
 		kw.cancel()
 	}
+
 	return nil
 }
 
@@ -845,6 +882,7 @@ func (kw *kubeUnit) Release(force bool) error {
 	if err != nil && !force {
 		return err
 	}
+
 	return kw.BaseWorkUnit.Release(force)
 }
 
@@ -901,6 +939,7 @@ func (cfg workKubeCfg) newWorker(w *Workceptor, unitID string, workType string) 
 		namePrefix:          fmt.Sprintf("%s-", strings.ToLower(cfg.WorkType)),
 	}
 	ku.BaseWorkUnit.Init(w, unitID, workType)
+
 	return ku
 }
 
@@ -938,12 +977,14 @@ func (cfg workKubeCfg) Prepare() error {
 	if method != "logger" && method != "tcp" {
 		return fmt.Errorf("stream mode must be logger or tcp")
 	}
+
 	return nil
 }
 
 // Run runs the action.
 func (cfg workKubeCfg) Run() error {
 	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker)
+
 	return err
 }
 

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -109,8 +109,8 @@ func (kw *kubeUnit) createPod(env map[string]string) error {
 	}
 
 	pod := &corev1.Pod{}
-	spec := &corev1.PodSpec{}
-	objectMeta := &metav1.ObjectMeta{}
+	var spec *corev1.PodSpec
+	var objectMeta *metav1.ObjectMeta
 	if ked.KubePod != "" {
 		decode := scheme.Codecs.UniversalDeserializer().Decode
 		_, _, err := decode([]byte(ked.KubePod), nil, pod)

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -677,6 +677,7 @@ func readFileToString(filename string) (string, error) {
 }
 
 // SetFromParams sets the in-memory state from parameters.
+//nolint:ifshort // Method to magical for linter
 func (kw *kubeUnit) SetFromParams(params map[string]string) error {
 	ked := kw.status.ExtraData.(*kubeExtraData)
 	type value struct {
@@ -809,8 +810,7 @@ func (kw *kubeUnit) UnredactedStatus() *StatusFileData {
 // startOrRestart is a shared implementation of Start() and Restart().
 func (kw *kubeUnit) startOrRestart() error {
 	// Connect to the Kubernetes API
-	err := kw.connectToKube()
-	if err != nil {
+	if err := kw.connectToKube(); err != nil {
 		return err
 	}
 	// Launch runner process

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -907,7 +907,7 @@ type workKubeCfg struct {
 	AllowRuntimeTLS     bool   `description:"Allow passing TLS parameters at runtime" default:"false"`
 	AllowRuntimeCommand bool   `description:"Allow specifying image & command at runtime" default:"false"`
 	AllowRuntimeParams  bool   `description:"Allow adding command parameters at runtime" default:"false"`
-	AllowRuntimePod     bool   `description:"Allow passing Pod at runtime" default: "false"`
+	AllowRuntimePod     bool   `description:"Allow passing Pod at runtime" default:"false"`
 	DeletePodOnRestart  bool   `description:"On restart, delete the pod if in pending state" default:"true"`
 	StreamMethod        string `description:"Method for connecting to worker pods: logger or tcp" default:"logger"`
 }

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -71,12 +71,11 @@ var ErrPodCompleted = fmt.Errorf("pod ran to completion")
 
 // podRunningAndReady is a completion criterion for pod ready to be attached to.
 func podRunningAndReady(event watch.Event) (bool, error) {
-	switch event.Type {
-	case watch.Deleted:
+	if event.Type == watch.Deleted {
 		return false, errors.NewNotFound(schema.GroupResource{Resource: "pods"}, "")
 	}
-	switch t := event.Object.(type) {
-	case *corev1.Pod:
+
+	if t, ok := event.Object.(*corev1.Pod); ok {
 		switch t.Status.Phase {
 		case corev1.PodFailed, corev1.PodSucceeded:
 			return false, ErrPodCompleted
@@ -395,11 +394,12 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 	close(finishedChan)
 	if errStdin != nil || errStdout != nil {
 		var errDetail string
-		if errStdin == nil {
+		switch {
+		case errStdin == nil:
 			errDetail = fmt.Sprintf("%s", errStdout)
-		} else if errStdout == nil {
+		case errStdout == nil:
 			errDetail = fmt.Sprintf("%s", errStdin)
-		} else {
+		default:
 			errDetail = fmt.Sprintf("stdin: %s, stdout: %s", errStdin, errStdout)
 		}
 		kw.UpdateBasicStatus(WorkStateFailed, fmt.Sprintf("Stream error running pod: %s", errDetail), stdout.Size())
@@ -644,11 +644,12 @@ func (kw *kubeUnit) connectUsingIncluster() error {
 
 func (kw *kubeUnit) connectToKube() error {
 	var err error
-	if kw.authMethod == "kubeconfig" || kw.authMethod == "runtime" {
+	switch {
+	case kw.authMethod == "kubeconfig" || kw.authMethod == "runtime":
 		err = kw.connectUsingKubeconfig()
-	} else if kw.authMethod == "incluster" {
+	case kw.authMethod == "incluster":
 		err = kw.connectUsingIncluster()
-	} else {
+	default:
 		return fmt.Errorf("unknown auth method %s", kw.authMethod)
 	}
 	if err != nil {

--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -53,6 +53,7 @@ func TestStatusFileLock(t *testing.T) {
 			for {
 				if ctx.Err() != nil {
 					wg2.Done()
+
 					return
 				}
 				err := sfd.Load(statusFilename)

--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -70,7 +70,7 @@ func TestStatusFileLock(t *testing.T) {
 				}
 				if detailIter >= 0 {
 					if int64(sfd.State) != sfd.StdoutSize || sfd.State != detailIter {
-						t.Fatal(fmt.Sprintf("Mismatched data in struct"))
+						t.Fatal("Mismatched data in struct")
 					}
 				}
 			}
@@ -78,7 +78,7 @@ func TestStatusFileLock(t *testing.T) {
 	}
 	wg.Wait()
 	cancel()
-	totalTime := time.Now().Sub(startTime)
+	totalTime := time.Since(startTime)
 	if totalTime < totalWaitTime {
 		t.Fatal("File locks apparently not locking")
 	}

--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestStatusFileLock(t *testing.T) {
-
 	numWriterThreads := 8
 	numReaderThreads := 8
 	baseWaitTime := 200 * time.Millisecond

--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -31,7 +31,7 @@ func TestStatusFileLock(t *testing.T) {
 	wg.Add(numWriterThreads)
 	for i := 0; i < numWriterThreads; i++ {
 		waitTime := time.Duration(i) * baseWaitTime
-		totalWaitTime = totalWaitTime + waitTime
+		totalWaitTime += waitTime
 		go func(iter int, waitTime time.Duration) {
 			sfd := StatusFileData{}
 			err = sfd.UpdateFullStatus(statusFilename, func(status *StatusFileData) {

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -32,6 +32,7 @@ func (pw *pythonUnit) Start() error {
 	}
 	cmd := exec.Command("receptor-python-worker",
 		fmt.Sprintf("%s:%s", pw.plugin, pw.function), pw.UnitDir(), string(configJSON))
+
 	return pw.runCommand(cmd)
 }
 
@@ -62,12 +63,14 @@ func (cfg workPythonCfg) newWorker(w *Workceptor, unitID string, workType string
 		config:   cfg.Config,
 	}
 	cw.BaseWorkUnit.Init(w, unitID, workType)
+
 	return cw
 }
 
 // Run runs the action.
 func (cfg workPythonCfg) Run() error {
 	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker)
+
 	return err
 }
 

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -5,8 +5,9 @@ package workceptor
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/ghjm/cmdline"
 	"os/exec"
+
+	"github.com/ghjm/cmdline"
 )
 
 // pythonUnit implements the WorkUnit interface

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ghjm/cmdline"
 )
 
-// pythonUnit implements the WorkUnit interface
+// pythonUnit implements the WorkUnit interface.
 type pythonUnit struct {
 	commandUnit
 	plugin   string
@@ -39,7 +39,7 @@ func (pw *pythonUnit) Start() error {
 // Command line
 // **************************************************************************
 
-// workPythonCfg is the cmdline configuration object for a Python worker plugin
+// workPythonCfg is the cmdline configuration object for a Python worker plugin.
 type workPythonCfg struct {
 	WorkType string                 `required:"true" description:"Name for this worker type"`
 	Plugin   string                 `required:"true" description:"Python module name of the worker plugin"`
@@ -47,7 +47,7 @@ type workPythonCfg struct {
 	Config   map[string]interface{} `description:"Plugin-specific configuration"`
 }
 
-// newWorker is a factory to produce worker instances
+// newWorker is a factory to produce worker instances.
 func (cfg workPythonCfg) newWorker(w *Workceptor, unitID string, workType string) WorkUnit {
 	cw := &pythonUnit{
 		commandUnit: commandUnit{
@@ -65,7 +65,7 @@ func (cfg workPythonCfg) newWorker(w *Workceptor, unitID string, workType string
 	return cw
 }
 
-// Run runs the action
+// Run runs the action.
 func (cfg workPythonCfg) Run() error {
 	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker)
 	return err

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -356,10 +356,8 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 			if mw.Err() != nil {
 				return
 			}
-		} else {
-			if sleepOrDone(mw.Done(), 1*time.Second) {
-				return
-			}
+		} else if sleepOrDone(mw.Done(), 1*time.Second) {
+			return
 		}
 		err := rw.Load()
 		if err != nil {

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -179,7 +179,7 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
 	}
-	submitIDRegex := regexp.MustCompile("with ID ([a-zA-Z0-9]+)\\.")
+	submitIDRegex := regexp.MustCompile(`with ID ([a-zA-Z0-9]+)\.`)
 	match := submitIDRegex.FindSubmatch([]byte(response))
 	if match == nil || len(match) != 2 {
 		return fmt.Errorf("could not parse response: %s", strings.TrimRight(response, "\n"))
@@ -514,7 +514,7 @@ func (rw *remoteUnit) runAndMonitor(mw *utils.JobContext, forRelease bool, actio
 
 func (rw *remoteUnit) setExpiration(mw *utils.JobContext) {
 	red := rw.Status().ExtraData.(*remoteExtraData)
-	dur := red.Expiration.Sub(time.Now())
+	dur := time.Until(red.Expiration)
 	select {
 	case <-mw.Done():
 	case <-time.After(dur):

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -20,13 +20,13 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// remoteUnit implements the WorkUnit interface for the Receptor remote worker plugin
+// remoteUnit implements the WorkUnit interface for the Receptor remote worker plugin.
 type remoteUnit struct {
 	BaseWorkUnit
 	topJC *utils.JobContext
 }
 
-// remoteExtraData is the content of the ExtraData JSON field for a remote work unit
+// remoteExtraData is the content of the ExtraData JSON field for a remote work unit.
 type remoteExtraData struct {
 	RemoteNode     string
 	RemoteWorkType string
@@ -41,7 +41,7 @@ type remoteExtraData struct {
 
 type actionFunc func(context.Context, net.Conn, *bufio.Reader) error
 
-// connectToRemote establishes a control socket connection to a remote node
+// connectToRemote establishes a control socket connection to a remote node.
 func (rw *remoteUnit) connectToRemote(ctx context.Context) (net.Conn, *bufio.Reader, error) {
 	status := rw.Status()
 	red, ok := status.ExtraData.(*remoteExtraData)
@@ -71,7 +71,7 @@ func (rw *remoteUnit) connectToRemote(ctx context.Context) (net.Conn, *bufio.Rea
 	return conn, reader, nil
 }
 
-// getConnection retries connectToRemote until connected or the context expires
+// getConnection retries connectToRemote until connected or the context expires.
 func (rw *remoteUnit) getConnection(ctx context.Context) (net.Conn, *bufio.Reader) {
 	connectDelay := utils.NewIncrementalDuration(SuccessWorkSleep, MaxWorkSleep, 1.5)
 	for {
@@ -103,7 +103,7 @@ func (rw *remoteUnit) getConnection(ctx context.Context) (net.Conn, *bufio.Reade
 	}
 }
 
-// connectAndRun makes a single attempt to connect to a remote node and runs an action function
+// connectAndRun makes a single attempt to connect to a remote node and runs an action function.
 func (rw *remoteUnit) connectAndRun(ctx context.Context, action actionFunc) error {
 	conn, reader, err := rw.connectToRemote(ctx)
 	if err != nil {
@@ -237,7 +237,7 @@ func (rw *remoteUnit) cancelOrReleaseRemoteUnit(ctx context.Context, conn net.Co
 	return nil
 }
 
-// monitorRemoteStatus monitors the remote status file and copies results to the local one
+// monitorRemoteStatus monitors the remote status file and copies results to the local one.
 func (rw *remoteUnit) monitorRemoteStatus(mw *utils.JobContext, forRelease bool) {
 	defer func() {
 		mw.Cancel()
@@ -307,7 +307,7 @@ func (rw *remoteUnit) monitorRemoteStatus(mw *utils.JobContext, forRelease bool)
 	}
 }
 
-// monitorRemoteStdout copies the remote stdout stream to the local buffer
+// monitorRemoteStdout copies the remote stdout stream to the local buffer.
 func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 	defer func() {
 		mw.Cancel()
@@ -399,7 +399,7 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 	}
 }
 
-// monitorRemoteUnit watches a remote unit on another node and maintains local status
+// monitorRemoteUnit watches a remote unit on another node and maintains local status.
 func (rw *remoteUnit) monitorRemoteUnit(ctx context.Context, forRelease bool) {
 	subJC := &utils.JobContext{}
 	if forRelease {
@@ -413,7 +413,7 @@ func (rw *remoteUnit) monitorRemoteUnit(ctx context.Context, forRelease bool) {
 	subJC.Wait()
 }
 
-// SetFromParams sets the in-memory state from parameters
+// SetFromParams sets the in-memory state from parameters.
 func (rw *remoteUnit) SetFromParams(params map[string]string) error {
 	for k, v := range params {
 		rw.status.ExtraData.(*remoteExtraData).RemoteParams[k] = v
@@ -421,7 +421,7 @@ func (rw *remoteUnit) SetFromParams(params map[string]string) error {
 	return nil
 }
 
-// Status returns a copy of the status currently loaded in memory
+// Status returns a copy of the status currently loaded in memory.
 func (rw *remoteUnit) Status() *StatusFileData {
 	status := rw.UnredactedStatus()
 	ed, ok := status.ExtraData.(*remoteExtraData)
@@ -439,7 +439,7 @@ func (rw *remoteUnit) Status() *StatusFileData {
 	return status
 }
 
-// UnredactedStatus returns a copy of the status currently loaded in memory, including secrets
+// UnredactedStatus returns a copy of the status currently loaded in memory, including secrets.
 func (rw *remoteUnit) UnredactedStatus() *StatusFileData {
 	rw.statusLock.RLock()
 	defer rw.statusLock.RUnlock()
@@ -456,7 +456,7 @@ func (rw *remoteUnit) UnredactedStatus() *StatusFileData {
 	return status
 }
 
-// runAndMonitor waits for a connection to be available, then starts the remote unit and monitors it
+// runAndMonitor waits for a connection to be available, then starts the remote unit and monitors it.
 func (rw *remoteUnit) runAndMonitor(mw *utils.JobContext, forRelease bool, action actionFunc) error {
 	return rw.getConnectionAndRun(mw, true, func(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {
 		err := action(ctx, conn, reader)
@@ -497,7 +497,7 @@ func (rw *remoteUnit) setExpiration(mw *utils.JobContext) {
 	}
 }
 
-// startOrRestart is a shared implementation of Start() and Restart()
+// startOrRestart is a shared implementation of Start() and Restart().
 func (rw *remoteUnit) startOrRestart(start bool) error {
 	red := rw.Status().ExtraData.(*remoteExtraData)
 	if start && red.RemoteStarted {
@@ -530,7 +530,7 @@ func (rw *remoteUnit) Start() error {
 	return rw.startOrRestart(true)
 }
 
-// Restart resumes monitoring a job after a Receptor restart
+// Restart resumes monitoring a job after a Receptor restart.
 func (rw *remoteUnit) Restart() error {
 	red := rw.Status().ExtraData.(*remoteExtraData)
 	if red.RemoteStarted {
@@ -539,7 +539,7 @@ func (rw *remoteUnit) Restart() error {
 	return fmt.Errorf("remote work had not previously started")
 }
 
-// cancelOrRelease is a shared implementation of Cancel() and Release()
+// cancelOrRelease is a shared implementation of Cancel() and Release().
 func (rw *remoteUnit) cancelOrRelease(release bool, force bool) error {
 	// Update the status file that the unit is locally cancelled/released
 	var remoteStarted bool

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"io"
 	"net"
 	"os"
@@ -17,6 +15,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // remoteUnit implements the WorkUnit interface for the Receptor remote worker plugin
@@ -82,7 +83,7 @@ func (rw *remoteUnit) getConnection(ctx context.Context) (net.Conn, *bufio.Reade
 			rw.Status().ExtraData.(*remoteExtraData).RemoteNode, err)
 		errStr := err.Error()
 		if strings.Contains(errStr, "CRYPTO_ERROR") {
-			var shouldExit = false
+			shouldExit := false
 			rw.UpdateFullStatus(func(status *StatusFileData) {
 				status.Detail = fmt.Sprintf("TLS error connecting to remote service: %s", errStr)
 				if !status.ExtraData.(*remoteExtraData).RemoteStarted {
@@ -321,7 +322,7 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 	}
 	remoteNode := red.RemoteNode
 	remoteUnitID := red.RemoteUnitID
-	stdout, err := os.OpenFile(rw.stdoutFileName, os.O_CREATE+os.O_APPEND+os.O_WRONLY, 0600)
+	stdout, err := os.OpenFile(rw.stdoutFileName, os.O_CREATE+os.O_APPEND+os.O_WRONLY, 0o600)
 	if err == nil {
 		err = stdout.Close()
 	}
@@ -369,7 +370,7 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 				logger.Warning("Remote node %s did not stream results\n", remoteNode)
 				continue
 			}
-			stdout, err := os.OpenFile(rw.stdoutFileName, os.O_CREATE+os.O_APPEND+os.O_WRONLY, 0600)
+			stdout, err := os.OpenFile(rw.stdoutFileName, os.O_CREATE+os.O_APPEND+os.O_WRONLY, 0o600)
 			if err != nil {
 				logger.Error("Could not open stdout file %s: %s\n", rw.stdoutFileName, err)
 				return

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -13,6 +13,7 @@ import (
 func saveStdoutSize(unitdir string, stdoutSize int64) error {
 	statusFilename := path.Join(unitdir, "status")
 	si := &StatusFileData{}
+
 	return si.UpdateFullStatus(statusFilename, func(status *StatusFileData) {
 		status.StdoutSize = stdoutSize
 	})
@@ -31,6 +32,7 @@ func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &stdoutWriter{
 		unitdir:      unitdir,
 		writer:       writer,
@@ -49,6 +51,7 @@ func (sw *stdoutWriter) Write(p []byte) (n int, err error) {
 	if werr != nil {
 		return wn, werr
 	}
+
 	return wn, serr
 }
 
@@ -71,6 +74,7 @@ func newStdinReader(unitdir string) (*stdinReader, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &stdinReader{
 		reader:   reader,
 		lasterr:  nil,
@@ -88,6 +92,7 @@ func (sr *stdinReader) Read(p []byte) (n int, err error) {
 			close(sr.doneChan)
 		})
 	}
+
 	return
 }
 

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 )
 
-// saveStdoutSize only the stdout size in the status metadata file in the unitdir
+// saveStdoutSize only the stdout size in the status metadata file in the unitdir.
 func saveStdoutSize(unitdir string, stdoutSize int64) error {
 	statusFilename := path.Join(unitdir, "status")
 	si := &StatusFileData{}
@@ -18,14 +18,14 @@ func saveStdoutSize(unitdir string, stdoutSize int64) error {
 	})
 }
 
-// stdoutWriter writes to a stdout file while also updating the status file
+// stdoutWriter writes to a stdout file while also updating the status file.
 type stdoutWriter struct {
 	unitdir      string
 	writer       io.Writer
 	bytesWritten int64
 }
 
-// newStdoutWriter allocates a new stdoutWriter, which writes to both the stdout and status files
+// newStdoutWriter allocates a new stdoutWriter, which writes to both the stdout and status files.
 func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
 	writer, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0o600)
 	if err != nil {
@@ -38,7 +38,7 @@ func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
 	}, nil
 }
 
-// Write writes data to the stdout file and status file, implementing io.Writer
+// Write writes data to the stdout file and status file, implementing io.Writer.
 func (sw *stdoutWriter) Write(p []byte) (n int, err error) {
 	wn, werr := sw.writer.Write(p)
 	var serr error = nil
@@ -52,12 +52,12 @@ func (sw *stdoutWriter) Write(p []byte) (n int, err error) {
 	return wn, serr
 }
 
-// Size returns the current size of the stdout file
+// Size returns the current size of the stdout file.
 func (sw *stdoutWriter) Size() int64 {
 	return sw.bytesWritten
 }
 
-// stdinReader reads from a stdin file and provides a Done function
+// stdinReader reads from a stdin file and provides a Done function.
 type stdinReader struct {
 	reader   io.Reader
 	lasterr  error
@@ -65,7 +65,7 @@ type stdinReader struct {
 	doneOnce sync.Once
 }
 
-// newStdinReader allocates a new stdinReader, which reads from a stdin file and provides a Done function
+// newStdinReader allocates a new stdinReader, which reads from a stdin file and provides a Done function.
 func newStdinReader(unitdir string) (*stdinReader, error) {
 	reader, err := os.Open(path.Join(unitdir, "stdin"))
 	if err != nil {
@@ -79,7 +79,7 @@ func newStdinReader(unitdir string) (*stdinReader, error) {
 	}, nil
 }
 
-// Read reads data from the stdout file, implementing io.Reader
+// Read reads data from the stdout file, implementing io.Reader.
 func (sr *stdinReader) Read(p []byte) (n int, err error) {
 	n, err = sr.reader.Read(p)
 	if err != nil {
@@ -91,12 +91,12 @@ func (sr *stdinReader) Read(p []byte) (n int, err error) {
 	return
 }
 
-// Done returns a channel that will be closed on error (including EOF) in the reader
+// Done returns a channel that will be closed on error (including EOF) in the reader.
 func (sr *stdinReader) Done() <-chan struct{} {
 	return sr.doneChan
 }
 
-// Error returns the most recent error encountered in the reader
+// Error returns the most recent error encountered in the reader.
 func (sr *stdinReader) Error() error {
 	return sr.lasterr
 }

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -43,7 +43,7 @@ func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
 // Write writes data to the stdout file and status file, implementing io.Writer.
 func (sw *stdoutWriter) Write(p []byte) (n int, err error) {
 	wn, werr := sw.writer.Write(p)
-	var serr error = nil
+	var serr error
 	if wn > 0 {
 		sw.bytesWritten += int64(wn)
 		serr = saveStdoutSize(sw.unitdir, sw.bytesWritten)

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -27,7 +27,7 @@ type stdoutWriter struct {
 
 // newStdoutWriter allocates a new stdoutWriter, which writes to both the stdout and status files
 func newStdoutWriter(unitdir string) (*stdoutWriter, error) {
-	writer, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0600)
+	writer, err := os.OpenFile(path.Join(unitdir, "stdout"), os.O_CREATE+os.O_WRONLY+os.O_SYNC, 0o600)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -377,9 +377,10 @@ func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan str
 		// Wait for stdout file to exist
 		for {
 			_, err := os.Stat(stdoutFilename)
-			if err == nil {
-				break
-			} else if os.IsNotExist(err) {
+
+			switch {
+			case err == nil:
+			case os.IsNotExist(err):
 				if IsComplete(unit.Status().State) {
 					close(resultChan)
 					logger.Warning("Unit completed without producing any stdout\n")
@@ -389,11 +390,15 @@ func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan str
 				if sleepOrDone(doneChan, 250*time.Millisecond) {
 					return
 				}
-			} else {
+
+				continue
+			default:
 				logger.Error("Error accessing stdout file: %s\n", err)
 
 				return
 			}
+
+			break
 		}
 		var stdout *os.File
 		var err error

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -21,7 +21,7 @@ import (
 	"github.com/project-receptor/receptor/pkg/utils"
 )
 
-// Workceptor is the main object that handles unit-of-work management
+// Workceptor is the main object that handles unit-of-work management.
 type Workceptor struct {
 	ctx             context.Context
 	nc              *netceptor.Netceptor
@@ -32,12 +32,12 @@ type Workceptor struct {
 	activeUnits     map[string]WorkUnit
 }
 
-// workType is the record for a registered type of work
+// workType is the record for a registered type of work.
 type workType struct {
 	newWorkerFunc NewWorkerFunc
 }
 
-// New constructs a new Workceptor instance
+// New constructs a new Workceptor instance.
 func New(ctx context.Context, nc *netceptor.Netceptor, dataDir string) (*Workceptor, error) {
 	if dataDir == "" {
 		dataDir = path.Join(os.TempDir(), "receptor")
@@ -59,10 +59,10 @@ func New(ctx context.Context, nc *netceptor.Netceptor, dataDir string) (*Workcep
 	return w, nil
 }
 
-// MainInstance is the global instance of Workceptor instantiated by the command-line main() function
+// MainInstance is the global instance of Workceptor instantiated by the command-line main() function.
 var MainInstance *Workceptor
 
-// stdoutSize returns size of stdout, if it exists, or 0 otherwise
+// stdoutSize returns size of stdout, if it exists, or 0 otherwise.
 func stdoutSize(unitdir string) int64 {
 	stat, err := os.Stat(path.Join(unitdir, "stdout"))
 	if err != nil {
@@ -71,7 +71,7 @@ func stdoutSize(unitdir string) int64 {
 	return stat.Size()
 }
 
-// RegisterWithControlService registers this workceptor instance with a control service instance
+// RegisterWithControlService registers this workceptor instance with a control service instance.
 func (w *Workceptor) RegisterWithControlService(cs *controlsvc.Server) error {
 	err := cs.AddControlFunc("work", &workceptorCommandType{
 		w: w,
@@ -82,7 +82,7 @@ func (w *Workceptor) RegisterWithControlService(cs *controlsvc.Server) error {
 	return nil
 }
 
-// RegisterWorker notifies the Workceptor of a new kind of work that can be done
+// RegisterWorker notifies the Workceptor of a new kind of work that can be done.
 func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc) error {
 	w.workTypesLock.Lock()
 	_, ok := w.workTypes[typeName]
@@ -131,7 +131,7 @@ func (w *Workceptor) generateUnitID(lock bool) (string, error) {
 	}
 }
 
-// AllocateUnit creates a new local work unit and generates an identifier for it
+// AllocateUnit creates a new local work unit and generates an identifier for it.
 func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string) (WorkUnit, error) {
 	w.workTypesLock.RLock()
 	wt, ok := w.workTypes[workTypeName]
@@ -157,7 +157,7 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 	return worker, nil
 }
 
-// AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
+// AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it.
 func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsclient, ttl string, params map[string]string) (WorkUnit, error) {
 	if tlsclient != "" {
 		_, err := w.nc.GetClientTLSConfig(tlsclient, "testhost", "receptor")
@@ -269,7 +269,7 @@ func (w *Workceptor) findUnit(unitID string) (WorkUnit, error) {
 	return unit, nil
 }
 
-// StartUnit starts a unit of work
+// StartUnit starts a unit of work.
 func (w *Workceptor) StartUnit(unitID string) error {
 	unit, err := w.findUnit(unitID)
 	if err != nil {
@@ -278,7 +278,7 @@ func (w *Workceptor) StartUnit(unitID string) error {
 	return unit.Start()
 }
 
-// ListKnownUnitIDs returns a slice containing the known unit IDs
+// ListKnownUnitIDs returns a slice containing the known unit IDs.
 func (w *Workceptor) ListKnownUnitIDs() []string {
 	w.activeUnitsLock.RLock()
 	defer w.activeUnitsLock.RUnlock()
@@ -289,7 +289,7 @@ func (w *Workceptor) ListKnownUnitIDs() []string {
 	return result
 }
 
-// UnitStatus returns the state of a unit
+// UnitStatus returns the state of a unit.
 func (w *Workceptor) UnitStatus(unitID string) (*StatusFileData, error) {
 	unit, err := w.findUnit(unitID)
 	if err != nil {
@@ -298,7 +298,7 @@ func (w *Workceptor) UnitStatus(unitID string) (*StatusFileData, error) {
 	return unit.Status(), nil
 }
 
-// CancelUnit cancels a unit of work, killing any processes
+// CancelUnit cancels a unit of work, killing any processes.
 func (w *Workceptor) CancelUnit(unitID string) error {
 	unit, err := w.findUnit(unitID)
 	if err != nil {
@@ -316,7 +316,7 @@ func (w *Workceptor) ReleaseUnit(unitID string, force bool) error {
 	return unit.Release(force)
 }
 
-// unitStatusForCFR returns status information as a map, suitable for a control function return value
+// unitStatusForCFR returns status information as a map, suitable for a control function return value.
 func (w *Workceptor) unitStatusForCFR(unitID string) (map[string]interface{}, error) {
 	status, err := w.UnitStatus(unitID)
 	if err != nil {
@@ -332,7 +332,7 @@ func (w *Workceptor) unitStatusForCFR(unitID string) (map[string]interface{}, er
 	return retMap, nil
 }
 
-// sleepOrDone sleeps until a timeout or the done channel is signaled
+// sleepOrDone sleeps until a timeout or the done channel is signaled.
 func sleepOrDone(doneChan <-chan struct{}, interval time.Duration) bool {
 	select {
 	case <-doneChan:
@@ -342,7 +342,7 @@ func sleepOrDone(doneChan <-chan struct{}, interval time.Duration) bool {
 	}
 }
 
-// GetResults returns a live stream of the results of a unit
+// GetResults returns a live stream of the results of a unit.
 func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan struct{}) (chan []byte, error) {
 	w.scanForUnit(unitID)
 	w.activeUnitsLock.RLock()

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -5,11 +5,6 @@ package workceptor
 import (
 	"context"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/randstr"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"io"
 	"io/ioutil"
 	"os"
@@ -18,6 +13,12 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/controlsvc"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/randstr"
+	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // Workceptor is the main object that handles unit-of-work management
@@ -125,7 +126,7 @@ func (w *Workceptor) generateUnitID(lock bool) (string, error) {
 			if err == nil {
 				continue
 			}
-			return ident, os.MkdirAll(unitdir, 0700)
+			return ident, os.MkdirAll(unitdir, 0o700)
 		}
 	}
 }

--- a/pkg/workceptor/workceptor_stub.go
+++ b/pkg/workceptor/workceptor_stub.go
@@ -7,6 +7,7 @@ package workceptor
 import (
 	"context"
 	"fmt"
+
 	"github.com/project-receptor/receptor/pkg/controlsvc"
 	"github.com/project-receptor/receptor/pkg/netceptor"
 )
@@ -15,8 +16,7 @@ import (
 var ErrNotImplemented = fmt.Errorf("not implemented")
 
 // Workceptor is the main object that handles unit-of-work management
-type Workceptor struct {
-}
+type Workceptor struct{}
 
 // New constructs a new Workceptor instance
 func New(ctx context.Context, nc *netceptor.Netceptor, dataDir string) (*Workceptor, error) {

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -122,6 +122,7 @@ func (sfd *StatusFileData) lockStatusFile(filename string) (*lockedfile.File, er
 	if err != nil {
 		return nil, err
 	}
+
 	return lockFile, nil
 }
 
@@ -141,6 +142,7 @@ func (sfd *StatusFileData) saveToFile(file io.Writer) error {
 	}
 	jsonBytes = append(jsonBytes, '\n')
 	_, err = file.Write(jsonBytes)
+
 	return err
 }
 
@@ -158,8 +160,10 @@ func (sfd *StatusFileData) Save(filename string) error {
 	err = sfd.saveToFile(file)
 	if err != nil {
 		_ = file.Close()
+
 		return err
 	}
+
 	return file.Close()
 }
 
@@ -167,6 +171,7 @@ func (sfd *StatusFileData) Save(filename string) error {
 func (bwu *BaseWorkUnit) Save() error {
 	bwu.statusLock.RLock()
 	defer bwu.statusLock.RUnlock()
+
 	return bwu.status.Save(bwu.statusFileName)
 }
 
@@ -176,6 +181,7 @@ func (sfd *StatusFileData) loadFromFile(file io.Reader) error {
 	if err != nil {
 		return err
 	}
+
 	return json.Unmarshal(jsonBytes, sfd)
 }
 
@@ -193,8 +199,10 @@ func (sfd *StatusFileData) Load(filename string) error {
 	err = sfd.loadFromFile(file)
 	if err != nil {
 		_ = file.Close()
+
 		return err
 	}
+
 	return file.Close()
 }
 
@@ -202,6 +210,7 @@ func (sfd *StatusFileData) Load(filename string) error {
 func (bwu *BaseWorkUnit) Load() error {
 	bwu.statusLock.Lock()
 	defer bwu.statusLock.Unlock()
+
 	return bwu.status.Load(bwu.statusFileName)
 }
 
@@ -250,6 +259,7 @@ func (sfd *StatusFileData) UpdateFullStatus(filename string, statusFunc func(*St
 	if err != nil {
 		return err
 	}
+
 	return nil
 }
 
@@ -357,6 +367,7 @@ func (bwu *BaseWorkUnit) getStatus() *StatusFileData {
 	var status StatusFileData
 	status = bwu.status
 	status.ExtraData = nil
+
 	return &status
 }
 
@@ -369,6 +380,7 @@ func (bwu *BaseWorkUnit) Status() *StatusFileData {
 func (bwu *BaseWorkUnit) UnredactedStatus() *StatusFileData {
 	bwu.statusLock.RLock()
 	defer bwu.statusLock.RUnlock()
+
 	return bwu.getStatus()
 }
 
@@ -387,9 +399,11 @@ func (bwu *BaseWorkUnit) Release(force bool) error {
 			if attemptsLeft > 0 {
 				logger.Warning("Error removing directory for %s. Retrying %d more times.", bwu.unitID, attemptsLeft)
 				time.Sleep(time.Second)
+
 				continue
 			} else {
 				logger.Error("Error removing directory for %s. No more retries left.", bwu.unitID)
+
 				return err
 			}
 		}
@@ -399,6 +413,7 @@ func (bwu *BaseWorkUnit) Release(force bool) error {
 	bwu.w.activeUnitsLock.Lock()
 	defer bwu.w.activeUnitsLock.Unlock()
 	delete(bwu.w.activeUnits, bwu.unitID)
+
 	return nil
 }
 
@@ -407,6 +422,7 @@ func (bwu *BaseWorkUnit) Release(force bool) error {
 func newUnknownWorker(w *Workceptor, unitID string, workType string) WorkUnit {
 	uu := &unknownUnit{}
 	uu.BaseWorkUnit.Init(w, unitID, workType)
+
 	return uu
 }
 
@@ -433,5 +449,6 @@ func (uu *unknownUnit) Cancel() error {
 func (uu *unknownUnit) Status() *StatusFileData {
 	status := uu.BaseWorkUnit.Status()
 	status.ExtraData = "Unknown WorkType"
+
 	return status
 }

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -6,15 +6,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/fsnotify/fsnotify"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/rogpeppe/go-internal/lockedfile"
 	"io"
 	"io/ioutil"
 	"os"
 	"path"
 	"sync"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
 // Work sleep constants
@@ -117,7 +118,7 @@ func (bwu *BaseWorkUnit) StdoutFileName() string {
 // lockStatusFile gains a lock on the status file
 func (sfd *StatusFileData) lockStatusFile(filename string) (*lockedfile.File, error) {
 	lockFileName := filename + ".lock"
-	lockFile, err := lockedfile.OpenFile(lockFileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	lockFile, err := lockedfile.OpenFile(lockFileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return nil, err
 	}
@@ -150,7 +151,7 @@ func (sfd *StatusFileData) Save(filename string) error {
 		return err
 	}
 	defer sfd.unlockStatusFile(filename, lockFile)
-	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
@@ -212,7 +213,7 @@ func (sfd *StatusFileData) UpdateFullStatus(filename string, statusFunc func(*St
 		return err
 	}
 	defer sfd.unlockStatusFile(filename, lockFile)
-	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0600)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, 0o600)
 	if err != nil {
 		return err
 	}

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -33,8 +33,8 @@ const (
 )
 
 // IsComplete returns true if a given WorkState indicates the job is finished.
-func IsComplete(WorkState int) bool {
-	return WorkState == WorkStateSucceeded || WorkState == WorkStateFailed
+func IsComplete(workState int) bool {
+	return workState == WorkStateSucceeded || workState == WorkStateFailed
 }
 
 // WorkStateToString returns a string representation of a WorkState.

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -128,8 +128,7 @@ func (sfd *StatusFileData) lockStatusFile(filename string) (*lockedfile.File, er
 
 // unlockStatusFile releases the lock on the status file.
 func (sfd *StatusFileData) unlockStatusFile(filename string, lockFile *lockedfile.File) {
-	err := lockFile.Close()
-	if err != nil {
+	if err := lockFile.Close(); err != nil {
 		logger.Error("Error closing %s.lock: %s", filename, err)
 	}
 }

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -364,8 +364,7 @@ loop:
 
 // getStatus returns a copy of the base status (no ExtraData).  The caller must already hold the statusLock.
 func (bwu *BaseWorkUnit) getStatus() *StatusFileData {
-	var status StatusFileData
-	status = bwu.status
+	status := bwu.status
 	status.ExtraData = nil
 
 	return &status

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -18,13 +18,13 @@ import (
 	"github.com/rogpeppe/go-internal/lockedfile"
 )
 
-// Work sleep constants
+// Work sleep constants.
 const (
 	SuccessWorkSleep = 1 * time.Second // Normal time to wait between checks
 	MaxWorkSleep     = 1 * time.Minute // Max time to ever wait between checks
 )
 
-// Work state constants
+// Work state constants.
 const (
 	WorkStatePending   = 0
 	WorkStateRunning   = 1
@@ -32,12 +32,12 @@ const (
 	WorkStateFailed    = 3
 )
 
-// IsComplete returns true if a given WorkState indicates the job is finished
+// IsComplete returns true if a given WorkState indicates the job is finished.
 func IsComplete(WorkState int) bool {
 	return WorkState == WorkStateSucceeded || WorkState == WorkStateFailed
 }
 
-// WorkStateToString returns a string representation of a WorkState
+// WorkStateToString returns a string representation of a WorkState.
 func WorkStateToString(workState int) string {
 	switch workState {
 	case WorkStatePending:
@@ -53,15 +53,15 @@ func WorkStateToString(workState int) string {
 	}
 }
 
-// ErrPending is returned when an operation hasn't succeeded or failed yet
+// ErrPending is returned when an operation hasn't succeeded or failed yet.
 var ErrPending = fmt.Errorf("operation pending")
 
-// IsPending returns true if the error is an ErrPending
+// IsPending returns true if the error is an ErrPending.
 func IsPending(err error) bool {
 	return err == ErrPending
 }
 
-// BaseWorkUnit includes data common to all work units, and partially implements the WorkUnit interface
+// BaseWorkUnit includes data common to all work units, and partially implements the WorkUnit interface.
 type BaseWorkUnit struct {
 	w               *Workceptor
 	status          StatusFileData
@@ -90,32 +90,32 @@ func (bwu *BaseWorkUnit) Init(w *Workceptor, unitID string, workType string) {
 	bwu.ctx, bwu.cancel = context.WithCancel(w.ctx)
 }
 
-// SetFromParams sets the in-memory state from parameters
+// SetFromParams sets the in-memory state from parameters.
 func (bwu *BaseWorkUnit) SetFromParams(params map[string]string) error {
 	return nil
 }
 
-// UnitDir returns the unit directory of this work unit
+// UnitDir returns the unit directory of this work unit.
 func (bwu *BaseWorkUnit) UnitDir() string {
 	return bwu.unitDir
 }
 
-// ID returns the unique identifier of this work unit
+// ID returns the unique identifier of this work unit.
 func (bwu *BaseWorkUnit) ID() string {
 	return bwu.unitID
 }
 
-// StatusFileName returns the full path to the status file in the unit dir
+// StatusFileName returns the full path to the status file in the unit dir.
 func (bwu *BaseWorkUnit) StatusFileName() string {
 	return bwu.statusFileName
 }
 
-// StdoutFileName returns the full path to the stdout file in the unit dir
+// StdoutFileName returns the full path to the stdout file in the unit dir.
 func (bwu *BaseWorkUnit) StdoutFileName() string {
 	return bwu.stdoutFileName
 }
 
-// lockStatusFile gains a lock on the status file
+// lockStatusFile gains a lock on the status file.
 func (sfd *StatusFileData) lockStatusFile(filename string) (*lockedfile.File, error) {
 	lockFileName := filename + ".lock"
 	lockFile, err := lockedfile.OpenFile(lockFileName, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
@@ -125,7 +125,7 @@ func (sfd *StatusFileData) lockStatusFile(filename string) (*lockedfile.File, er
 	return lockFile, nil
 }
 
-// unlockStatusFile releases the lock on the status file
+// unlockStatusFile releases the lock on the status file.
 func (sfd *StatusFileData) unlockStatusFile(filename string, lockFile *lockedfile.File) {
 	err := lockFile.Close()
 	if err != nil {
@@ -133,7 +133,7 @@ func (sfd *StatusFileData) unlockStatusFile(filename string, lockFile *lockedfil
 	}
 }
 
-// saveToFile saves status to an already-open file
+// saveToFile saves status to an already-open file.
 func (sfd *StatusFileData) saveToFile(file io.Writer) error {
 	jsonBytes, err := json.Marshal(sfd)
 	if err != nil {
@@ -144,7 +144,7 @@ func (sfd *StatusFileData) saveToFile(file io.Writer) error {
 	return err
 }
 
-// Save saves status to a file
+// Save saves status to a file.
 func (sfd *StatusFileData) Save(filename string) error {
 	lockFile, err := sfd.lockStatusFile(filename)
 	if err != nil {
@@ -163,14 +163,14 @@ func (sfd *StatusFileData) Save(filename string) error {
 	return file.Close()
 }
 
-// Save saves status to a file
+// Save saves status to a file.
 func (bwu *BaseWorkUnit) Save() error {
 	bwu.statusLock.RLock()
 	defer bwu.statusLock.RUnlock()
 	return bwu.status.Save(bwu.statusFileName)
 }
 
-// loadFromFile loads status from an already open file
+// loadFromFile loads status from an already open file.
 func (sfd *StatusFileData) loadFromFile(file io.Reader) error {
 	jsonBytes, err := ioutil.ReadAll(file)
 	if err != nil {
@@ -179,7 +179,7 @@ func (sfd *StatusFileData) loadFromFile(file io.Reader) error {
 	return json.Unmarshal(jsonBytes, sfd)
 }
 
-// Load loads status from a file
+// Load loads status from a file.
 func (sfd *StatusFileData) Load(filename string) error {
 	lockFile, err := sfd.lockStatusFile(filename)
 	if err != nil {
@@ -198,7 +198,7 @@ func (sfd *StatusFileData) Load(filename string) error {
 	return file.Close()
 }
 
-// Load loads status from a file
+// Load loads status from a file.
 func (bwu *BaseWorkUnit) Load() error {
 	bwu.statusLock.Lock()
 	defer bwu.statusLock.Unlock()
@@ -289,12 +289,12 @@ func (bwu *BaseWorkUnit) UpdateBasicStatus(state int, detail string, stdoutSize 
 	}
 }
 
-// LastUpdateError returns the last error (including nil) resulting from an UpdateBasicStatus or UpdateFullStatus
+// LastUpdateError returns the last error (including nil) resulting from an UpdateBasicStatus or UpdateFullStatus.
 func (bwu *BaseWorkUnit) LastUpdateError() error {
 	return bwu.lastUpdateError
 }
 
-// monitorLocalStatus watches a unit dir and keeps the in-memory workUnit up to date with status changes
+// monitorLocalStatus watches a unit dir and keeps the in-memory workUnit up to date with status changes.
 func (bwu *BaseWorkUnit) monitorLocalStatus() {
 	statusFile := path.Join(bwu.UnitDir(), "status")
 	watcher, err := fsnotify.NewWatcher()
@@ -360,19 +360,19 @@ func (bwu *BaseWorkUnit) getStatus() *StatusFileData {
 	return &status
 }
 
-// Status returns a copy of the status currently loaded in memory (use Load to get it from disk)
+// Status returns a copy of the status currently loaded in memory (use Load to get it from disk).
 func (bwu *BaseWorkUnit) Status() *StatusFileData {
 	return bwu.UnredactedStatus()
 }
 
-// UnredactedStatus returns a copy of the status currently loaded in memory, including secrets
+// UnredactedStatus returns a copy of the status currently loaded in memory, including secrets.
 func (bwu *BaseWorkUnit) UnredactedStatus() *StatusFileData {
 	bwu.statusLock.RLock()
 	defer bwu.statusLock.RUnlock()
 	return bwu.getStatus()
 }
 
-// Release releases this unit of work, deleting its files
+// Release releases this unit of work, deleting its files.
 func (bwu *BaseWorkUnit) Release(force bool) error {
 	bwu.statusLock.Lock()
 	defer bwu.statusLock.Unlock()
@@ -410,7 +410,7 @@ func newUnknownWorker(w *Workceptor, unitID string, workType string) WorkUnit {
 	return uu
 }
 
-// unknownUnit is used to represent units we find on disk, but don't recognize their WorkType
+// unknownUnit is used to represent units we find on disk, but don't recognize their WorkType.
 type unknownUnit struct {
 	BaseWorkUnit
 }

--- a/receptorctl/setup.cfg
+++ b/receptorctl/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = receptorctl
 author = Red Hat
-author-email = info@ansible.com
+author_email = info@ansible.com
 summary = "Receptorctl is a front-end CLI and importable Python library that interacts with Receptor over its control socket interface."
-home-page = https://github.com/project-receptor/receptor/tree/devel/receptorctl
-description-file = README.md
-description-content-type = text/markdown
+home_page = https://github.com/project-receptor/receptor/tree/devel/receptorctl
+description_file = README.md
+description_content_type = text/markdown
 
 [entry_points]
 console_scripts =

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -26,6 +26,7 @@ func ConfirmListening(pid int) (bool, error) {
 	if strings.Contains(out.String(), pidString) {
 		return true, nil
 	}
+
 	return false, nil
 }
 
@@ -112,6 +113,7 @@ func TestSSLListeners(t *testing.T) {
 				if err == nil {
 					return true
 				}
+
 				return false
 			}
 

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 	"os/exec"
 	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 )
 
 func ConfirmListening(pid int) (bool, error) {

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -15,8 +15,7 @@ import (
 
 func ConfirmListening(pid int) (bool, error) {
 	pidString := "pid=" + strconv.Itoa(pid)
-	var out bytes.Buffer
-	out = bytes.Buffer{}
+	out := bytes.Buffer{}
 	ssCmd := exec.Command("ss", "-tulnp")
 	ssCmd.Stdout = &out
 	err := ssCmd.Run()
@@ -110,11 +109,8 @@ func TestSSLListeners(t *testing.T) {
 				opensslCmd.Stdin = &opensslStdIn
 				opensslCmd.Stdout = &opensslStdOut
 				err = opensslCmd.Run()
-				if err == nil {
-					return true
-				}
 
-				return false
+				return err == nil
 			}
 
 			ctx, _ := context.WithTimeout(context.Background(), 2*time.Second)

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -18,8 +18,7 @@ func ConfirmListening(pid int) (bool, error) {
 	out := bytes.Buffer{}
 	ssCmd := exec.Command("ss", "-tulnp")
 	ssCmd.Stdout = &out
-	err := ssCmd.Run()
-	if err != nil {
+	if err := ssCmd.Run(); err != nil {
 		return false, err
 	}
 	if strings.Contains(out.String(), pidString) {
@@ -32,8 +31,7 @@ func ConfirmListening(pid int) (bool, error) {
 func TestHelp(t *testing.T) {
 	t.Parallel()
 	cmd := exec.Command("receptor", "--help")
-	err := cmd.Run()
-	if err != nil {
+	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -87,6 +87,9 @@ func TestSSLListeners(t *testing.T) {
 			t.Parallel()
 
 			key, crt, err := utils.GenerateCert("test", "localhost", []string{"localhost"}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
 
 			receptorStdOut := bytes.Buffer{}
 			port := utils.ReserveTCPPort()

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -171,7 +171,7 @@ func NewCLIMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 
 // NewCLIMeshFromYaml takes a yaml mesh description and returns a mesh of nodes
 // listening and dialing as defined in the yaml.
-func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, error) {
+func NewCLIMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*CLIMesh, error) {
 	mesh := &CLIMesh{}
 	// Setup the mesh directory
 	baseDir := utils.TestBaseDir
@@ -193,7 +193,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 
 	// We must start listening on all our nodes before we start dialing so
 	// there's something to dial into
-	for k := range MeshDefinition.Nodes {
+	for k := range meshDefinition.Nodes {
 		node := NewCLINode(k)
 		tempdir, err = ioutil.TempDir(mesh.dir, k+"-")
 		if err != nil {
@@ -203,7 +203,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 		// Keep track of if we need to add an attribute for the node id or if
 		// it already exists
 		needsIDAttr := true
-		for attrkey, attr := range MeshDefinition.Nodes[k].Nodedef {
+		for attrkey, attr := range meshDefinition.Nodes[k].Nodedef {
 			attrMap := attr.(map[interface{}]interface{})
 			for k, v := range attrMap {
 				k = k.(string)
@@ -233,7 +233,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 					}
 				}
 			}
-			MeshDefinition.Nodes[k].Nodedef[attrkey] = attrMap
+			meshDefinition.Nodes[k].Nodedef[attrkey] = attrMap
 		}
 		if needsIDAttr {
 			idYaml := make(map[interface{}]interface{})
@@ -242,20 +242,20 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 			nodeYaml["datadir"] = filepath.Join(node.dir, "datadir")
 			os.Mkdir(nodeYaml["datadir"].(string), 0o755)
 			idYaml["node"] = nodeYaml
-			MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, idYaml)
+			meshDefinition.Nodes[k].Nodedef = append(meshDefinition.Nodes[k].Nodedef, idYaml)
 		}
 		logYaml := make(map[interface{}]interface{})
 		levelYaml := make(map[interface{}]interface{})
 		levelYaml["level"] = "debug"
 		logYaml["log-level"] = levelYaml
-		MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, logYaml)
+		meshDefinition.Nodes[k].Nodedef = append(meshDefinition.Nodes[k].Nodedef, logYaml)
 		nodes[k] = node
 	}
-	for k := range MeshDefinition.Nodes {
-		for connNode, connYaml := range MeshDefinition.Nodes[k].Connections {
+	for k := range meshDefinition.Nodes {
+		for connNode, connYaml := range meshDefinition.Nodes[k].Connections {
 			index := connYaml.Index
 			TLS := connYaml.TLS
-			attr := MeshDefinition.Nodes[connNode].Nodedef[index]
+			attr := meshDefinition.Nodes[connNode].Nodedef[index]
 			attrMap := attr.(map[interface{}]interface{})
 			listener, ok := attrMap["tcp-listener"]
 			if ok {
@@ -279,7 +279,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 					peerYaml["tls"] = TLS
 				}
 				dialerYaml["tcp-peer"] = peerYaml
-				MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, dialerYaml)
+				meshDefinition.Nodes[k].Nodedef = append(meshDefinition.Nodes[k].Nodedef, dialerYaml)
 			}
 			listener, ok = attrMap["udp-listener"]
 			if ok {
@@ -299,7 +299,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 				peerYaml["address"] = addr
 				peerYaml["cost"] = getListenerCost(listenerMap, k)
 				dialerYaml["udp-peer"] = peerYaml
-				MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, dialerYaml)
+				meshDefinition.Nodes[k].Nodedef = append(meshDefinition.Nodes[k].Nodedef, dialerYaml)
 			}
 			listener, ok = attrMap["ws-listener"]
 			if ok {
@@ -329,7 +329,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 					peerYaml["tls"] = TLS
 				}
 				dialerYaml["ws-peer"] = peerYaml
-				MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, dialerYaml)
+				meshDefinition.Nodes[k].Nodedef = append(meshDefinition.Nodes[k].Nodedef, dialerYaml)
 			}
 		}
 	}
@@ -338,7 +338,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 	for k, node := range nodes {
 		needsControlService := true
 		controlServiceIndex := 0
-		for index, attr := range MeshDefinition.Nodes[k].Nodedef {
+		for index, attr := range meshDefinition.Nodes[k].Nodedef {
 			attrMap := attr.(map[interface{}]interface{})
 			for k, v := range attrMap {
 				k = k.(string)
@@ -369,21 +369,21 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 			tmp["filename"] = controlSocket
 			controlServiceYaml := make(map[interface{}]interface{})
 			controlServiceYaml["control-service"] = tmp
-			MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, controlServiceYaml)
+			meshDefinition.Nodes[k].Nodedef = append(meshDefinition.Nodes[k].Nodedef, controlServiceYaml)
 		} else {
-			MeshDefinition.Nodes[k].Nodedef[controlServiceIndex].(map[interface{}]interface{})["control-service"].(map[interface{}]interface{})["filename"] = controlSocket
+			meshDefinition.Nodes[k].Nodedef[controlServiceIndex].(map[interface{}]interface{})["control-service"].(map[interface{}]interface{})["filename"] = controlSocket
 		}
 	}
 
 	for k, node := range nodes {
-		node.yamlConfig = MeshDefinition.Nodes[k].Nodedef
+		node.yamlConfig = meshDefinition.Nodes[k].Nodedef
 		err = node.Start()
 		if err != nil {
 			return nil, err
 		}
 	}
 	mesh.nodes = nodes
-	mesh.MeshDefinition = &MeshDefinition
+	mesh.MeshDefinition = &meshDefinition
 
 	failedMesh := make(chan *CLINode)
 	time.Sleep(100 * time.Millisecond)

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -459,13 +459,9 @@ func (m *CLIMesh) CheckConnections() bool {
 				continue
 			}
 		}
-		for nodeID, node := range m.MeshDefinition.Nodes {
+		for nodeID := range m.MeshDefinition.Nodes {
 			if nodeID == status.NodeID {
 				continue
-			}
-			for k := range node.Connections {
-				if k == status.NodeID {
-				}
 			}
 		}
 		if reflect.DeepEqual(actualConnections, expectedConnections) {

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -61,6 +61,7 @@ func (n *CLINode) Status() (*netceptor.Status, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return status, nil
 }
 
@@ -94,6 +95,7 @@ func (n *CLINode) Start() error {
 	n.receptorCmd.Stdout = stdout
 	n.receptorCmd.Stderr = stderr
 	err = n.receptorCmd.Start()
+
 	return err
 }
 
@@ -145,6 +147,7 @@ func (m *CLIMesh) Nodes() map[string]Node {
 	for k, v := range m.nodes {
 		nodes[k] = v
 	}
+
 	return nodes
 }
 
@@ -398,6 +401,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 	case node := <-failedMesh:
 		mesh.Destroy()
 		mesh.WaitForShutdown()
+
 		return nil, fmt.Errorf("Failed to create mesh: node %s exited early", node.dir)
 	case <-time.After(time.Until(time.Now().Add(100 * time.Millisecond))):
 	}
@@ -439,16 +443,19 @@ func (m *CLIMesh) CheckConnections() bool {
 			listenerYaml, ok := configItemYaml["tcp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 			listenerYaml, ok = configItemYaml["udp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 			listenerYaml, ok = configItemYaml["ws-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 		}
@@ -465,6 +472,7 @@ func (m *CLIMesh) CheckConnections() bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -498,6 +506,7 @@ func (m *CLIMesh) CheckAdvertisements() bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -518,6 +527,7 @@ func (m *CLIMesh) CheckKnownConnectionCosts() bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -539,6 +549,7 @@ func (m *CLIMesh) CheckRoutes() bool {
 			}
 		}
 	}
+
 	return true
 }
 
@@ -552,6 +563,7 @@ func (m *CLIMesh) CheckControlSockets() bool {
 		}
 		controller.Close()
 	}
+
 	return true
 }
 
@@ -573,6 +585,7 @@ func (m *CLIMesh) WaitForReady(ctx context.Context) error {
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckAdvertisements) {
 		return errors.New("Timed out while waiting for Advertisements")
 	}
+
 	return nil
 }
 
@@ -586,5 +599,6 @@ func (m *CLIMesh) Status() ([]*netceptor.Status, error) {
 		}
 		out = append(out, status)
 	}
+
 	return out, nil
 }

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -256,7 +256,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 			index := connYaml.Index
 			TLS := connYaml.TLS
 			attr := MeshDefinition.Nodes[connNode].Nodedef[index]
-			attrMap, ok := attr.(map[interface{}]interface{})
+			attrMap := attr.(map[interface{}]interface{})
 			listener, ok := attrMap["tcp-listener"]
 			if ok {
 				dialerYaml := make(map[interface{}]interface{})
@@ -439,7 +439,7 @@ func (m *CLIMesh) CheckConnections() bool {
 		expectedConnections := map[string]float64{}
 		for k, connYaml := range m.MeshDefinition.Nodes[status.NodeID].Connections {
 			index := connYaml.Index
-			configItemYaml, ok := m.MeshDefinition.Nodes[k].Nodedef[index].(map[interface{}]interface{})
+			configItemYaml := m.MeshDefinition.Nodes[k].Nodedef[index].(map[interface{}]interface{})
 			listenerYaml, ok := configItemYaml["tcp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -21,11 +21,10 @@ import (
 // CLINode holds a Netceptor, this layer of abstraction might be unnecessary and
 // go away later.
 type CLINode struct {
-	receptorCmd    *exec.Cmd
-	dir            string
-	yamlConfigPath string
-	yamlConfig     []interface{}
-	controlSocket  string
+	receptorCmd   *exec.Cmd
+	dir           string
+	yamlConfig    []interface{}
+	controlSocket string
 }
 
 // CLIMesh contains a list of Nodes and the yaml definition that created them.

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -19,7 +19,7 @@ import (
 )
 
 // CLINode holds a Netceptor, this layer of abstraction might be unnecessary and
-// go away later
+// go away later.
 type CLINode struct {
 	receptorCmd    *exec.Cmd
 	dir            string
@@ -28,14 +28,14 @@ type CLINode struct {
 	controlSocket  string
 }
 
-// CLIMesh contains a list of Nodes and the yaml definition that created them
+// CLIMesh contains a list of Nodes and the yaml definition that created them.
 type CLIMesh struct {
 	nodes          map[string]*CLINode
 	MeshDefinition *YamlData
 	dir            string
 }
 
-// NewCLINode builds a node with the name passed as the argument
+// NewCLINode builds a node with the name passed as the argument.
 func NewCLINode(name string) *CLINode {
 	return &CLINode{
 		receptorCmd:   nil,
@@ -43,13 +43,13 @@ func NewCLINode(name string) *CLINode {
 	}
 }
 
-// Dir returns the basedir which contains all of the node data
+// Dir returns the basedir which contains all of the node data.
 func (n *CLINode) Dir() string {
 	return n.dir
 }
 
 // Status returns the status of the node using the control socket to query the
-// node
+// node.
 func (n *CLINode) Status() (*netceptor.Status, error) {
 	controller := receptorcontrol.New()
 	err := controller.Connect(n.controlSocket)
@@ -64,17 +64,17 @@ func (n *CLINode) Status() (*netceptor.Status, error) {
 	return status, nil
 }
 
-// ControlSocket Returns the path to the controlsocket
+// ControlSocket Returns the path to the controlsocket.
 func (n *CLINode) ControlSocket() string {
 	return n.controlSocket
 }
 
-// Shutdown kills the receptor process
+// Shutdown kills the receptor process.
 func (n *CLINode) Shutdown() {
 	n.receptorCmd.Process.Kill()
 }
 
-// Start writes the the node config to disk and starts the receptor process
+// Start writes the the node config to disk and starts the receptor process.
 func (n *CLINode) Start() error {
 	strData, err := yaml.Marshal(n.yamlConfig)
 	if err != nil {
@@ -98,7 +98,7 @@ func (n *CLINode) Start() error {
 }
 
 // Destroy kills the receptor process and puts its ports back into the pool to
-// be reallocated once it's shutdown
+// be reallocated once it's shutdown.
 func (n *CLINode) Destroy() {
 	n.Shutdown()
 	go func() {
@@ -129,17 +129,17 @@ func (n *CLINode) Destroy() {
 	}()
 }
 
-// WaitForShutdown Waits for the receptor process to finish
+// WaitForShutdown Waits for the receptor process to finish.
 func (n *CLINode) WaitForShutdown() {
 	n.receptorCmd.Wait()
 }
 
-// Dir returns the basedir which contains all of the mesh data
+// Dir returns the basedir which contains all of the mesh data.
 func (m *CLIMesh) Dir() string {
 	return m.dir
 }
 
-// Nodes Returns a list of nodes
+// Nodes Returns a list of nodes.
 func (m *CLIMesh) Nodes() map[string]Node {
 	nodes := make(map[string]Node)
 	for k, v := range m.nodes {
@@ -149,7 +149,7 @@ func (m *CLIMesh) Nodes() map[string]Node {
 }
 
 // NewCLIMeshFromFile Takes a filename of a file with a yaml description of a mesh, loads it and
-// calls NewMeshFromYaml on it
+// calls NewMeshFromYaml on it.
 func NewCLIMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 	yamlDat, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -167,7 +167,7 @@ func NewCLIMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 }
 
 // NewCLIMeshFromYaml takes a yaml mesh description and returns a mesh of nodes
-// listening and dialing as defined in the yaml
+// listening and dialing as defined in the yaml.
 func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, error) {
 	mesh := &CLIMesh{}
 	// Setup the mesh directory
@@ -406,14 +406,14 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 }
 
 // Destroy stops all running Netceptors and their backends and frees all
-// relevant resources
+// relevant resources.
 func (m *CLIMesh) Destroy() {
 	for _, node := range m.nodes {
 		node.Destroy()
 	}
 }
 
-// WaitForShutdown Waits for all running Netceptors and their backends to stop
+// WaitForShutdown Waits for all running Netceptors and their backends to stop.
 func (m *CLIMesh) WaitForShutdown() {
 	for _, node := range m.nodes {
 		node.WaitForShutdown()
@@ -421,7 +421,7 @@ func (m *CLIMesh) WaitForShutdown() {
 }
 
 // CheckConnections returns true if the connections defined in our mesh definition are
-// consistent with the connections made by the nodes
+// consistent with the connections made by the nodes.
 func (m *CLIMesh) CheckConnections() bool {
 	statusList, err := m.Status()
 	if err != nil {
@@ -469,7 +469,7 @@ func (m *CLIMesh) CheckConnections() bool {
 }
 
 // CheckAdvertisements returns true if the advertisements are recorded in
-// a manner consistent with the work-commands defined for the mesh
+// a manner consistent with the work-commands defined for the mesh.
 func (m *CLIMesh) CheckAdvertisements() bool {
 	statusList, err := m.Status()
 	if err != nil {
@@ -501,7 +501,7 @@ func (m *CLIMesh) CheckAdvertisements() bool {
 	return false
 }
 
-// CheckKnownConnectionCosts returns true if every node has the same view of the connections in the mesh
+// CheckKnownConnectionCosts returns true if every node has the same view of the connections in the mesh.
 func (m *CLIMesh) CheckKnownConnectionCosts() bool {
 	meshStatus, err := m.Status()
 	if err != nil {
@@ -521,7 +521,7 @@ func (m *CLIMesh) CheckKnownConnectionCosts() bool {
 	return true
 }
 
-// CheckRoutes returns true if every node has a route to every other node
+// CheckRoutes returns true if every node has a route to every other node.
 func (m *CLIMesh) CheckRoutes() bool {
 	meshStatus, err := m.Status()
 	if err != nil {
@@ -543,7 +543,7 @@ func (m *CLIMesh) CheckRoutes() bool {
 }
 
 // CheckControlSockets Checks if the Control sockets in the mesh are all running and accepting
-// connections
+// connections.
 func (m *CLIMesh) CheckControlSockets() bool {
 	for _, node := range m.nodes {
 		controller := receptorcontrol.New()
@@ -555,7 +555,7 @@ func (m *CLIMesh) CheckControlSockets() bool {
 	return true
 }
 
-// WaitForReady Waits for connections and routes to converge
+// WaitForReady Waits for connections and routes to converge.
 func (m *CLIMesh) WaitForReady(ctx context.Context) error {
 	sleepInterval := 100 * time.Millisecond
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckControlSockets) {
@@ -576,7 +576,7 @@ func (m *CLIMesh) WaitForReady(ctx context.Context) error {
 	return nil
 }
 
-// Status returns a list of statuses from the contained netceptors
+// Status returns a list of statuses from the contained netceptors.
 func (m *CLIMesh) Status() ([]*netceptor.Status, error) {
 	var out []*netceptor.Status
 	for _, node := range m.nodes {

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -261,7 +261,7 @@ func NewCLIMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 				dialerYaml := make(map[interface{}]interface{})
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 				peerYaml := make(map[interface{}]interface{})
 				bindaddr, ok := listenerMap["bindaddr"].(string)
@@ -285,7 +285,7 @@ func NewCLIMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 				dialerYaml := make(map[interface{}]interface{})
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 				peerYaml := make(map[interface{}]interface{})
 				bindaddr, ok := listenerMap["bindaddr"].(string)
@@ -305,7 +305,7 @@ func NewCLIMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 				dialerYaml := make(map[interface{}]interface{})
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 				peerYaml := make(map[interface{}]interface{})
 
@@ -401,7 +401,7 @@ func NewCLIMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 		mesh.Destroy()
 		mesh.WaitForShutdown()
 
-		return nil, fmt.Errorf("Failed to create mesh: node %s exited early", node.dir)
+		return nil, fmt.Errorf("failed to create mesh: node %s exited early", node.dir)
 	case <-time.After(time.Until(time.Now().Add(100 * time.Millisecond))):
 	}
 
@@ -566,19 +566,19 @@ func (m *CLIMesh) CheckControlSockets() bool {
 func (m *CLIMesh) WaitForReady(ctx context.Context) error {
 	sleepInterval := 100 * time.Millisecond
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckControlSockets) {
-		return errors.New("Timed out while waiting for control sockets")
+		return errors.New("timed out while waiting for control sockets")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckConnections) {
-		return errors.New("Timed out while waiting for Connections")
+		return errors.New("timed out while waiting for Connections")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckKnownConnectionCosts) {
-		return errors.New("Timed out while checking Connection Costs")
+		return errors.New("timed out while checking Connection Costs")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckRoutes) {
-		return errors.New("Timed out while waiting for routes to converge")
+		return errors.New("timed out while waiting for routes to converge")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckAdvertisements) {
-		return errors.New("Timed out while waiting for Advertisements")
+		return errors.New("timed out while waiting for Advertisements")
 	}
 
 	return nil

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -15,6 +11,11 @@ import (
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"gopkg.in/yaml.v2"
 )
 
 // CLINode holds a Netceptor, this layer of abstraction might be unnecessary and
@@ -80,7 +81,7 @@ func (n *CLINode) Start() error {
 		return err
 	}
 	nodedefPath := filepath.Join(n.dir, "nodedef.yaml")
-	ioutil.WriteFile(nodedefPath, strData, 0644)
+	ioutil.WriteFile(nodedefPath, strData, 0o644)
 	n.receptorCmd = exec.Command("receptor", "--config", nodedefPath)
 	stdout, err := os.Create(filepath.Join(n.dir, "stdout"))
 	if err != nil {
@@ -174,7 +175,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 	if dirSuffix != "" {
 		baseDir = filepath.Join(utils.TestBaseDir, dirSuffix)
 	}
-	err := os.MkdirAll(baseDir, 0755)
+	err := os.MkdirAll(baseDir, 0o755)
 	if err != nil {
 		return nil, err
 	}
@@ -236,7 +237,7 @@ func NewCLIMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*CLIMesh, er
 			nodeYaml := make(map[interface{}]interface{})
 			nodeYaml["id"] = k
 			nodeYaml["datadir"] = filepath.Join(node.dir, "datadir")
-			os.Mkdir(nodeYaml["datadir"].(string), 0755)
+			os.Mkdir(nodeYaml["datadir"].(string), 0o755)
 			idYaml["node"] = nodeYaml
 			MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, idYaml)
 		}

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -591,7 +591,7 @@ func (m *CLIMesh) WaitForReady(ctx context.Context) error {
 
 // Status returns a list of statuses from the contained netceptors.
 func (m *CLIMesh) Status() ([]*netceptor.Status, error) {
-	var out []*netceptor.Status
+	out := []*netceptor.Status{}
 	for _, node := range m.nodes {
 		status, err := node.Status()
 		if err != nil {

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -386,7 +386,7 @@ done`
 			index := connYaml.Index
 			TLS := connYaml.TLS
 			attr := MeshDefinition.Nodes[connNode].Nodedef[index]
-			attrMap, ok := attr.(map[interface{}]interface{})
+			attrMap := attr.(map[interface{}]interface{})
 			listener, ok := attrMap["tcp-listener"]
 			if ok {
 				dialerYaml := make(map[interface{}]interface{})
@@ -559,7 +559,7 @@ func (m *ContainerMesh) CheckConnections() bool {
 		expectedConnections := map[string]float64{}
 		for k, connYaml := range m.MeshDefinition.Nodes[status.NodeID].Connections {
 			index := connYaml.Index
-			configItemYaml, ok := m.MeshDefinition.Nodes[k].Nodedef[index].(map[interface{}]interface{})
+			configItemYaml := m.MeshDefinition.Nodes[k].Nodedef[index].(map[interface{}]interface{})
 			listenerYaml, ok := configItemYaml["tcp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -579,15 +579,6 @@ func (m *ContainerMesh) CheckConnections() bool {
 				continue
 			}
 		}
-		for nodeID, node := range m.MeshDefinition.Nodes {
-			if nodeID == status.NodeID {
-				continue
-			}
-			for k := range node.Connections {
-				if k == status.NodeID {
-				}
-			}
-		}
 		if reflect.DeepEqual(actualConnections, expectedConnections) {
 			return true
 		}

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -390,7 +390,7 @@ done`
 				dialerYaml := make(map[interface{}]interface{})
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 				peerYaml := make(map[interface{}]interface{})
 				bindaddr, ok := listenerMap["bindaddr"].(string)
@@ -414,7 +414,7 @@ done`
 				dialerYaml := make(map[interface{}]interface{})
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 				peerYaml := make(map[interface{}]interface{})
 				bindaddr, ok := listenerMap["bindaddr"].(string)
@@ -434,7 +434,7 @@ done`
 				dialerYaml := make(map[interface{}]interface{})
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 				peerYaml := make(map[interface{}]interface{})
 
@@ -519,7 +519,7 @@ done`
 			mesh.Destroy()
 			mesh.WaitForShutdown()
 
-			return nil, errors.New("Failed to create mesh")
+			return nil, errors.New("failed to create mesh")
 		case <-time.After(time.Until(time.Now().Add(100 * time.Millisecond))):
 		}
 	}
@@ -646,16 +646,16 @@ func (m *ContainerMesh) CheckControlSockets() bool {
 func (m *ContainerMesh) WaitForReady(ctx context.Context) error {
 	sleepInterval := 100 * time.Millisecond
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckControlSockets) {
-		return errors.New("Timed out while waiting for control sockets")
+		return errors.New("timed out while waiting for control sockets")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckConnections) {
-		return errors.New("Timed out while waiting for Connections")
+		return errors.New("timed out while waiting for Connections")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckKnownConnectionCosts) {
-		return errors.New("Timed out while checking Connection Costs")
+		return errors.New("timed out while checking Connection Costs")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckRoutes) {
-		return errors.New("Timed out while waiting for routes to converge")
+		return errors.New("timed out while waiting for routes to converge")
 	}
 
 	return nil

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -674,7 +674,7 @@ func (m *ContainerMesh) WaitForReady(ctx context.Context) error {
 
 // Status returns a list of statuses from the contained netceptors.
 func (m *ContainerMesh) Status() ([]*netceptor.Status, error) {
-	var out []*netceptor.Status
+	out := []*netceptor.Status{}
 	for _, node := range m.nodes {
 		status, err := node.Status()
 		if err != nil {

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -42,7 +42,7 @@ func init() {
 }
 
 // ContainerNode holds a Netceptor, this layer of abstraction might be unnecessary and
-// go away later
+// go away later.
 type ContainerNode struct {
 	dir                    string
 	yamlConfigPath         string
@@ -53,25 +53,25 @@ type ContainerNode struct {
 	TCRules                *TCRuleYaml
 }
 
-// ContainerMesh contains a list of Nodes and the yaml definition that created them
+// ContainerMesh contains a list of Nodes and the yaml definition that created them.
 type ContainerMesh struct {
 	nodes          map[string]*ContainerNode
 	MeshDefinition *YamlData
 	dir            string
 }
 
-// NewContainerNode builds a node with the name passed as the argument
+// NewContainerNode builds a node with the name passed as the argument.
 func NewContainerNode(name string) *ContainerNode {
 	return &ContainerNode{}
 }
 
-// Dir returns the basedir which contains all of the node data
+// Dir returns the basedir which contains all of the node data.
 func (n *ContainerNode) Dir() string {
 	return n.dir
 }
 
 // Status returns the status of the node using the control socket to query the
-// node
+// node.
 func (n *ContainerNode) Status() (*netceptor.Status, error) {
 	controller := receptorcontrol.New()
 	err := controller.Connect(n.externalControlSocket)
@@ -86,18 +86,18 @@ func (n *ContainerNode) Status() (*netceptor.Status, error) {
 	return status, nil
 }
 
-// ControlSocket Returns the path to the controlsocket
+// ControlSocket Returns the path to the controlsocket.
 func (n *ContainerNode) ControlSocket() string {
 	return n.externalControlSocket
 }
 
-// Shutdown kills the receptor process
+// Shutdown kills the receptor process.
 func (n *ContainerNode) Shutdown() {
 	receptorCmd := exec.Command(containerRunner, "stop", n.containerName)
 	receptorCmd.Start()
 }
 
-// Start writes the the node config to disk and starts the receptor process
+// Start writes the the node config to disk and starts the receptor process.
 func (n *ContainerNode) Start() error {
 	strData, err := yaml.Marshal(n.yamlConfig)
 	if err != nil {
@@ -170,7 +170,7 @@ func (n *ContainerNode) Start() error {
 }
 
 // Destroy kills the receptor process and puts its ports back into the pool to
-// be reallocated once it's shutdown
+// be reallocated once it's shutdown.
 func (n *ContainerNode) Destroy() {
 	n.Shutdown()
 	go func() {
@@ -203,18 +203,18 @@ func (n *ContainerNode) Destroy() {
 	}()
 }
 
-// WaitForShutdown Waits for the receptor process to finish
+// WaitForShutdown Waits for the receptor process to finish.
 func (n *ContainerNode) WaitForShutdown() {
 	Cmd := exec.Command(containerRunner, "wait", n.containerName)
 	Cmd.Run()
 }
 
-// Dir returns the basedir which contains all of the mesh data
+// Dir returns the basedir which contains all of the mesh data.
 func (m *ContainerMesh) Dir() string {
 	return m.dir
 }
 
-// Nodes Returns a list of nodes
+// Nodes Returns a list of nodes.
 func (m *ContainerMesh) Nodes() map[string]Node {
 	nodes := make(map[string]Node)
 	for k, v := range m.nodes {
@@ -224,7 +224,7 @@ func (m *ContainerMesh) Nodes() map[string]Node {
 }
 
 // NewContainerMeshFromFile Takes a filename of a file with a yaml description of a mesh, loads it and
-// calls NewMeshFromYaml on it
+// calls NewMeshFromYaml on it.
 func NewContainerMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 	yamlDat, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -242,7 +242,7 @@ func NewContainerMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 }
 
 // NewContainerMeshFromYaml takes a yaml mesh description and returns a mesh of nodes
-// listening and dialing as defined in the yaml
+// listening and dialing as defined in the yaml.
 func NewContainerMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*ContainerMesh, error) {
 	containerComposeData := make(map[string]interface{})
 	containerComposeData["version"] = "2.4"
@@ -526,14 +526,14 @@ done`
 }
 
 // Destroy stops all running Netceptors and their backends and frees all
-// relevant resources
+// relevant resources.
 func (m *ContainerMesh) Destroy() {
 	for _, node := range m.nodes {
 		node.Destroy()
 	}
 }
 
-// WaitForShutdown Waits for all running Netceptors and their backends to stop
+// WaitForShutdown Waits for all running Netceptors and their backends to stop.
 func (m *ContainerMesh) WaitForShutdown() {
 	for _, node := range m.nodes {
 		node.WaitForShutdown()
@@ -541,7 +541,7 @@ func (m *ContainerMesh) WaitForShutdown() {
 }
 
 // CheckConnections returns true if the connections defined in our mesh definition are
-// consistent with the connections made by the nodes
+// consistent with the connections made by the nodes.
 func (m *ContainerMesh) CheckConnections() bool {
 	statusList, err := m.Status()
 	if err != nil {
@@ -588,7 +588,7 @@ func (m *ContainerMesh) CheckConnections() bool {
 	return false
 }
 
-// CheckKnownConnectionCosts returns true if every node has the same view of the connections in the mesh
+// CheckKnownConnectionCosts returns true if every node has the same view of the connections in the mesh.
 func (m *ContainerMesh) CheckKnownConnectionCosts() bool {
 	meshStatus, err := m.Status()
 	if err != nil {
@@ -608,7 +608,7 @@ func (m *ContainerMesh) CheckKnownConnectionCosts() bool {
 	return true
 }
 
-// CheckRoutes returns true if every node has a route to every other node
+// CheckRoutes returns true if every node has a route to every other node.
 func (m *ContainerMesh) CheckRoutes() bool {
 	meshStatus, err := m.Status()
 	if err != nil {
@@ -630,7 +630,7 @@ func (m *ContainerMesh) CheckRoutes() bool {
 }
 
 // CheckControlSockets Checks if the Control sockets in the mesh are all running and accepting
-// connections
+// connections.
 func (m *ContainerMesh) CheckControlSockets() bool {
 	for _, node := range m.nodes {
 		controller := receptorcontrol.New()
@@ -642,7 +642,7 @@ func (m *ContainerMesh) CheckControlSockets() bool {
 	return true
 }
 
-// WaitForReady Waits for connections and routes to converge
+// WaitForReady Waits for connections and routes to converge.
 func (m *ContainerMesh) WaitForReady(ctx context.Context) error {
 	sleepInterval := 100 * time.Millisecond
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckControlSockets) {
@@ -660,7 +660,7 @@ func (m *ContainerMesh) WaitForReady(ctx context.Context) error {
 	return nil
 }
 
-// Status returns a list of statuses from the contained netceptors
+// Status returns a list of statuses from the contained netceptors.
 func (m *ContainerMesh) Status() ([]*netceptor.Status, error) {
 	var out []*netceptor.Status
 	for _, node := range m.nodes {

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -4,10 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -17,12 +13,19 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"gopkg.in/yaml.v2"
 )
 
 var containerImage string
 
-var containerRunner string
-var containerComposeRunner string
+var (
+	containerRunner        string
+	containerComposeRunner string
+)
 
 func init() {
 	containerImage = os.Getenv("CONTAINER_IMAGE")
@@ -101,7 +104,7 @@ func (n *ContainerNode) Start() error {
 		return err
 	}
 	nodedefPath := filepath.Join(n.dir, "receptor.conf")
-	ioutil.WriteFile(nodedefPath, strData, 0644)
+	ioutil.WriteFile(nodedefPath, strData, 0o644)
 	Cmd := exec.Command(containerRunner, "start", n.containerName)
 	output, err := Cmd.CombinedOutput()
 	if err != nil {
@@ -150,7 +153,7 @@ func (n *ContainerNode) Start() error {
 		if err != nil {
 			return err
 		}
-		err = f.Chmod(0755)
+		err = f.Chmod(0o755)
 		if err != nil {
 			return err
 		}
@@ -250,7 +253,7 @@ func NewContainerMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*Conta
 	if dirSuffix != "" {
 		baseDir = filepath.Join(utils.TestBaseDir, dirSuffix)
 	}
-	err := os.MkdirAll(baseDir, 0755)
+	err := os.MkdirAll(baseDir, 0o755)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +276,7 @@ done`
 	if err != nil {
 		return nil, err
 	}
-	err = f.Chmod(0755)
+	err = f.Chmod(0o755)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +367,7 @@ done`
 			nodeYaml["id"] = k
 			externalDataDir := filepath.Join(node.dir, "datadir")
 			nodeYaml["datadir"] = "/etc/receptor/datadir"
-			os.Mkdir(externalDataDir, 0755)
+			os.Mkdir(externalDataDir, 0o755)
 			idYaml["node"] = nodeYaml
 			MeshDefinition.Nodes[k].Nodedef = append(MeshDefinition.Nodes[k].Nodedef, idYaml)
 		}
@@ -479,7 +482,7 @@ done`
 		return nil, err
 	}
 	nodedefPath := filepath.Join(mesh.dir, "docker-compose.yaml")
-	ioutil.WriteFile(nodedefPath, containerComposeDataStr, 0644)
+	ioutil.WriteFile(nodedefPath, containerComposeDataStr, 0o644)
 
 	containerCompose := exec.Command(containerComposeRunner, "up", "--no-start")
 	// Add COMPOSE_PARALLEL_LIMIT=500 to our environment because of

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -44,13 +44,11 @@ func init() {
 // ContainerNode holds a Netceptor, this layer of abstraction might be unnecessary and
 // go away later.
 type ContainerNode struct {
-	dir                    string
-	yamlConfigPath         string
-	yamlConfig             []interface{}
-	containerControlSocket string
-	externalControlSocket  string
-	containerName          string
-	TCRules                *TCRuleYaml
+	dir                   string
+	yamlConfig            []interface{}
+	externalControlSocket string
+	containerName         string
+	TCRules               *TCRuleYaml
 }
 
 // ContainerMesh contains a list of Nodes and the yaml definition that created them.

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -83,6 +83,7 @@ func (n *ContainerNode) Status() (*netceptor.Status, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return status, nil
 }
 
@@ -166,6 +167,7 @@ func (n *ContainerNode) Start() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -220,6 +222,7 @@ func (m *ContainerMesh) Nodes() map[string]Node {
 	for k, v := range m.nodes {
 		nodes[k] = v
 	}
+
 	return nodes
 }
 
@@ -517,6 +520,7 @@ done`
 		case <-failedMesh:
 			mesh.Destroy()
 			mesh.WaitForShutdown()
+
 			return nil, errors.New("Failed to create mesh")
 		case <-time.After(time.Until(time.Now().Add(100 * time.Millisecond))):
 		}
@@ -559,16 +563,19 @@ func (m *ContainerMesh) CheckConnections() bool {
 			listenerYaml, ok := configItemYaml["tcp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 			listenerYaml, ok = configItemYaml["udp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 			listenerYaml, ok = configItemYaml["ws-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 		}
@@ -585,6 +592,7 @@ func (m *ContainerMesh) CheckConnections() bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -605,6 +613,7 @@ func (m *ContainerMesh) CheckKnownConnectionCosts() bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -626,6 +635,7 @@ func (m *ContainerMesh) CheckRoutes() bool {
 			}
 		}
 	}
+
 	return true
 }
 
@@ -639,6 +649,7 @@ func (m *ContainerMesh) CheckControlSockets() bool {
 		}
 		controller.Close()
 	}
+
 	return true
 }
 
@@ -657,6 +668,7 @@ func (m *ContainerMesh) WaitForReady(ctx context.Context) error {
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckRoutes) {
 		return errors.New("Timed out while waiting for routes to converge")
 	}
+
 	return nil
 }
 
@@ -670,5 +682,6 @@ func (m *ContainerMesh) Status() ([]*netceptor.Status, error) {
 		}
 		out = append(out, status)
 	}
+
 	return out, nil
 }

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -52,6 +52,7 @@ func handleError(err error, fatal bool) {
 // NewLibNode builds a node with the name passed as the argument.
 func NewLibNode(name string) *LibNode {
 	n1 := netceptor.New(context.Background(), name, nil)
+
 	return &LibNode{
 		NetceptorInstance: n1,
 		serverTLSConfigs:  make(map[string]*tls.Config),
@@ -67,6 +68,7 @@ func (n *LibNode) Dir() string {
 // Status returns the status of the node.
 func (n *LibNode) Status() (*netceptor.Status, error) {
 	status := n.NetceptorInstance.Status()
+
 	return &status, nil
 }
 
@@ -102,6 +104,7 @@ func (m *LibMesh) Nodes() map[string]Node {
 	for k, v := range m.nodes {
 		nodes[k] = v
 	}
+
 	return nodes
 }
 
@@ -114,6 +117,7 @@ func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]fl
 	}
 	n.Backends = append(n.Backends, b1)
 	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
+
 	return err
 }
 
@@ -125,6 +129,7 @@ func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) erro
 		return err
 	}
 	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
+
 	return err
 }
 
@@ -137,6 +142,7 @@ func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]fl
 	}
 	n.Backends = append(n.Backends, b1)
 	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
+
 	return err
 }
 
@@ -148,6 +154,7 @@ func (n *LibNode) UDPDial(address string, cost float64) error {
 		return err
 	}
 	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
+
 	return err
 }
 
@@ -161,6 +168,7 @@ func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[str
 	}
 	n.Backends = append(n.Backends, b1)
 	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
+
 	return err
 }
 
@@ -173,6 +181,7 @@ func (n *LibNode) WebsocketDial(address string, cost float64, tlsCfg *tls.Config
 		return err
 	}
 	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
+
 	return err
 }
 
@@ -493,6 +502,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 	}
 	mesh.nodes = nodes
 	mesh.MeshDefinition = &MeshDefinition
+
 	return mesh, nil
 }
 
@@ -529,16 +539,19 @@ func (m *LibMesh) CheckConnections() bool {
 			listenerYaml, ok := configItemYaml["tcp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 			listenerYaml, ok = configItemYaml["udp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 			listenerYaml, ok = configItemYaml["ws-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)
+
 				continue
 			}
 		}
@@ -555,6 +568,7 @@ func (m *LibMesh) CheckConnections() bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -575,6 +589,7 @@ func (m *LibMesh) CheckKnownConnectionCosts() bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -596,6 +611,7 @@ func (m *LibMesh) CheckRoutes() bool {
 			}
 		}
 	}
+
 	return true
 }
 
@@ -609,6 +625,7 @@ func (m *LibMesh) CheckControlSockets() bool {
 		}
 		controller.Close()
 	}
+
 	return true
 }
 
@@ -627,6 +644,7 @@ func (m *LibMesh) WaitForReady(ctx context.Context) error {
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckRoutes) {
 		return errors.New("Timed out while waiting for routes to converge")
 	}
+
 	return nil
 }
 
@@ -640,5 +658,6 @@ func (m *LibMesh) Status() ([]*netceptor.Status, error) {
 		}
 		out = append(out, status)
 	}
+
 	return out, nil
 }

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -6,18 +6,19 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/backends"
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/backends"
+	"github.com/project-receptor/receptor/pkg/controlsvc"
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"gopkg.in/yaml.v2"
 )
 
 // LibNode holds a Netceptor, this layer of abstraction might be unnecessary and
@@ -208,7 +209,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 		baseDir = filepath.Join(utils.TestBaseDir, dirSuffix)
 	}
 	// Ignore the error, if the dir already exists thats fine
-	err := os.MkdirAll(baseDir, 0755)
+	err := os.MkdirAll(baseDir, 0o755)
 	if err != nil {
 		return nil, err
 	}
@@ -227,7 +228,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 		if err != nil {
 			return nil, err
 		}
-		os.Mkdir(node.dir, 0755)
+		os.Mkdir(node.dir, 0o755)
 		for _, attr := range MeshDefinition.Nodes[k].Nodedef {
 			attrMap := attr.(map[interface{}]interface{})
 			for k, v := range attrMap {
@@ -339,12 +340,12 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 						if !ok {
 							return nil, errors.New("nodecost map key was not a string")
 						}
-						//vStr, ok := v.(string)
+						// vStr, ok := v.(string)
 						vFloat, ok := v.(float64)
 						if !ok {
 							return nil, errors.New("nodecost map value was not a float")
 						}
-						//vFloat, err := strconv.ParseFloat(vStr, 64)
+						// vFloat, err := strconv.ParseFloat(vStr, 64)
 						if err != nil {
 							return nil, err
 						}
@@ -485,7 +486,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 		node.controlSocket = filepath.Join(tempdir, "controlsock")
 
 		node.controlServer = controlsvc.New(true, node.NetceptorInstance)
-		err = node.controlServer.RunControlSvc(ctx, "control", nil, node.controlSocket, os.FileMode(0600), "", nil)
+		err = node.controlServer.RunControlSvc(ctx, "control", nil, node.controlSocket, os.FileMode(0o600), "", nil)
 		if err != nil {
 			return nil, err
 		}

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -334,7 +334,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 					}
 					nodeCost := make(map[string]float64)
 
-					// Use nodeCost map if possible
+					// Use nodeCost map if possible.
 					if vMap["nodecost"] != nil {
 						interfaceNodeCost := vMap["nodecost"].(map[interface{}]interface{})
 						for k, v := range interfaceNodeCost {
@@ -643,7 +643,7 @@ func (m *LibMesh) WaitForReady(ctx context.Context) error {
 
 // Status returns a list of statuses from the contained netceptors.
 func (m *LibMesh) Status() ([]*netceptor.Status, error) {
-	var out []*netceptor.Status
+	out := []*netceptor.Status{}
 	for _, node := range m.nodes {
 		status, err := node.Status()
 		if err != nil {

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -41,14 +41,6 @@ type LibMesh struct {
 	dir            string
 }
 
-// Error handler that gets called for backend errors.
-func handleError(err error, fatal bool) {
-	fmt.Printf("Error: %s\n", err)
-	if fatal {
-		os.Exit(1)
-	}
-}
-
 // NewLibNode builds a node with the name passed as the argument.
 func NewLibNode(name string) *LibNode {
 	n1 := netceptor.New(context.Background(), name, nil)

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -22,7 +22,7 @@ import (
 )
 
 // LibNode holds a Netceptor, this layer of abstraction might be unnecessary and
-// go away later
+// go away later.
 type LibNode struct {
 	dir                    string
 	NetceptorInstance      *netceptor.Netceptor
@@ -34,14 +34,14 @@ type LibNode struct {
 	clientTLSConfigs       map[string]*tls.Config
 }
 
-// LibMesh contains a list of Nodes and the yaml definition that created them
+// LibMesh contains a list of Nodes and the yaml definition that created them.
 type LibMesh struct {
 	nodes          map[string]*LibNode
 	MeshDefinition *YamlData
 	dir            string
 }
 
-// Error handler that gets called for backend errors
+// Error handler that gets called for backend errors.
 func handleError(err error, fatal bool) {
 	fmt.Printf("Error: %s\n", err)
 	if fatal {
@@ -49,7 +49,7 @@ func handleError(err error, fatal bool) {
 	}
 }
 
-// NewLibNode builds a node with the name passed as the argument
+// NewLibNode builds a node with the name passed as the argument.
 func NewLibNode(name string) *LibNode {
 	n1 := netceptor.New(context.Background(), name, nil)
 	return &LibNode{
@@ -59,44 +59,44 @@ func NewLibNode(name string) *LibNode {
 	}
 }
 
-// Dir returns the basedir which contains all of the node data
+// Dir returns the basedir which contains all of the node data.
 func (n *LibNode) Dir() string {
 	return n.dir
 }
 
-// Status returns the status of the node
+// Status returns the status of the node.
 func (n *LibNode) Status() (*netceptor.Status, error) {
 	status := n.NetceptorInstance.Status()
 	return &status, nil
 }
 
-// ControlSocket Returns the path to the controlsocket
+// ControlSocket Returns the path to the controlsocket.
 func (n *LibNode) ControlSocket() string {
 	return n.controlSocket
 }
 
-// Start is not implemented yet
+// Start is not implemented yet.
 func (n *LibNode) Start() error {
 	panic("Start is not yet implemented for LibNode")
 }
 
-// Shutdown is not implemented yet
+// Shutdown is not implemented yet.
 func (n *LibNode) Shutdown() {
 	panic("Shutdown is not yet implemented for LibNode")
 }
 
-// Destroy shuts the node down
+// Destroy shuts the node down.
 func (n *LibNode) Destroy() {
 	n.controlServerCanceller()
 	n.NetceptorInstance.Shutdown()
 }
 
-// WaitForShutdown Waits for the node to shutdown completely
+// WaitForShutdown Waits for the node to shutdown completely.
 func (n *LibNode) WaitForShutdown() {
 	n.NetceptorInstance.BackendWait()
 }
 
-// Nodes Returns a list of nodes
+// Nodes Returns a list of nodes.
 func (m *LibMesh) Nodes() map[string]Node {
 	nodes := make(map[string]Node)
 	for k, v := range m.nodes {
@@ -106,7 +106,7 @@ func (m *LibMesh) Nodes() map[string]Node {
 }
 
 // TCPListen helper function to create and start a TCPListener
-// This might be an unnecessary abstraction and maybe should be deleted
+// This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]float64, tlsCfg *tls.Config) error {
 	b1, err := backends.NewTCPListener(address, tlsCfg)
 	if err != nil {
@@ -118,7 +118,7 @@ func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]fl
 }
 
 // TCPDial helper function to create and start a TCPDialer
-// This might be an unnecessary abstraction and maybe should be deleted
+// This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) error {
 	b1, err := backends.NewTCPDialer(address, true, tlsCfg)
 	if err != nil {
@@ -129,7 +129,7 @@ func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) erro
 }
 
 // UDPListen helper function to create and start a UDPListener
-// This might be an unnecessary abstraction and maybe should be deleted
+// This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]float64) error {
 	b1, err := backends.NewUDPListener(address)
 	if err != nil {
@@ -141,7 +141,7 @@ func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]fl
 }
 
 // UDPDial helper function to create and start a UDPDialer
-// This might be an unnecessary abstraction and maybe should be deleted
+// This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) UDPDial(address string, cost float64) error {
 	b1, err := backends.NewUDPDialer(address, true)
 	if err != nil {
@@ -152,7 +152,7 @@ func (n *LibNode) UDPDial(address string, cost float64) error {
 }
 
 // WebsocketListen helper function to create and start a WebsocketListener
-// This might be an unnecessary abstraction and maybe should be deleted
+// This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[string]float64, tlsCfg *tls.Config) error {
 	// TODO: Add support for TLS
 	b1, err := backends.NewWebsocketListener(address, tlsCfg)
@@ -165,7 +165,7 @@ func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[str
 }
 
 // WebsocketDial helper function to create and start a WebsocketDialer
-// This might be an unnecessary abstraction and maybe should be deleted
+// This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) WebsocketDial(address string, cost float64, tlsCfg *tls.Config) error {
 	// TODO: Add support for TLS and extra headers
 	b1, err := backends.NewWebsocketDialer(address, nil, "", true)
@@ -176,13 +176,13 @@ func (n *LibNode) WebsocketDial(address string, cost float64, tlsCfg *tls.Config
 	return err
 }
 
-// Dir returns the basedir which contains all of the mesh data
+// Dir returns the basedir which contains all of the mesh data.
 func (m *LibMesh) Dir() string {
 	return m.dir
 }
 
 // NewLibMeshFromFile Takes a filename of a file with a yaml description of a mesh, loads it and
-// calls NewMeshFromYaml on it
+// calls NewMeshFromYaml on it.
 func NewLibMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 	yamlDat, err := ioutil.ReadFile(filename)
 	if err != nil {
@@ -200,7 +200,7 @@ func NewLibMeshFromFile(filename, dirSuffix string) (Mesh, error) {
 }
 
 // NewLibMeshFromYaml takes a yaml mesh description and returns a mesh of nodes
-// listening and dialing as defined in the yaml
+// listening and dialing as defined in the yaml.
 func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, error) {
 	mesh := &LibMesh{}
 	// Setup the mesh directory
@@ -496,14 +496,14 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 	return mesh, nil
 }
 
-// Destroy stops all running Netceptors and their backends
+// Destroy stops all running Netceptors and their backends.
 func (m *LibMesh) Destroy() {
 	for _, node := range m.nodes {
 		node.Destroy()
 	}
 }
 
-// WaitForShutdown Waits for all running Netceptors and their backends to stop
+// WaitForShutdown Waits for all running Netceptors and their backends to stop.
 func (m *LibMesh) WaitForShutdown() {
 	for _, node := range m.nodes {
 		node.WaitForShutdown()
@@ -511,7 +511,7 @@ func (m *LibMesh) WaitForShutdown() {
 }
 
 // CheckConnections returns true if the connections defined in our mesh definition are
-// consistent with the connections made by the nodes
+// consistent with the connections made by the nodes.
 func (m *LibMesh) CheckConnections() bool {
 	statusList, err := m.Status()
 	if err != nil {
@@ -558,7 +558,7 @@ func (m *LibMesh) CheckConnections() bool {
 	return false
 }
 
-// CheckKnownConnectionCosts returns true if every node has the same view of the connections in the mesh
+// CheckKnownConnectionCosts returns true if every node has the same view of the connections in the mesh.
 func (m *LibMesh) CheckKnownConnectionCosts() bool {
 	meshStatus, err := m.Status()
 	if err != nil {
@@ -578,7 +578,7 @@ func (m *LibMesh) CheckKnownConnectionCosts() bool {
 	return true
 }
 
-// CheckRoutes returns true if every node has a route to every other node
+// CheckRoutes returns true if every node has a route to every other node.
 func (m *LibMesh) CheckRoutes() bool {
 	meshStatus, err := m.Status()
 	if err != nil {
@@ -600,7 +600,7 @@ func (m *LibMesh) CheckRoutes() bool {
 }
 
 // CheckControlSockets Checks if the Control sockets in the mesh are all running and accepting
-// connections
+// connections.
 func (m *LibMesh) CheckControlSockets() bool {
 	for _, node := range m.nodes {
 		controller := receptorcontrol.New()
@@ -612,7 +612,7 @@ func (m *LibMesh) CheckControlSockets() bool {
 	return true
 }
 
-// WaitForReady Waits for connections and routes to converge
+// WaitForReady Waits for connections and routes to converge.
 func (m *LibMesh) WaitForReady(ctx context.Context) error {
 	sleepInterval := 100 * time.Millisecond
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckControlSockets) {
@@ -630,7 +630,7 @@ func (m *LibMesh) WaitForReady(ctx context.Context) error {
 	return nil
 }
 
-// Status returns a list of statuses from the contained netceptors
+// Status returns a list of statuses from the contained netceptors.
 func (m *LibMesh) Status() ([]*netceptor.Status, error) {
 	var out []*netceptor.Status
 	for _, node := range m.nodes {

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -552,15 +552,6 @@ func (m *LibMesh) CheckConnections() bool {
 				continue
 			}
 		}
-		for nodeID, node := range m.MeshDefinition.Nodes {
-			if nodeID == status.NodeID {
-				continue
-			}
-			for k := range node.Connections {
-				if k == status.NodeID {
-				}
-			}
-		}
 		if reflect.DeepEqual(actualConnections, expectedConnections) {
 			return true
 		}

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -331,7 +331,7 @@ func NewLibMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*LibMesh, er
 						cost = 1.0
 					}
 					if err != nil {
-						return nil, fmt.Errorf("Unable to determine cost for %s", k)
+						return nil, fmt.Errorf("unable to determine cost for %s", k)
 					}
 					nodeCost := make(map[string]float64)
 
@@ -420,13 +420,13 @@ func NewLibMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*LibMesh, er
 			if ok {
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 
 				cost := getListenerCost(listenerMap, k)
 
 				if err != nil {
-					return nil, fmt.Errorf("Unable to determine cost for %s", k)
+					return nil, fmt.Errorf("unable to determine cost for %s", k)
 				}
 
 				addr := listenerMap["bindaddr"].(string) + ":" + listenerMap["port"].(string)
@@ -439,12 +439,12 @@ func NewLibMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*LibMesh, er
 			if ok {
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 				cost := getListenerCost(listenerMap, k)
 
 				if err != nil {
-					return nil, fmt.Errorf("Unable to determine cost for %s", k)
+					return nil, fmt.Errorf("unable to determine cost for %s", k)
 				}
 
 				addr := listenerMap["bindaddr"].(string) + ":" + listenerMap["port"].(string)
@@ -457,13 +457,13 @@ func NewLibMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*LibMesh, er
 			if ok {
 				listenerMap, ok := listener.(map[interface{}]interface{})
 				if !ok {
-					return nil, errors.New("Listener object is not a map")
+					return nil, errors.New("listener object is not a map")
 				}
 
 				cost := getListenerCost(listenerMap, k)
 
 				if err != nil {
-					return nil, fmt.Errorf("Unable to determine cost for %s", k)
+					return nil, fmt.Errorf("unable to determine cost for %s", k)
 				}
 
 				proto := "ws://"
@@ -621,16 +621,16 @@ func (m *LibMesh) CheckControlSockets() bool {
 func (m *LibMesh) WaitForReady(ctx context.Context) error {
 	sleepInterval := 100 * time.Millisecond
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckControlSockets) {
-		return errors.New("Timed out while waiting for control sockets")
+		return errors.New("timed out while waiting for control sockets")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckConnections) {
-		return errors.New("Timed out while waiting for Connections")
+		return errors.New("timed out while waiting for Connections")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckKnownConnectionCosts) {
-		return errors.New("Timed out while checking Connection Costs")
+		return errors.New("timed out while checking Connection Costs")
 	}
 	if !utils.CheckUntilTimeout(ctx, sleepInterval, m.CheckRoutes) {
-		return errors.New("Timed out while waiting for routes to converge")
+		return errors.New("timed out while waiting for routes to converge")
 	}
 
 	return nil

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -335,22 +335,23 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 					nodeCost := make(map[string]float64)
 
 					// Use nodeCost map if possible
-					interfaceNodeCost, ok := vMap["nodecost"].(map[interface{}]interface{})
-					for k, v := range interfaceNodeCost {
-						kStr, ok := k.(string)
-						if !ok {
-							return nil, errors.New("nodecost map key was not a string")
+					if vMap["nodecost"] != nil {
+						interfaceNodeCost := vMap["nodecost"].(map[interface{}]interface{})
+						for k, v := range interfaceNodeCost {
+							key, ok := k.(string)
+							if !ok {
+								return nil, errors.New("nodecost map key was not a string")
+							}
+							value, ok := v.(float64)
+							if !ok {
+								return nil, errors.New("nodecost map value was not a float")
+							}
+							// vFloat, err := strconv.ParseFloat(vStr, 64)
+							if err != nil {
+								return nil, err
+							}
+							nodeCost[key] = value
 						}
-						// vStr, ok := v.(string)
-						vFloat, ok := v.(float64)
-						if !ok {
-							return nil, errors.New("nodecost map value was not a float")
-						}
-						// vFloat, err := strconv.ParseFloat(vStr, 64)
-						if err != nil {
-							return nil, err
-						}
-						nodeCost[kStr] = vFloat
 					}
 
 					bindaddr, ok := vMap["bindaddr"].(string)
@@ -410,7 +411,7 @@ func NewLibMeshFromYaml(MeshDefinition YamlData, dirSuffix string) (*LibMesh, er
 		for connNode, connYaml := range MeshDefinition.Nodes[k].Connections {
 			index := connYaml.Index
 			attr := MeshDefinition.Nodes[connNode].Nodedef[index]
-			attrMap, ok := attr.(map[interface{}]interface{})
+			attrMap := attr.(map[interface{}]interface{})
 			listener, ok := attrMap["tcp-listener"]
 			if ok {
 				listenerMap, ok := listener.(map[interface{}]interface{})
@@ -527,7 +528,7 @@ func (m *LibMesh) CheckConnections() bool {
 		expectedConnections := map[string]float64{}
 		for k, connYaml := range m.MeshDefinition.Nodes[status.NodeID].Connections {
 			index := connYaml.Index
-			configItemYaml, ok := m.MeshDefinition.Nodes[k].Nodedef[index].(map[interface{}]interface{})
+			configItemYaml := m.MeshDefinition.Nodes[k].Nodedef[index].(map[interface{}]interface{})
 			listenerYaml, ok := configItemYaml["tcp-listener"].(map[interface{}]interface{})
 			if ok {
 				expectedConnections[k] = getListenerCost(listenerYaml, status.NodeID)

--- a/tests/functional/lib/mesh/mesh.go
+++ b/tests/functional/lib/mesh/mesh.go
@@ -83,5 +83,6 @@ func getListenerCost(listenerYaml map[interface{}]interface{}, nodeID string) fl
 	} else {
 		cost = 1.0
 	}
+
 	return cost
 }

--- a/tests/functional/lib/mesh/mesh.go
+++ b/tests/functional/lib/mesh/mesh.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Node Defines the interface for nodes made using the CLI, Library, and
-// containers
+// containers.
 type Node interface {
 	Dir() string
 	Status() (*netceptor.Status, error)
@@ -19,7 +19,7 @@ type Node interface {
 }
 
 // Mesh Defines the interface for meshes made using the CLI, Library, and
-// containers
+// containers.
 type Mesh interface {
 	Dir() string
 	Nodes() map[string]Node
@@ -33,20 +33,20 @@ type Mesh interface {
 }
 
 // YamlData is the top level structure that defines how our yaml mesh data should be
-// represented
+// represented.
 type YamlData struct {
 	Nodes map[string]*YamlNode
 }
 
 // YamlConnection represents a meta connection object that gets used to
-// generate the peer config for receptor
+// generate the peer config for receptor.
 type YamlConnection struct {
 	Index int
 	TLS   string
 }
 
 // TCRuleYaml represents the rules to apply to the receptor container interface, note this only has
-// effect on docker receptor nodes, and podman receptor nodes run by root
+// effect on docker receptor nodes, and podman receptor nodes run by root.
 type TCRuleYaml struct {
 	// Adds delay to the interface
 	Delay string
@@ -62,7 +62,7 @@ type TCRuleYaml struct {
 	Corrupt string
 }
 
-// YamlNode describes how a single node should be represented in yaml
+// YamlNode describes how a single node should be represented in yaml.
 type YamlNode struct {
 	Connections map[string]YamlConnection
 	TCRules     *TCRuleYaml

--- a/tests/functional/lib/mesh/mesh.go
+++ b/tests/functional/lib/mesh/mesh.go
@@ -2,6 +2,7 @@ package mesh
 
 import (
 	"context"
+
 	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -143,8 +143,8 @@ func (r *ReceptorControl) ReadAndParseJSON() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	str := string(data)
-	if strings.HasPrefix(str, "ERROR") {
+
+	if str := string(data); strings.HasPrefix(str, "ERROR") {
 		return nil, fmt.Errorf(str)
 	}
 	jsonData := make(map[string]interface{})

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -115,7 +115,7 @@ func (r *ReceptorControl) handshake() error {
 	if err != nil {
 		return err
 	}
-	if matched != true {
+	if !matched {
 		return fmt.Errorf("failed control socket handshake, got: %s", data)
 	}
 
@@ -293,7 +293,7 @@ func (r *ReceptorControl) GetWorkStatus(unitID string) (*workceptor.StatusFileDa
 }
 
 func (r *ReceptorControl) getWorkList() (map[string]interface{}, error) {
-	_, err := r.WriteStr(fmt.Sprintf("work list\n"))
+	_, err := r.WriteStr("work list\n")
 	if err != nil {
 		return nil, err
 	}
@@ -399,11 +399,8 @@ func (r *ReceptorControl) AssertWorkTimedOut(ctx context.Context, unitID string)
 			return false
 		}
 		detail := workStatus.Detail
-		if strings.HasPrefix(detail, "Work unit expired on") {
-			return true
-		}
 
-		return false
+		return strings.HasPrefix(detail, "Work unit expired on")
 	}
 	if !assertWithTimeout(ctx, check) {
 		fmt.Errorf("Failed to assert work timed out or ctx timed out")
@@ -420,11 +417,8 @@ func (r *ReceptorControl) AssertWorkReleased(ctx context.Context, unitID string)
 			return false
 		}
 		_, ok := workList[unitID] // unitID should not be in list
-		if ok {
-			return false
-		}
 
-		return true
+		return !ok
 	}
 	if !assertWithTimeout(ctx, check) {
 		return fmt.Errorf("Failed to assert %s is released or ctx timed out", unitID)

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -60,7 +60,7 @@ func (r *ReceptorControl) Reconnect() error {
 			return err
 		}
 	} else {
-		return fmt.Errorf("Could not reconnect, no socketFilename")
+		return fmt.Errorf("could not reconnect, no socketFilename")
 	}
 
 	return nil
@@ -322,7 +322,7 @@ func (r *ReceptorControl) assertWorkState(ctx context.Context, unitID string, st
 // AssertWorkRunning waits until work status is running.
 func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateRunning) {
-		return fmt.Errorf("Failed to assert %s is running or ctx timed out", unitID)
+		return fmt.Errorf("failed to assert %s is running or ctx timed out", unitID)
 	}
 
 	return nil
@@ -331,7 +331,7 @@ func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, unitID string) 
 // AssertWorkPending waits until status is pending.
 func (r *ReceptorControl) AssertWorkPending(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStatePending) {
-		return fmt.Errorf("Failed to assert %s is pending or ctx timed out", unitID)
+		return fmt.Errorf("failed to assert %s is pending or ctx timed out", unitID)
 	}
 
 	return nil
@@ -340,7 +340,7 @@ func (r *ReceptorControl) AssertWorkPending(ctx context.Context, unitID string) 
 // AssertWorkSucceeded waits until status is successful.
 func (r *ReceptorControl) AssertWorkSucceeded(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateSucceeded) {
-		return fmt.Errorf("Failed to assert %s succeeded or ctx timed out", unitID)
+		return fmt.Errorf("failed to assert %s succeeded or ctx timed out", unitID)
 	}
 
 	return nil
@@ -349,7 +349,7 @@ func (r *ReceptorControl) AssertWorkSucceeded(ctx context.Context, unitID string
 // AssertWorkFailed waits until status is failed.
 func (r *ReceptorControl) AssertWorkFailed(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateFailed) {
-		return fmt.Errorf("Failed to assert %s failed or ctx timed out", unitID)
+		return fmt.Errorf("failed to assert %s failed or ctx timed out", unitID)
 	}
 
 	return nil
@@ -382,7 +382,7 @@ func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, unitID string
 		return false
 	}
 	if !assertWithTimeout(ctx, check) {
-		return fmt.Errorf("Failed to assert %s is cancelled or ctx timed out", unitID)
+		return fmt.Errorf("failed to assert %s is cancelled or ctx timed out", unitID)
 	}
 
 	return nil
@@ -403,7 +403,7 @@ func (r *ReceptorControl) AssertWorkTimedOut(ctx context.Context, unitID string)
 		return strings.HasPrefix(detail, "Work unit expired on")
 	}
 	if !assertWithTimeout(ctx, check) {
-		return fmt.Errorf("Failed to assert work timed out or ctx timed out")
+		return fmt.Errorf("failed to assert work timed out or ctx timed out")
 	}
 
 	return nil
@@ -421,7 +421,7 @@ func (r *ReceptorControl) AssertWorkReleased(ctx context.Context, unitID string)
 		return !ok
 	}
 	if !assertWithTimeout(ctx, check) {
-		return fmt.Errorf("Failed to assert %s is released or ctx timed out", unitID)
+		return fmt.Errorf("failed to assert %s is released or ctx timed out", unitID)
 	}
 
 	return nil

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -15,13 +15,13 @@ import (
 	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 )
 
-// ReceptorControl Connects to a control socket and provides basic commands
+// ReceptorControl Connects to a control socket and provides basic commands.
 type ReceptorControl struct {
 	socketConn     *net.UnixConn
 	socketFilename string
 }
 
-// New Returns an empty ReceptorControl
+// New Returns an empty ReceptorControl.
 func New() *ReceptorControl {
 	return &ReceptorControl{
 		socketConn:     nil,
@@ -30,7 +30,7 @@ func New() *ReceptorControl {
 }
 
 // Connect connects to the socket at the specified filename and checks the
-// handshake with the control service
+// handshake with the control service.
 func (r *ReceptorControl) Connect(filename string) error {
 	if r.socketConn != nil {
 		return errors.New("Tried to connect to a socket after already being connected to a socket")
@@ -51,7 +51,7 @@ func (r *ReceptorControl) Connect(filename string) error {
 	return nil
 }
 
-// Reconnect to unix socket
+// Reconnect to unix socket.
 func (r *ReceptorControl) Reconnect() error {
 	if r.socketFilename != "" {
 		err := r.Connect(r.socketFilename)
@@ -64,7 +64,7 @@ func (r *ReceptorControl) Reconnect() error {
 	return nil
 }
 
-// Read reads a line from the socket
+// Read reads a line from the socket.
 func (r *ReceptorControl) Read() ([]byte, error) {
 	dataBytes := make([]byte, 0)
 	buf := make([]byte, 1)
@@ -83,12 +83,12 @@ func (r *ReceptorControl) Read() ([]byte, error) {
 	return dataBytes, nil
 }
 
-// Write writes some data to the socket
+// Write writes some data to the socket.
 func (r *ReceptorControl) Write(data []byte) (int, error) {
 	return r.socketConn.Write(data)
 }
 
-// ReadStr reads some data from the socket and converts it to a string
+// ReadStr reads some data from the socket and converts it to a string.
 func (r *ReceptorControl) ReadStr() (string, error) {
 	data, err := r.Read()
 	if err != nil {
@@ -97,7 +97,7 @@ func (r *ReceptorControl) ReadStr() (string, error) {
 	return string(data), nil
 }
 
-// WriteStr writes string data to the socket
+// WriteStr writes string data to the socket.
 func (r *ReceptorControl) WriteStr(data string) (int, error) {
 	return r.Write([]byte(data))
 }
@@ -117,20 +117,20 @@ func (r *ReceptorControl) handshake() error {
 	return nil
 }
 
-// Close closes the connection to the socket
+// Close closes the connection to the socket.
 func (r *ReceptorControl) Close() error {
 	err := r.socketConn.Close()
 	r.socketConn = nil
 	return err
 }
 
-// CloseWrite closes the write side of the socket
+// CloseWrite closes the write side of the socket.
 func (r *ReceptorControl) CloseWrite() error {
 	err := r.socketConn.CloseWrite()
 	return err
 }
 
-// ReadAndParseJSON reads data from the socket and parses it as json
+// ReadAndParseJSON reads data from the socket and parses it as json.
 func (r *ReceptorControl) ReadAndParseJSON() (map[string]interface{}, error) {
 	data, err := r.Read()
 	if err != nil {
@@ -148,7 +148,7 @@ func (r *ReceptorControl) ReadAndParseJSON() (map[string]interface{}, error) {
 	return jsonData, nil
 }
 
-// Ping pings the specified node
+// Ping pings the specified node.
 func (r *ReceptorControl) Ping(node string) (string, error) {
 	_, err := r.WriteStr(fmt.Sprintf("ping %s\n", node))
 	if err != nil {
@@ -165,7 +165,7 @@ func (r *ReceptorControl) Ping(node string) (string, error) {
 	return fmt.Sprintf("Reply from %s in %s", jsonData["From"].(string), jsonData["TimeStr"].(string)), nil
 }
 
-// Status retrieves the status of the current node
+// Status retrieves the status of the current node.
 func (r *ReceptorControl) Status() (*netceptor.Status, error) {
 	_, err := r.WriteStr("status\n")
 	if err != nil {
@@ -210,7 +210,7 @@ func (r *ReceptorControl) getWorkSubmitResponse() (string, error) {
 	return unitID, nil
 }
 
-// WorkSubmitJSON begins work on remote node via JSON command
+// WorkSubmitJSON begins work on remote node via JSON command.
 func (r *ReceptorControl) WorkSubmitJSON(command string) (string, error) {
 	_, err := r.WriteStr(fmt.Sprintf("%s\n", command))
 	if err != nil {
@@ -223,7 +223,7 @@ func (r *ReceptorControl) WorkSubmitJSON(command string) (string, error) {
 	return unitID, nil
 }
 
-// WorkSubmit begins work on remote node
+// WorkSubmit begins work on remote node.
 func (r *ReceptorControl) WorkSubmit(node, workType string) (string, error) {
 	_, err := r.WriteStr(fmt.Sprintf("work submit %s %s\n", node, workType))
 	if err != nil {
@@ -236,12 +236,12 @@ func (r *ReceptorControl) WorkSubmit(node, workType string) (string, error) {
 	return unitID, nil
 }
 
-// WorkStart begins work on local node
+// WorkStart begins work on local node.
 func (r *ReceptorControl) WorkStart(workType string) (string, error) {
 	return r.WorkSubmit("localhost", workType)
 }
 
-// WorkCancel cancels work
+// WorkCancel cancels work.
 func (r *ReceptorControl) WorkCancel(unitID string) (map[string]interface{}, error) {
 	_, err := r.WriteStr(fmt.Sprintf("work cancel %s\n", unitID))
 	if err != nil {
@@ -250,7 +250,7 @@ func (r *ReceptorControl) WorkCancel(unitID string) (map[string]interface{}, err
 	return r.ReadAndParseJSON()
 }
 
-// WorkRelease cancels and deletes work
+// WorkRelease cancels and deletes work.
 func (r *ReceptorControl) WorkRelease(unitID string) (map[string]interface{}, error) {
 	_, err := r.WriteStr(fmt.Sprintf("work release %s\n", unitID))
 	if err != nil {
@@ -259,7 +259,7 @@ func (r *ReceptorControl) WorkRelease(unitID string) (map[string]interface{}, er
 	return r.ReadAndParseJSON()
 }
 
-// GetWorkStatus returns JSON of status file for a given unitID
+// GetWorkStatus returns JSON of status file for a given unitID.
 func (r *ReceptorControl) GetWorkStatus(unitID string) (*workceptor.StatusFileData, error) {
 	status := &workceptor.StatusFileData{}
 	_, err := r.WriteStr(fmt.Sprintf("work status %s\n", unitID))
@@ -302,7 +302,7 @@ func (r *ReceptorControl) assertWorkState(ctx context.Context, unitID string, st
 	return assertWithTimeout(ctx, check)
 }
 
-// AssertWorkRunning waits until work status is running
+// AssertWorkRunning waits until work status is running.
 func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateRunning) {
 		return fmt.Errorf("Failed to assert %s is running or ctx timed out", unitID)
@@ -310,7 +310,7 @@ func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, unitID string) 
 	return nil
 }
 
-// AssertWorkPending waits until status is pending
+// AssertWorkPending waits until status is pending.
 func (r *ReceptorControl) AssertWorkPending(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStatePending) {
 		return fmt.Errorf("Failed to assert %s is pending or ctx timed out", unitID)
@@ -318,7 +318,7 @@ func (r *ReceptorControl) AssertWorkPending(ctx context.Context, unitID string) 
 	return nil
 }
 
-// AssertWorkSucceeded waits until status is successful
+// AssertWorkSucceeded waits until status is successful.
 func (r *ReceptorControl) AssertWorkSucceeded(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateSucceeded) {
 		return fmt.Errorf("Failed to assert %s succeeded or ctx timed out", unitID)
@@ -326,7 +326,7 @@ func (r *ReceptorControl) AssertWorkSucceeded(ctx context.Context, unitID string
 	return nil
 }
 
-// AssertWorkFailed waits until status is failed
+// AssertWorkFailed waits until status is failed.
 func (r *ReceptorControl) AssertWorkFailed(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateFailed) {
 		return fmt.Errorf("Failed to assert %s failed or ctx timed out", unitID)
@@ -334,7 +334,7 @@ func (r *ReceptorControl) AssertWorkFailed(ctx context.Context, unitID string) e
 	return nil
 }
 
-// AssertWorkCancelled waits until work status is cancelled
+// AssertWorkCancelled waits until work status is cancelled.
 func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, unitID string) error {
 	check := func() bool {
 		workStatus, err := r.GetWorkStatus(unitID)
@@ -365,7 +365,7 @@ func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, unitID string
 	return nil
 }
 
-// AssertWorkTimedOut asserts that work failed
+// AssertWorkTimedOut asserts that work failed.
 func (r *ReceptorControl) AssertWorkTimedOut(ctx context.Context, unitID string) error {
 	check := func() bool {
 		workStatus, err := r.GetWorkStatus(unitID)
@@ -387,7 +387,7 @@ func (r *ReceptorControl) AssertWorkTimedOut(ctx context.Context, unitID string)
 	return nil
 }
 
-// AssertWorkReleased asserts that work is not in work list
+// AssertWorkReleased asserts that work is not in work list.
 func (r *ReceptorControl) AssertWorkReleased(ctx context.Context, unitID string) error {
 	check := func() bool {
 		workList, err := r.getWorkList()
@@ -438,7 +438,7 @@ func (r *ReceptorControl) getWorkResults(unitID string, readSize int) ([]byte, e
 	return buf, nil
 }
 
-// AssertWorkResults makes sure results match expected byte array
+// AssertWorkResults makes sure results match expected byte array.
 func (r *ReceptorControl) AssertWorkResults(unitID string, expectedResults []byte) error {
 	workResults, err := r.getWorkResults(unitID, len(expectedResults))
 	if err != nil {

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -403,7 +403,7 @@ func (r *ReceptorControl) AssertWorkTimedOut(ctx context.Context, unitID string)
 		return strings.HasPrefix(detail, "Work unit expired on")
 	}
 	if !assertWithTimeout(ctx, check) {
-		fmt.Errorf("Failed to assert work timed out or ctx timed out")
+		return fmt.Errorf("Failed to assert work timed out or ctx timed out")
 	}
 
 	return nil

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/workceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 	"net"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/project-receptor/receptor/pkg/workceptor"
+	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 )
 
 // ReceptorControl Connects to a control socket and provides basic commands
@@ -301,7 +302,7 @@ func (r *ReceptorControl) assertWorkState(ctx context.Context, unitID string, st
 	return assertWithTimeout(ctx, check)
 }
 
-//AssertWorkRunning waits until work status is running
+// AssertWorkRunning waits until work status is running
 func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, unitID string) error {
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateRunning) {
 		return fmt.Errorf("Failed to assert %s is running or ctx timed out", unitID)
@@ -333,7 +334,7 @@ func (r *ReceptorControl) AssertWorkFailed(ctx context.Context, unitID string) e
 	return nil
 }
 
-//AssertWorkCancelled waits until work status is cancelled
+// AssertWorkCancelled waits until work status is cancelled
 func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, unitID string) error {
 	check := func() bool {
 		workStatus, err := r.GetWorkStatus(unitID)

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -33,7 +33,7 @@ func New() *ReceptorControl {
 // handshake with the control service.
 func (r *ReceptorControl) Connect(filename string) error {
 	if r.socketConn != nil {
-		return errors.New("Tried to connect to a socket after already being connected to a socket")
+		return errors.New("tried to connect to a socket after already being connected to a socket")
 	}
 	addr, err := net.ResolveUnixAddr("unix", filename)
 	if err != nil {
@@ -48,6 +48,7 @@ func (r *ReceptorControl) Connect(filename string) error {
 		return err
 	}
 	r.socketFilename = filename
+
 	return nil
 }
 
@@ -61,6 +62,7 @@ func (r *ReceptorControl) Reconnect() error {
 	} else {
 		return fmt.Errorf("Could not reconnect, no socketFilename")
 	}
+
 	return nil
 }
 
@@ -80,6 +82,7 @@ func (r *ReceptorControl) Read() ([]byte, error) {
 			dataBytes = append(dataBytes, buf[0])
 		}
 	}
+
 	return dataBytes, nil
 }
 
@@ -94,6 +97,7 @@ func (r *ReceptorControl) ReadStr() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return string(data), nil
 }
 
@@ -112,8 +116,9 @@ func (r *ReceptorControl) handshake() error {
 		return err
 	}
 	if matched != true {
-		return fmt.Errorf("Failed control socket handshake, got: %s", data)
+		return fmt.Errorf("failed control socket handshake, got: %s", data)
 	}
+
 	return nil
 }
 
@@ -121,12 +126,14 @@ func (r *ReceptorControl) handshake() error {
 func (r *ReceptorControl) Close() error {
 	err := r.socketConn.Close()
 	r.socketConn = nil
+
 	return err
 }
 
 // CloseWrite closes the write side of the socket.
 func (r *ReceptorControl) CloseWrite() error {
 	err := r.socketConn.CloseWrite()
+
 	return err
 }
 
@@ -145,6 +152,7 @@ func (r *ReceptorControl) ReadAndParseJSON() (map[string]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return jsonData, nil
 }
 
@@ -162,6 +170,7 @@ func (r *ReceptorControl) Ping(node string) (string, error) {
 	if !success {
 		return "", errors.New(jsonData["Error"].(string))
 	}
+
 	return fmt.Sprintf("Reply from %s in %s", jsonData["From"].(string), jsonData["TimeStr"].(string)), nil
 }
 
@@ -207,6 +216,7 @@ func (r *ReceptorControl) getWorkSubmitResponse() (string, error) {
 		return "", err
 	}
 	unitID := fmt.Sprintf("%v", response["unitid"])
+
 	return unitID, nil
 }
 
@@ -220,6 +230,7 @@ func (r *ReceptorControl) WorkSubmitJSON(command string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return unitID, nil
 }
 
@@ -233,6 +244,7 @@ func (r *ReceptorControl) WorkSubmit(node, workType string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return unitID, nil
 }
 
@@ -247,6 +259,7 @@ func (r *ReceptorControl) WorkCancel(unitID string) (map[string]interface{}, err
 	if err != nil {
 		return nil, err
 	}
+
 	return r.ReadAndParseJSON()
 }
 
@@ -256,6 +269,7 @@ func (r *ReceptorControl) WorkRelease(unitID string) (map[string]interface{}, er
 	if err != nil {
 		return nil, err
 	}
+
 	return r.ReadAndParseJSON()
 }
 
@@ -274,6 +288,7 @@ func (r *ReceptorControl) GetWorkStatus(unitID string) (*workceptor.StatusFileDa
 	if err != nil {
 		return status, err
 	}
+
 	return status, nil
 }
 
@@ -297,8 +312,10 @@ func assertWithTimeout(ctx context.Context, check func() bool) bool {
 func (r *ReceptorControl) assertWorkState(ctx context.Context, unitID string, state int) bool {
 	check := func() bool {
 		workStatus, _ := r.GetWorkStatus(unitID)
+
 		return workStatus.State == state
 	}
+
 	return assertWithTimeout(ctx, check)
 }
 
@@ -307,6 +324,7 @@ func (r *ReceptorControl) AssertWorkRunning(ctx context.Context, unitID string) 
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateRunning) {
 		return fmt.Errorf("Failed to assert %s is running or ctx timed out", unitID)
 	}
+
 	return nil
 }
 
@@ -315,6 +333,7 @@ func (r *ReceptorControl) AssertWorkPending(ctx context.Context, unitID string) 
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStatePending) {
 		return fmt.Errorf("Failed to assert %s is pending or ctx timed out", unitID)
 	}
+
 	return nil
 }
 
@@ -323,6 +342,7 @@ func (r *ReceptorControl) AssertWorkSucceeded(ctx context.Context, unitID string
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateSucceeded) {
 		return fmt.Errorf("Failed to assert %s succeeded or ctx timed out", unitID)
 	}
+
 	return nil
 }
 
@@ -331,6 +351,7 @@ func (r *ReceptorControl) AssertWorkFailed(ctx context.Context, unitID string) e
 	if !r.assertWorkState(ctx, unitID, workceptor.WorkStateFailed) {
 		return fmt.Errorf("Failed to assert %s failed or ctx timed out", unitID)
 	}
+
 	return nil
 }
 
@@ -357,11 +378,13 @@ func (r *ReceptorControl) AssertWorkCancelled(ctx context.Context, unitID string
 				return true
 			}
 		}
+
 		return false
 	}
 	if !assertWithTimeout(ctx, check) {
 		return fmt.Errorf("Failed to assert %s is cancelled or ctx timed out", unitID)
 	}
+
 	return nil
 }
 
@@ -379,11 +402,13 @@ func (r *ReceptorControl) AssertWorkTimedOut(ctx context.Context, unitID string)
 		if strings.HasPrefix(detail, "Work unit expired on") {
 			return true
 		}
+
 		return false
 	}
 	if !assertWithTimeout(ctx, check) {
 		fmt.Errorf("Failed to assert work timed out or ctx timed out")
 	}
+
 	return nil
 }
 
@@ -398,6 +423,7 @@ func (r *ReceptorControl) AssertWorkReleased(ctx context.Context, unitID string)
 		if ok {
 			return false
 		}
+
 		return true
 	}
 	if !assertWithTimeout(ctx, check) {
@@ -435,6 +461,7 @@ func (r *ReceptorControl) getWorkResults(unitID string, readSize int) ([]byte, e
 	if err != nil {
 		return nil, err
 	}
+
 	return buf, nil
 }
 
@@ -447,5 +474,6 @@ func (r *ReceptorControl) AssertWorkResults(unitID string, expectedResults []byt
 	if string(expectedResults) != string(workResults) {
 		return fmt.Errorf("work results did not match expected results")
 	}
+
 	return nil
 }

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -24,15 +24,15 @@ var (
 	tcpPortPool  []int
 )
 
-// TestBaseDir holds the base directory that all permanent test logs should go in
+// TestBaseDir holds the base directory that all permanent test logs should go in.
 var TestBaseDir string
 
 // ControlSocketBaseDir holds the base directory for controlsockets, control sockets
 // have a limited path length, therefore we cant always put them along side the
-// node they are attached to
+// node they are attached to.
 var ControlSocketBaseDir string
 
-// CertBaseDir specifies the directory that generated certs get put in
+// CertBaseDir specifies the directory that generated certs get put in.
 var CertBaseDir string
 
 func init() {
@@ -71,7 +71,7 @@ func makeRange(start, stop, step int) ([]int, error) {
 // There's a race condition here where the port we grab *could* later be
 // grabbed by another process/thread before we use it, if you rely on this you
 // should handle a case where the port given is in use before you are able to
-// open it
+// open it.
 func ReserveTCPPort() int {
 	tcpPortMutex.Lock()
 	defer tcpPortMutex.Unlock()
@@ -94,7 +94,7 @@ func ReserveTCPPort() int {
 }
 
 // FreeTCPPort puts a port back into the pool such that it can be allocated
-// later
+// later.
 func FreeTCPPort(portNum int) {
 	tcpPortMutex.Lock()
 	defer tcpPortMutex.Unlock()
@@ -106,7 +106,7 @@ func FreeTCPPort(portNum int) {
 // There's a race condition here where the port we grab *could* later be
 // grabbed by another process/thread before we use it, if you rely on this you
 // should handle a case where the port given is in use before you are able to
-// open it
+// open it.
 func ReserveUDPPort() int {
 	udpPortMutex.Lock()
 	defer udpPortMutex.Unlock()
@@ -135,7 +135,7 @@ func ReserveUDPPort() int {
 }
 
 // FreeUDPPort puts a port back into the pool such that it can be allocated
-// later
+// later.
 func FreeUDPPort(portNum int) {
 	udpPortMutex.Lock()
 	defer udpPortMutex.Unlock()
@@ -143,7 +143,7 @@ func FreeUDPPort(portNum int) {
 	udpPortPool = append(udpPortPool, portNum)
 }
 
-// GenerateCA generates a CA certificate and key
+// GenerateCA generates a CA certificate and key.
 func GenerateCA(name, commonName string) (string, string, error) {
 	dir, err := ioutil.TempDir(CertBaseDir, "")
 	if err != nil {
@@ -168,7 +168,7 @@ func GenerateCA(name, commonName string) (string, string, error) {
 	return keyPath, crtPath, nil
 }
 
-// GenerateCert generates a private and public key for testing in the directory specified
+// GenerateCert generates a private and public key for testing in the directory specified.
 func GenerateCert(name, commonName string, DNSNames, NodeIDs []string) (string, string, error) {
 	dir, err := ioutil.TempDir(CertBaseDir, "")
 	if err != nil {
@@ -212,7 +212,7 @@ func GenerateCert(name, commonName string, DNSNames, NodeIDs []string) (string, 
 }
 
 // GenerateCertWithCA generates a private and public key for testing in the directory
-// specified using the ca specified
+// specified using the ca specified.
 func GenerateCertWithCA(name, caKeyPath, caCrtPath, commonName string, DNSNames, NodeIDs []string) (string, string, error) {
 	dir, err := ioutil.TempDir(CertBaseDir, "")
 	if err != nil {
@@ -259,7 +259,7 @@ func GenerateCertWithCA(name, caKeyPath, caCrtPath, commonName string, DNSNames,
 }
 
 // CheckUntilTimeout Polls the check function until the context expires, in
-// which case it returns false
+// which case it returns false.
 func CheckUntilTimeout(ctx context.Context, interval time.Duration, check func() bool) bool {
 	for ready := check(); !ready; ready = check() {
 		if ctx.Err() != nil {
@@ -272,7 +272,7 @@ func CheckUntilTimeout(ctx context.Context, interval time.Duration, check func()
 
 // CheckUntilTimeoutWithErr does the same as CheckUntilTimeout but requires the
 // check function returns (bool, error), and will return an error immediately
-// if the check function returns an error
+// if the check function returns an error.
 func CheckUntilTimeoutWithErr(ctx context.Context, interval time.Duration, check func() (bool, error)) (bool, error) {
 	for ready, err := check(); !ready; ready, err = check() {
 		if err != nil {

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"errors"
-	"github.com/project-receptor/receptor/pkg/certificates"
 	"io/ioutil"
 	"net"
 	"os"
@@ -11,13 +10,19 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/project-receptor/receptor/pkg/certificates"
 )
 
-var udpPortMutex sync.Mutex
-var udpPortPool []int
+var (
+	udpPortMutex sync.Mutex
+	udpPortPool  []int
+)
 
-var tcpPortMutex sync.Mutex
-var tcpPortPool []int
+var (
+	tcpPortMutex sync.Mutex
+	tcpPortPool  []int
+)
 
 // TestBaseDir holds the base directory that all permanent test logs should go in
 var TestBaseDir string
@@ -38,11 +43,11 @@ func init() {
 	defer tcpPortMutex.Unlock()
 	tcpPortPool, _ = makeRange(10000, 65000, 1)
 	TestBaseDir = filepath.Join(os.TempDir(), "receptor-testing")
-	os.Mkdir(TestBaseDir, 0700)
+	os.Mkdir(TestBaseDir, 0o700)
 	ControlSocketBaseDir = filepath.Join(TestBaseDir, "controlsockets")
-	os.Mkdir(ControlSocketBaseDir, 0700)
+	os.Mkdir(ControlSocketBaseDir, 0o700)
 	CertBaseDir = filepath.Join(TestBaseDir, "receptor-testing-certs")
-	os.Mkdir(CertBaseDir, 0700)
+	os.Mkdir(CertBaseDir, 0o700)
 }
 
 func makeRange(start, stop, step int) ([]int, error) {
@@ -110,7 +115,7 @@ func ReserveUDPPort() int {
 		portNum := udpPortPool[len(udpPortPool)-1]
 		udpPortPool = udpPortPool[:len(udpPortPool)-1]
 		portStr := strconv.Itoa(portNum)
-		//udpPort, err := net.Listen("udp", ":"+portStr)
+		// udpPort, err := net.Listen("udp", ":"+portStr)
 		udpAddr, err := net.ResolveUDPAddr("udp", ":"+portStr)
 		if err != nil {
 			panic("err")

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -287,7 +287,7 @@ func CheckUntilTimeoutWithErr(ctx context.Context, interval time.Duration, check
 			return false, err
 		}
 		if ctx.Err() != nil {
-			return false, nil
+			return false, nil //nolint:nilerr // Make this nice later.
 		}
 		time.Sleep(interval)
 	}

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -63,6 +63,7 @@ func makeRange(start, stop, step int) ([]int, error) {
 	} else {
 		return nil, errors.New("Unable to make range")
 	}
+
 	return out, nil
 }
 
@@ -84,6 +85,7 @@ func ReserveTCPPort() int {
 		if err == nil {
 			tcpPort.Close()
 			tcpPortPool = tcpPortPool[:len(tcpPortPool)-1]
+
 			return portNum
 		}
 		// If we havent reserved this port but it's taken, prepend it to
@@ -125,6 +127,7 @@ func ReserveUDPPort() int {
 		if err == nil {
 			udpConn.Close()
 			udpPortPool = udpPortPool[:len(udpPortPool)-1]
+
 			return portNum
 		}
 		// If we havent reserved this port but it's taken, prepend it to
@@ -165,6 +168,7 @@ func GenerateCA(name, commonName string) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+
 	return keyPath, crtPath, nil
 }
 
@@ -208,6 +212,7 @@ func GenerateCert(name, commonName string, DNSNames, NodeIDs []string) (string, 
 	if err != nil {
 		return "", "", err
 	}
+
 	return keyPath, crtPath, nil
 }
 
@@ -255,6 +260,7 @@ func GenerateCertWithCA(name, caKeyPath, caCrtPath, commonName string, DNSNames,
 	if err != nil {
 		return "", "", err
 	}
+
 	return keyPath, crtPath, nil
 }
 
@@ -267,6 +273,7 @@ func CheckUntilTimeout(ctx context.Context, interval time.Duration, check func()
 		}
 		time.Sleep(interval)
 	}
+
 	return true
 }
 
@@ -283,5 +290,6 @@ func CheckUntilTimeoutWithErr(ctx context.Context, interval time.Duration, check
 		}
 		time.Sleep(interval)
 	}
+
 	return true, nil
 }

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -52,15 +52,16 @@ func init() {
 
 func makeRange(start, stop, step int) ([]int, error) {
 	out := []int{}
-	if step > 0 && start < stop {
+	switch {
+	case step > 0 && start < stop:
 		for ; start < stop; start += step {
 			out = append(out, start)
 		}
-	} else if step < 0 && start > stop {
+	case step < 0 && start > stop:
 		for ; start > stop; start += step {
 			out = append(out, start)
 		}
-	} else {
+	default:
 		return nil, errors.New("Unable to make range")
 	}
 
@@ -173,7 +174,7 @@ func GenerateCA(name, commonName string) (string, string, error) {
 }
 
 // GenerateCert generates a private and public key for testing in the directory specified.
-func GenerateCert(name, commonName string, DNSNames, NodeIDs []string) (string, string, error) {
+func GenerateCert(name, commonName string, dnsNames, nodeIDs []string) (string, string, error) {
 	dir, err := ioutil.TempDir(CertBaseDir, "")
 	if err != nil {
 		return "", "", err
@@ -191,8 +192,8 @@ func GenerateCert(name, commonName string, DNSNames, NodeIDs []string) (string, 
 		CommonName: commonName,
 		Bits:       2048,
 		CertNames: certificates.CertNames{
-			DNSNames: DNSNames,
-			NodeIDs:  NodeIDs,
+			DNSNames: dnsNames,
+			NodeIDs:  nodeIDs,
 		},
 	})
 	if err != nil {
@@ -218,7 +219,7 @@ func GenerateCert(name, commonName string, DNSNames, NodeIDs []string) (string, 
 
 // GenerateCertWithCA generates a private and public key for testing in the directory
 // specified using the ca specified.
-func GenerateCertWithCA(name, caKeyPath, caCrtPath, commonName string, DNSNames, NodeIDs []string) (string, string, error) {
+func GenerateCertWithCA(name, caKeyPath, caCrtPath, commonName string, dnsNames, nodeIDs []string) (string, string, error) {
 	dir, err := ioutil.TempDir(CertBaseDir, "")
 	if err != nil {
 		return "", "", err
@@ -239,8 +240,8 @@ func GenerateCertWithCA(name, caKeyPath, caCrtPath, commonName string, DNSNames,
 		CommonName: commonName,
 		Bits:       2048,
 		CertNames: certificates.CertNames{
-			DNSNames: DNSNames,
-			NodeIDs:  NodeIDs,
+			DNSNames: dnsNames,
+			NodeIDs:  nodeIDs,
 		},
 	})
 	if err != nil {

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -62,7 +62,7 @@ func makeRange(start, stop, step int) ([]int, error) {
 			out = append(out, start)
 		}
 	default:
-		return nil, errors.New("Unable to make range")
+		return nil, errors.New("unable to make range")
 	}
 
 	return out, nil

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -252,6 +252,7 @@ func TestMeshShutdown(t *testing.T) {
 				}
 				if !strings.Contains(out.String(), pidString) {
 					done = true
+
 					break
 				}
 				time.Sleep(100 * time.Millisecond)

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -4,10 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	_ "github.com/fortytw2/leaktest"
-	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -15,6 +11,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	_ "github.com/fortytw2/leaktest"
+	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
+	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
+	"gopkg.in/yaml.v2"
 )
 
 // Test that a mesh starts and that connections are what we expect and that
@@ -213,7 +214,7 @@ func TestTraceroute(t *testing.T) {
 
 // Test that a mesh starts and that connections are what we expect
 func TestMeshShutdown(t *testing.T) {
-	//defer leaktest.Check(t)()
+	// defer leaktest.Check(t)()
 	testTable := []struct {
 		filename string
 	}{
@@ -287,7 +288,7 @@ func TestCosts(t *testing.T) {
 	}
 	data.Nodes["node2"] = &mesh.YamlNode{
 		Connections: map[string]mesh.YamlConnection{
-			"node1": mesh.YamlConnection{
+			"node1": {
 				Index: 0,
 			},
 		},
@@ -295,7 +296,7 @@ func TestCosts(t *testing.T) {
 	}
 	data.Nodes["node3"] = &mesh.YamlNode{
 		Connections: map[string]mesh.YamlConnection{
-			"node1": mesh.YamlConnection{
+			"node1": {
 				Index: 0,
 			},
 		},
@@ -303,7 +304,7 @@ func TestCosts(t *testing.T) {
 	}
 	data.Nodes["node4"] = &mesh.YamlNode{
 		Connections: map[string]mesh.YamlConnection{
-			"node1": mesh.YamlConnection{
+			"node1": {
 				Index: 0,
 			},
 		},
@@ -338,7 +339,6 @@ func TestCosts(t *testing.T) {
 		}
 		controller.Close()
 	}
-
 }
 
 func TestDuplicateNodes(t *testing.T) {
@@ -359,7 +359,7 @@ func TestDuplicateNodes(t *testing.T) {
 	}
 	data.Nodes["node2"] = &mesh.YamlNode{
 		Connections: map[string]mesh.YamlConnection{
-			"node1": mesh.YamlConnection{
+			"node1": {
 				Index: 0,
 			},
 		},
@@ -371,7 +371,7 @@ func TestDuplicateNodes(t *testing.T) {
 	}
 	data.Nodes["node1_dup"] = &mesh.YamlNode{
 		Connections: map[string]mesh.YamlConnection{
-			"node2": mesh.YamlConnection{
+			"node2": {
 				Index: 0,
 			},
 		},

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -152,6 +152,9 @@ func TestTraceroute(t *testing.T) {
 			controlNode := m.Nodes()["controller"]
 			controller := receptorcontrol.New()
 			err = controller.Connect(controlNode.ControlSocket())
+			if err != nil {
+				t.Fatal(err)
+			}
 			_, err = controller.WriteStr("traceroute node7\n")
 			if err != nil {
 				t.Fatal(err)

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Test that a mesh starts and that connections are what we expect and that
-// each node's view of the mesh converges
+// each node's view of the mesh converges.
 func TestMeshStartup(t *testing.T) {
 	testTable := []struct {
 		filename string
@@ -74,7 +74,7 @@ func TestMeshStartup(t *testing.T) {
 	}
 }
 
-// Test that a mesh starts and that connections are what we expect
+// Test that a mesh starts and that connections are what we expect.
 func TestMeshConnections(t *testing.T) {
 	testTable := []struct {
 		filename string
@@ -122,7 +122,7 @@ func TestMeshConnections(t *testing.T) {
 	}
 }
 
-// Test that traceroute works
+// Test that traceroute works.
 func TestTraceroute(t *testing.T) {
 	testTable := []struct {
 		filename string
@@ -212,7 +212,7 @@ func TestTraceroute(t *testing.T) {
 	}
 }
 
-// Test that a mesh starts and that connections are what we expect
+// Test that a mesh starts and that connections are what we expect.
 func TestMeshShutdown(t *testing.T) {
 	// defer leaktest.Check(t)()
 	testTable := []struct {

--- a/tests/functional/mesh/tls_test.go
+++ b/tests/functional/mesh/tls_test.go
@@ -2,12 +2,13 @@ package mesh
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	_ "github.com/fortytw2/leaktest"
 	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
 	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
 	"github.com/project-receptor/receptor/tests/functional/lib/utils"
-	"testing"
-	"time"
 )
 
 func TestTCPSSLConnections(t *testing.T) {
@@ -62,7 +63,7 @@ func TestTCPSSLConnections(t *testing.T) {
 			}
 			data.Nodes["node2"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node1": mesh.YamlConnection{
+					"node1": {
 						Index: 1,
 						TLS:   "client-cert2",
 					},
@@ -92,7 +93,7 @@ func TestTCPSSLConnections(t *testing.T) {
 			}
 			data.Nodes["node3"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node2": mesh.YamlConnection{
+					"node2": {
 						Index: 2,
 						TLS:   "client-secure",
 					},
@@ -192,7 +193,7 @@ func TestTCPSSLClientAuthFailNoKey(t *testing.T) {
 			}
 			data.Nodes["node2"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node1": mesh.YamlConnection{
+					"node1": {
 						Index: 1,
 						TLS:   "client-insecure",
 					},
@@ -281,7 +282,7 @@ func TestTCPSSLClientAuthFailBadKey(t *testing.T) {
 			}
 			data.Nodes["node2"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node1": mesh.YamlConnection{
+					"node1": {
 						Index: 1,
 						TLS:   "client-insecure",
 					},
@@ -354,7 +355,7 @@ func TestTCPSSLServerAuthFailNoKey(t *testing.T) {
 			}
 			data.Nodes["node2"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node1": mesh.YamlConnection{
+					"node1": {
 						Index: 1,
 						TLS:   "client-secure",
 					},
@@ -441,7 +442,7 @@ func TestTCPSSLServerAuthFailBadKey(t *testing.T) {
 			}
 			data.Nodes["node2"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node1": mesh.YamlConnection{
+					"node1": {
 						Index: 1,
 						TLS:   "client-secure",
 					},

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -185,6 +185,7 @@ func TestWork(t *testing.T) {
 				}
 				controllers[k] = controller
 			}
+
 			return controllers, m, expectedResults
 		}
 
@@ -205,11 +206,13 @@ func TestWork(t *testing.T) {
 				if os.IsNotExist(err) {
 					return true
 				}
+
 				return false
 			}
 			if !utils.CheckUntilTimeout(ctx, 3000*time.Millisecond, check) {
 				return fmt.Errorf("unitID %s on %s did not release", unitID, nodeID)
 			}
+
 			return nil
 		}
 
@@ -224,11 +227,13 @@ func TestWork(t *testing.T) {
 				if int(fstat.Size()) >= waitUntilSize {
 					return true
 				}
+
 				return false
 			}
 			if !utils.CheckUntilTimeout(ctx, 3000*time.Millisecond, check) {
 				return fmt.Errorf("file size not correct for %s", stdoutFilename)
 			}
+
 			return nil
 		}
 
@@ -590,7 +595,6 @@ func TestWork(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
-
 	}
 }
 

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -529,7 +529,6 @@ func TestWork(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			ctx, _ = context.WithTimeout(context.Background(), 60*time.Second)
 			err = controllers["node1"].AssertWorkResults(unitID, expectedResults)
 			if err != nil {
 				t.Fatal(err)
@@ -627,6 +626,9 @@ func TestRuntimeParams(t *testing.T) {
 	nodes := m.Nodes()
 	controller := receptorcontrol.New()
 	err = controller.Connect(nodes["node0"].ControlSocket())
+	if err != nil {
+		t.Fatal(err)
+	}
 	command := `{"command":"work","subcommand":"submit","worktype":"echo","node":"node0","params":"it worked!"}`
 	unitID, err := controller.WorkSubmitJSON(command)
 	if err != nil {
@@ -648,6 +650,9 @@ func TestKubeRuntimeParams(t *testing.T) {
 	home := os.Getenv("HOME")
 	configfilename := filepath.Join(home, ".kube/config")
 	reader, err := os.Open(configfilename)
+	if err != nil {
+		t.Fatal(err)
+	}
 	buf, err := ioutil.ReadAll(reader)
 	if err != nil {
 		t.Fatal(err)
@@ -685,6 +690,9 @@ func TestKubeRuntimeParams(t *testing.T) {
 	nodes := m.Nodes()
 	controller := receptorcontrol.New()
 	err = controller.Connect(nodes["node0"].ControlSocket())
+	if err != nil {
+		t.Fatal(err)
+	}
 	command := fmt.Sprintf(`{"command": "work", "subcommand": "submit", "node": "localhost", "worktype": "echo", "secret_kube_pod": "---\napiVersion: v1\nkind: Pod\nspec:\n  containers:\n  - name: worker\n    image: centos:8\n    command:\n    - bash\n    args:\n    - \"-c\"\n    - for i in {1..5}; do echo $i;done\n", "secret_kube_config": "%s"}`, kubeconfig)
 	unitID, err := controller.WorkSubmitJSON(command)
 	if err != nil {
@@ -735,6 +743,9 @@ func TestRuntimeParamsNotAllowed(t *testing.T) {
 	nodes := m.Nodes()
 	controller := receptorcontrol.New()
 	err = controller.Connect(nodes["node0"].ControlSocket())
+	if err != nil {
+		t.Fatal(err)
+	}
 	command := `{"command":"work","subcommand":"submit","worktype":"echo","node":"node0","params":"it worked!"}`
 	_, err = controller.WorkSubmitJSON(command)
 	if err == nil {
@@ -780,6 +791,9 @@ func TestKubeContainerFailure(t *testing.T) {
 	nodes := m.Nodes()
 	controller := receptorcontrol.New()
 	err = controller.Connect(nodes["node0"].ControlSocket())
+	if err != nil {
+		t.Fatal(err)
+	}
 	job := `{"command":"work","subcommand":"submit","worktype":"kubejob","node":"node0"}`
 	unitID, err := controller.WorkSubmitJSON(job)
 	if err != nil {

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -127,7 +127,7 @@ func TestWork(t *testing.T) {
 			}
 			data.Nodes["node1"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node2": mesh.YamlConnection{
+					"node2": {
 						Index: 0,
 					},
 				},
@@ -154,7 +154,7 @@ func TestWork(t *testing.T) {
 			}
 			data.Nodes["node3"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node2": mesh.YamlConnection{
+					"node2": {
 						Index: 0,
 					},
 				},
@@ -589,7 +589,6 @@ func TestWork(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-
 		})
 
 	}

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func checkSkipKube(t *testing.T) {
-	skip := os.Getenv("SKIP_KUBE")
-	if skip == "1" {
+	if skip := os.Getenv("SKIP_KUBE"); skip == "1" {
 		t.Skip("Kubernetes tests are set to skip, unset SKIP_KUBE to run them")
 	}
 }

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -203,11 +203,8 @@ func TestWork(t *testing.T) {
 			workPath := filepath.Join(nodeDir, "datadir", nodeID, unitID)
 			check := func() bool {
 				_, err := os.Stat(workPath)
-				if os.IsNotExist(err) {
-					return true
-				}
 
-				return false
+				return os.IsNotExist(err)
 			}
 			if !utils.CheckUntilTimeout(ctx, 3000*time.Millisecond, check) {
 				return fmt.Errorf("unitID %s on %s did not release", unitID, nodeID)
@@ -224,11 +221,8 @@ func TestWork(t *testing.T) {
 					return false
 				}
 				fstat, _ := os.Stat(stdoutFilename)
-				if int(fstat.Size()) >= waitUntilSize {
-					return true
-				}
 
-				return false
+				return int(fstat.Size()) >= waitUntilSize
 			}
 			if !utils.CheckUntilTimeout(ctx, 3000*time.Millisecond, check) {
 				return fmt.Errorf("file size not correct for %s", stdoutFilename)


### PR DESCRIPTION
Extends #365. Applied code changes are grouped into linters by commits.