### PR TITLE
main() should exit when netceptor cancel is called.

### DIFF
--- a/cmd/receptor.go
+++ b/cmd/receptor.go
@@ -146,6 +146,6 @@ func main() {
 	case <-time.After(100 * time.Millisecond):
 	}
 	logger.Info("Initialization complete\n")
-	doneMain := make(chan struct{})
-	<-doneMain
+
+	<-netceptor.MainInstance.NetceptorDone()
 }

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -362,6 +362,11 @@ func (s *Netceptor) Shutdown() {
 	s.cancelFunc()
 }
 
+// NetceptorDone returns the channel for the netceptor context.
+func (s *Netceptor) NetceptorDone() <-chan struct{} {
+	return s.context.Done()
+}
+
 // NodeID returns the local Node ID of this Netceptor instance.
 func (s *Netceptor) NodeID() string {
 	return s.nodeID


### PR DESCRIPTION
we no longer exit from main when backends are closed, but the tests expect receptor to terminate when netceptor.cancel() is called, thus we can wait on the main netceptor.context.Done() channel before exiting main.