### PR TITLE
Restrict TLS proto version to 1.2 minimum and reduce cipher list

### DIFF
--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -81,7 +81,9 @@ func TestWebsocketExternalInterop(t *testing.T) {
 		Addr:    li.Addr().String(),
 		Handler: mux,
 		TLSConfig: &tls.Config{
-			Certificates: []tls.Certificate{tlsCert},
+			Certificates:             []tls.Certificate{tlsCert},
+			MinVersion:               tls.VersionTLS12,
+			PreferServerCipherSuites: true,
 		},
 	}
 	go func() {
@@ -96,8 +98,10 @@ func TestWebsocketExternalInterop(t *testing.T) {
 	CAcerts := x509.NewCertPool()
 	CAcerts.AppendCertsFromPEM(certPEM)
 	tls2 := &tls.Config{
-		RootCAs:    CAcerts,
-		ServerName: "localhost",
+		RootCAs:          CAcerts,
+		ServerName:       "localhost",
+		MinVersion:       tls.VersionTLS12,
+		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 	}
 	b2, err := NewWebsocketDialer("wss://"+li.Addr().String(), tls2, "X-Extra-Data: SomeData", true)
 	if err != nil {

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -463,8 +463,10 @@ func generateServerTLSConfig() *tls.Config {
 	}
 
 	return &tls.Config{
-		Certificates: []tls.Certificate{tlsCert},
-		NextProtos:   []string{"netceptor"},
+		Certificates:             []tls.Certificate{tlsCert},
+		NextProtos:               []string{"netceptor"},
+		MinVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
 	}
 }
 
@@ -488,5 +490,6 @@ func generateClientTLSConfig() *tls.Config {
 		VerifyPeerCertificate: verifyServerCertificate,
 		NextProtos:            []string{"netceptor"},
 		ServerName:            insecureCommonName,
+		MinVersion:            tls.VersionTLS12,
 	}
 }

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -309,7 +309,9 @@ func NewWithConsts(ctx context.Context, nodeID string, allowedPeers []string,
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	s.clientTLSConfigs["default"] = &tls.Config{}
+	s.clientTLSConfigs["default"] = &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
 	s.addNameHash(nodeID)
 	s.context, s.cancelFunc = context.WithCancel(ctx)
 	s.unreachableBroker = utils.NewBroker(s.context, reflect.TypeOf(UnreachableNotification{}))

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -1,3 +1,4 @@
+//go:build !no_tls_config
 // +build !no_tls_config
 
 package netceptor
@@ -31,7 +32,10 @@ type tlsServerCfg struct {
 
 // Prepare creates the tls.config and stores it in the global map.
 func (cfg tlsServerCfg) Prepare() error {
-	tlscfg := &tls.Config{}
+	tlscfg := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
+	}
 
 	certbytes, err := ioutil.ReadFile(cfg.Cert)
 	if err != nil {
@@ -81,7 +85,10 @@ type tlsClientConfig struct {
 
 // Prepare creates the tls.config and stores it in the global map.
 func (cfg tlsClientConfig) Prepare() error {
-	tlscfg := &tls.Config{}
+	tlscfg := &tls.Config{
+		MinVersion:               tls.VersionTLS12,
+		PreferServerCipherSuites: true,
+	}
 
 	if cfg.Cert != "" || cfg.Key != "" {
 		if cfg.Cert == "" || cfg.Key == "" {

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -237,7 +237,9 @@ func NewLibMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*LibMesh, er
 				if k == "tls-client" {
 					vMap := v.(map[interface{}]interface{})
 					// Taken from pkg/netceptor/tlsconfig.go
-					tlscfg := &tls.Config{}
+					tlscfg := &tls.Config{
+						MinVersion: tls.VersionTLS12,
+					}
 
 					if vMap["cert"] != "" || vMap["key"] != "" {
 						if vMap["cert"] == "" || vMap["key"] == "" {
@@ -275,7 +277,10 @@ func NewLibMeshFromYaml(meshDefinition YamlData, dirSuffix string) (*LibMesh, er
 				} else if k == "tls-server" {
 					vMap := v.(map[interface{}]interface{})
 					// Taken from pkg/netceptor/tlsconfig.go
-					tlscfg := &tls.Config{}
+					tlscfg := &tls.Config{
+						MinVersion:               tls.VersionTLS12,
+						PreferServerCipherSuites: true,
+					}
 
 					certbytes, err := ioutil.ReadFile(vMap["cert"].(string))
 					if err != nil {


### PR DESCRIPTION
Anything below it is unsafe and should be forbidden. Since v1.2
has a rather large cipher set (v1.3 restricts it) this also
recduces the cipher set.