### PR TITLE
Change module name to correct location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ else
 endif
 
 receptor: $(shell find pkg -type f -name '*.go') ./cmd/receptor-cl/receptor.go
-	CGO_ENABLED=0 go build -o receptor -ldflags "-X 'github.com/project-receptor/receptor/pkg/version.Version=$(APPVER)'" $(TAGPARAM) ./cmd/receptor-cl
+	CGO_ENABLED=0 go build -o receptor -ldflags "-X 'github.com/ansible/receptor/pkg/version.Version=$(APPVER)'" $(TAGPARAM) ./cmd/receptor-cl
 
 lint:
 	@golint cmd/... pkg/... example/...

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Receptor is an overlay network intended to ease the distribution of work across 
 
 The easiest way to check out Receptor is to run it as a container.  Images are kept on the Quay registry.  To use this, run:
 ```
-[docker|podman] pull quay.io/project-receptor/receptor
+[docker|podman] pull quay.io/ansible/receptor
 [docker|podman] run -d -v /path/to/receptor.conf:/etc/receptor/receptor.conf:Z receptor
 ```
 
@@ -33,8 +33,8 @@ dnf install receptor receptorctl
 
 This code can be imported and used from Go programs.  The main libraries are:
 
-* _Netceptor_: https://pkg.go.dev/github.com/project-receptor/receptor/pkg/netceptor
-* _Workceptor_: https://pkg.go.dev/github.com/project-receptor/receptor/pkg/workceptor
+* _Netceptor_: https://pkg.go.dev/github.com/ansible/receptor/pkg/netceptor
+* _Workceptor_: https://pkg.go.dev/github.com/ansible/receptor/pkg/workceptor
 
 See the `example/` directory for examples of using these libraries from Go.
 
@@ -58,4 +58,4 @@ Receptor can also take its configuration from a file in YAML format.  The allowe
 
 ## Python Receptor and the 0.6 versions
 
-As of June 25th, this repo is the Go implementation of Receptor. If you are looking for the older Python version of Receptor, including any 0.6.x version, it is now located at https://github.com/project-receptor/python-receptor.
+As of June 25th, this repo is the Go implementation of Receptor. If you are looking for the older Python version of Receptor, including any 0.6.x version, it is now located at https://github.com/ansible/python-receptor.

--- a/cmd/receptor-cb/main.go
+++ b/cmd/receptor-cb/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/project-receptor/receptor/pkg/version"
+	"github.com/ansible/receptor/pkg/version"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/receptor-cb/serve.go
+++ b/cmd/receptor-cb/serve.go
@@ -6,7 +6,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/project-receptor/receptor/pkg"
+	"github.com/ansible/receptor/pkg"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/receptor-cb/tls-ca.go
+++ b/cmd/receptor-cb/tls-ca.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/certificates"
+	"github.com/ansible/receptor/pkg/certificates"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/receptor-cb/tls-req.go
+++ b/cmd/receptor-cb/tls-req.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/project-receptor/receptor/pkg/certificates"
+	"github.com/ansible/receptor/pkg/certificates"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/receptor-cb/tls-sign.go
+++ b/cmd/receptor-cb/tls-sign.go
@@ -3,7 +3,7 @@ package main
 import (
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/certificates"
+	"github.com/ansible/receptor/pkg/certificates"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -8,15 +8,15 @@ import (
 	"sync"
 	"time"
 
+	_ "github.com/ansible/receptor/pkg/backends"
+	_ "github.com/ansible/receptor/pkg/certificates"
+	"github.com/ansible/receptor/pkg/controlsvc"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	_ "github.com/ansible/receptor/pkg/services"
+	_ "github.com/ansible/receptor/pkg/version"
+	"github.com/ansible/receptor/pkg/workceptor"
 	"github.com/ghjm/cmdline"
-	_ "github.com/project-receptor/receptor/pkg/backends"
-	_ "github.com/project-receptor/receptor/pkg/certificates"
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	_ "github.com/project-receptor/receptor/pkg/services"
-	_ "github.com/project-receptor/receptor/pkg/version"
-	"github.com/project-receptor/receptor/pkg/workceptor"
 )
 
 type nodeCfg struct {

--- a/docs/examples/simple-network/build/receptor/Dockerfile
+++ b/docs/examples/simple-network/build/receptor/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/project-receptor/receptor
+FROM quay.io/ansible/receptor
 
 RUN set -x \
     # Set fastest repo

--- a/example/net.go
+++ b/example/net.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/backends"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/backends"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 /*

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/project-receptor/receptor
+module github.com/ansible/receptor
 
 go 1.16
 

--- a/packaging/rpm/receptor-python-worker.spec.j2
+++ b/packaging/rpm/receptor-python-worker.spec.j2
@@ -6,13 +6,13 @@ Summary: Python worker plugin interface for Receptor
 Name: %{name}
 Version: %{version}
 Release: %{release}
-Source0: https://github.com/project-receptor/receptor/archive/%{version}/receptor-%{version}.tar.gz
+Source0: https://github.com/ansible/receptor/archive/%{version}/receptor-%{version}.tar.gz
 
 License: APL 2.0
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}
 BuildArch: noarch
-Url: https://github.com/project-receptor/receptor/receptor-python-worker
+Url: https://github.com/ansible/receptor/receptor-python-worker
 
 BuildRequires: python3
 BuildRequires: python3-setuptools

--- a/packaging/rpm/receptor.spec.j2
+++ b/packaging/rpm/receptor.spec.j2
@@ -6,8 +6,8 @@ Name:           receptor
 Version:        {{ version }}
 Release:        {{ release }}%{?dist}
 
-# https://github.com/project-receptor/receptor
-%global goipath         github.com/project-receptor/receptor
+# https://github.com/ansible/receptor
+%global goipath         github.com/ansible/receptor
 
 %global common_description %{expand:
 Project Receptor is a flexible multi-service relayer with remote execution and

--- a/packaging/rpm/receptorctl.spec.j2
+++ b/packaging/rpm/receptorctl.spec.j2
@@ -6,13 +6,13 @@ Summary: Command line utility for Receptor
 Name: %{name}
 Version: %{version}
 Release: %{release}
-Source0: https://github.com/project-receptor/receptor/archive/%{version}/receptor-%{version}.tar.gz
+Source0: https://github.com/ansible/receptor/archive/%{version}/receptor-%{version}.tar.gz
 
 License: APL 2.0
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Prefix: %{_prefix}
 BuildArch: noarch
-Url: https://github.com/project-receptor/receptor/receptorctl
+Url: https://github.com/ansible/receptor/receptorctl
 
 %if 0%{?rhel} == 7
 BuildRequires: python36

--- a/pkg/backends/backends.go
+++ b/pkg/backends/backends.go
@@ -1,3 +1,4 @@
+//go:build !no_backends
 // +build !no_backends
 
 package backends
@@ -6,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 // ErrInvalidCost indicates an invalid path cost.

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -1,5 +1,5 @@
-// +build !no_tcp_backend
-// +build !no_backends
+//go:build !no_tcp_backend && !no_backends
+// +build !no_tcp_backend,!no_backends
 
 package backends
 
@@ -11,12 +11,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/framer"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/tls"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/framer"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/tls"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // TCPDialer implements Backend for outbound TCP.

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -1,5 +1,5 @@
-// +build !no_udp_backend
-// +build !no_backends
+//go:build !no_udp_backend && !no_backends
+// +build !no_udp_backend,!no_backends
 
 package backends
 
@@ -10,10 +10,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // UDPMaxPacketLen is the maximum size of a message that can be sent over UDP.

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -5,9 +5,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/utils"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/utils"
 )
 
 const (

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/gorilla/websocket"
-	"github.com/project-receptor/receptor/pkg/netceptor"
 )
 
 // This test verifies that a websockets backend client can connect to an

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -1,5 +1,5 @@
-// +build !no_websocket_backend
-// +build !no_backends
+//go:build !no_websocket_backend && !no_backends
+// +build !no_websocket_backend,!no_backends
 
 package backends
 
@@ -14,11 +14,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/tls"
 	"github.com/ghjm/cmdline"
 	"github.com/gorilla/websocket"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/tls"
 )
 
 // WebsocketDialer implements Backend for outbound Websocket.

--- a/pkg/certificates/ca.go
+++ b/pkg/certificates/ca.go
@@ -1,3 +1,4 @@
+//go:build !no_cert_auth
 // +build !no_cert_auth
 
 package certificates
@@ -16,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/utils"
+	"github.com/ansible/receptor/pkg/utils"
 )
 
 // CertNames lists the subjectAltNames that can be assigned to a certificate or request.

--- a/pkg/controlsvc/connect.go
+++ b/pkg/controlsvc/connect.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 type (

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -1,3 +1,4 @@
+//go:build !no_controlsvc
 // +build !no_controlsvc
 
 package controlsvc
@@ -15,11 +16,11 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/tls"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/tls"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // sockControl implements the ControlFuncOperations interface that is passed back to control functions.

--- a/pkg/controlsvc/controlsvc_stub.go
+++ b/pkg/controlsvc/controlsvc_stub.go
@@ -1,3 +1,4 @@
+//go:build no_controlsvc
 // +build no_controlsvc
 
 // Stub package to satisfy controlsvc dependencies while providing no functionality
@@ -11,7 +12,7 @@ import (
 	"net"
 	"os"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 // ErrNotImplemented is returned by most functions in this unit since it is a non-functional stub

--- a/pkg/controlsvc/interfaces.go
+++ b/pkg/controlsvc/interfaces.go
@@ -3,7 +3,7 @@ package controlsvc
 import (
 	"io"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 // ControlCommandType is a type of command that can be run from the control service.

--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 type (

--- a/pkg/controlsvc/reload.go
+++ b/pkg/controlsvc/reload.go
@@ -3,8 +3,8 @@ package controlsvc
 import (
 	"fmt"
 
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 type (

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -3,9 +3,9 @@ package controlsvc
 import (
 	"fmt"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/utils"
-	"github.com/project-receptor/receptor/pkg/version"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/utils"
+	"github.com/ansible/receptor/pkg/version"
 )
 
 type (

--- a/pkg/controlsvc/traceroute.go
+++ b/pkg/controlsvc/traceroute.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 type (

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -16,8 +16,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/lucas-clemente/quic-go"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 type acceptResult struct {

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -7,9 +7,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/framer"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/gorilla/websocket"
-	"github.com/project-receptor/receptor/pkg/framer"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // ExternalBackend is a backend implementation for the situation when non-Receptor code

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -16,12 +16,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/randstr"
+	"github.com/ansible/receptor/pkg/tickrunner"
+	"github.com/ansible/receptor/pkg/utils"
 	priorityQueue "github.com/jupp0r/go-priority-queue"
 	"github.com/minio/highwayhash"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/randstr"
-	"github.com/project-receptor/receptor/pkg/tickrunner"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // defaultMTU is the largest message sendable over the Netceptor network.

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
 	"github.com/prep/socketpair"
-	"github.com/project-receptor/receptor/pkg/logger"
 )
 
 type logWriter struct {

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/utils"
+	"github.com/ansible/receptor/pkg/utils"
 )
 
 // PacketConn implements the net.PacketConn interface via the Receptor network.

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -7,12 +7,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/project-receptor/receptor/pkg/backends"
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/services"
-	"github.com/project-receptor/receptor/pkg/workceptor"
+	"github.com/ansible/receptor/pkg/backends"
+	"github.com/ansible/receptor/pkg/controlsvc"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/services"
+	"github.com/ansible/receptor/pkg/workceptor"
 )
 
 // ErrNoBackends indicates that no backends were specified for a receptor instance.

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -1,5 +1,5 @@
-// +build !windows,!no_command_service
-// +build !windows,!no_services
+//go:build !windows && !no_command_service && !windows && !no_services
+// +build !windows,!no_command_service,!windows,!no_services
 
 package services
 
@@ -9,12 +9,12 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/tls"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/creack/pty"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/tls"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 func runCommand(qc net.Conn, command string) error {

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -1,5 +1,5 @@
-// +build linux,!no_ip_router
-// +build linux,!no_services
+//go:build linux && !no_ip_router && linux && !no_services
+// +build linux,!no_ip_router,linux,!no_services
 
 package services
 
@@ -12,10 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/utils"
 	"github.com/songgao/water"
 	"github.com/vishvananda/netlink"
 	"golang.org/x/net/ipv4"

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -1,12 +1,12 @@
-// +build linux,!no_ip_router
-// +build linux,!no_services
+//go:build linux && !no_ip_router && linux && !no_services
+// +build linux,!no_ip_router,linux,!no_services
 
 package services
 
 import (
 	"fmt"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 // Services defines a set of receptor services.

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -1,5 +1,5 @@
-// +build !no_proxies
-// +build !no_services
+//go:build !no_proxies && !no_services
+// +build !no_proxies,!no_services
 
 package services
 
@@ -8,11 +8,11 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/tls"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/tls"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // TCPProxyServiceInbound listens on a TCP port and forwards the connection over the Receptor network.

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -1,5 +1,5 @@
-// +build !no_proxies
-// +build !no_services
+//go:build !no_proxies && !no_services
+// +build !no_proxies,!no_services
 
 package services
 
@@ -8,10 +8,10 @@ import (
 	"net"
 	"strconv"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // UDPProxyServiceInbound listens on a UDP port and forwards packets to a remote Receptor service.

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -1,5 +1,5 @@
-// +build !no_proxies
-// +build !no_services
+//go:build !no_proxies && !no_services
+// +build !no_proxies,!no_services
 
 package services
 
@@ -9,11 +9,11 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/tls"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/tls"
-	"github.com/project-receptor/receptor/pkg/utils"
 )
 
 // UnixProxyServiceInbound listens on a Unix socket and forwards connections over the Receptor network.

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/project-receptor/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/logger"
 )
 
 // NormalBufferSize is the size of buffers used by various processes when copying data between sockets.

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -1,3 +1,4 @@
+//go:build !no_workceptor
 // +build !no_workceptor
 
 package workceptor
@@ -12,9 +13,9 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ghjm/cmdline"
 	"github.com/google/shlex"
-	"github.com/project-receptor/receptor/pkg/logger"
 )
 
 // commandUnit implements the WorkUnit interface for the Receptor command worker plugin.

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -1,3 +1,4 @@
+//go:build !no_workceptor
 // +build !no_workceptor
 
 package workceptor
@@ -9,8 +10,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/controlsvc"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 type workceptorCommandType struct {

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -1,3 +1,4 @@
+//go:build !no_workceptor
 // +build !no_workceptor
 
 package workceptor
@@ -8,7 +9,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 func newCommandWorker(w *Workceptor, unitID string, workType string) WorkUnit {

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -1,3 +1,4 @@
+//go:build !no_workceptor
 // +build !no_workceptor
 
 package workceptor
@@ -15,9 +16,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ghjm/cmdline"
 	"github.com/google/shlex"
-	"github.com/project-receptor/receptor/pkg/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -1,3 +1,4 @@
+//go:build !no_workceptor
 // +build !no_workceptor
 
 package workceptor
@@ -16,8 +17,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/utils"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/utils"
 )
 
 // remoteUnit implements the WorkUnit interface for the Receptor remote worker plugin.

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -1,3 +1,4 @@
+//go:build !no_workceptor
 // +build !no_workceptor
 
 package workceptor
@@ -14,11 +15,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/logger"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/randstr"
-	"github.com/project-receptor/receptor/pkg/utils"
+	"github.com/ansible/receptor/pkg/controlsvc"
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/randstr"
+	"github.com/ansible/receptor/pkg/utils"
 )
 
 // Workceptor is the main object that handles unit-of-work management.

--- a/pkg/workceptor/workceptor_stub.go
+++ b/pkg/workceptor/workceptor_stub.go
@@ -1,3 +1,4 @@
+//go:build no_workceptor
 // +build no_workceptor
 
 package workceptor
@@ -8,8 +9,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/controlsvc"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 // ErrNotImplemented is returned from functions that are stubbed out

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -1,3 +1,4 @@
+//go:build !no_workceptor
 // +build !no_workceptor
 
 package workceptor
@@ -13,8 +14,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
 	"github.com/fsnotify/fsnotify"
-	"github.com/project-receptor/receptor/pkg/logger"
 	"github.com/rogpeppe/go-internal/lockedfile"
 )
 

--- a/receptorctl/setup.cfg
+++ b/receptorctl/setup.cfg
@@ -3,7 +3,7 @@ name = receptorctl
 author = Red Hat
 author_email = info@ansible.com
 summary = "Receptorctl is a front-end CLI and importable Python library that interacts with Receptor over its control socket interface."
-home_page = https://github.com/project-receptor/receptor/tree/devel/receptorctl
+home_page = https://github.com/ansible/receptor/tree/devel/receptorctl
 description_file = README.md
 description_content_type = text/markdown
 

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"github.com/ansible/receptor/tests/functional/lib/utils"
 )
 
 func ConfirmListening(pid int) (bool, error) {

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -12,9 +12,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/ansible/receptor/tests/functional/lib/utils"
 	"gopkg.in/yaml.v2"
 )
 

--- a/tests/functional/lib/mesh/containermesh.go
+++ b/tests/functional/lib/mesh/containermesh.go
@@ -14,9 +14,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/ansible/receptor/tests/functional/lib/utils"
 	"gopkg.in/yaml.v2"
 )
 

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -13,11 +13,11 @@ import (
 	"strings"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/backends"
-	"github.com/project-receptor/receptor/pkg/controlsvc"
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"github.com/ansible/receptor/pkg/backends"
+	"github.com/ansible/receptor/pkg/controlsvc"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/ansible/receptor/tests/functional/lib/utils"
 	"gopkg.in/yaml.v2"
 )
 

--- a/tests/functional/lib/mesh/mesh.go
+++ b/tests/functional/lib/mesh/mesh.go
@@ -3,7 +3,7 @@ package mesh
 import (
 	"context"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
 
 // Node Defines the interface for nodes made using the CLI, Library, and

--- a/tests/functional/lib/receptorcontrol/receptorcontrol.go
+++ b/tests/functional/lib/receptorcontrol/receptorcontrol.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/netceptor"
-	"github.com/project-receptor/receptor/pkg/workceptor"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
+	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/workceptor"
+	"github.com/ansible/receptor/tests/functional/lib/utils"
 )
 
 // ReceptorControl Connects to a control socket and provides basic commands.

--- a/tests/functional/lib/utils/utils.go
+++ b/tests/functional/lib/utils/utils.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/project-receptor/receptor/pkg/certificates"
+	"github.com/ansible/receptor/pkg/certificates"
 )
 
 var (

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -12,9 +12,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ansible/receptor/tests/functional/lib/mesh"
+	"github.com/ansible/receptor/tests/functional/lib/receptorcontrol"
 	_ "github.com/fortytw2/leaktest"
-	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
 	"gopkg.in/yaml.v2"
 )
 

--- a/tests/functional/mesh/tls_test.go
+++ b/tests/functional/mesh/tls_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ansible/receptor/tests/functional/lib/mesh"
+	"github.com/ansible/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/ansible/receptor/tests/functional/lib/utils"
 	_ "github.com/fortytw2/leaktest"
-	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 )
 
 func TestTCPSSLConnections(t *testing.T) {

--- a/tests/functional/mesh/work_test.go
+++ b/tests/functional/mesh/work_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ansible/receptor/tests/functional/lib/mesh"
+	"github.com/ansible/receptor/tests/functional/lib/receptorcontrol"
+	"github.com/ansible/receptor/tests/functional/lib/utils"
 	_ "github.com/fortytw2/leaktest"
-	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"github.com/project-receptor/receptor/tests/functional/lib/utils"
 )
 
 func checkSkipKube(t *testing.T) {


### PR DESCRIPTION
Module name should point to the repository location, which has changed
from github.com/receptor-project/receptor to
github.com/ansible/receptor.