### PR TITLE
Add default receptor.conf

### DIFF
--- a/packaging/rpm/receptor.conf
+++ b/packaging/rpm/receptor.conf
@@ -1,0 +1,11 @@
+---
+- node: 
+    id: receptor
+
+- log-level: info
+
+- control-service:
+    service: control
+    filename: /var/run/receptor/receptor.sock
+
+- local-only:


### PR DESCRIPTION
Add default receptor.conf so that systemd service will work out of the box.  The RPM changes that pair with this require this default config file to exist.  