### PR TITLE
On reload, detect if modified config is reloadable

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/songgao/water v0.0.0-20200317203138-2b4b6d7c09d8
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
+	github.com/stretchr/testify v1.7.0
 	github.com/vishvananda/netlink v1.1.0
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c // indirect

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -309,12 +309,20 @@ func (cfg tcpDialerCfg) Run() error {
 	return nil
 }
 
+func (cfg tcpDialerCfg) PreReload() error {
+	return cfg.Prepare()
+}
+
+func (cfg tcpListenerCfg) PreReload() error {
+	return cfg.Prepare()
+}
+
 func (cfg tcpDialerCfg) Reload() error {
-	return runFuncs([]func() error{cfg.Prepare, cfg.Run})
+	return cfg.Run()
 }
 
 func (cfg tcpListenerCfg) Reload() error {
-	return runFuncs([]func() error{cfg.Prepare, cfg.Run})
+	return cfg.Run()
 }
 
 func init() {

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -341,12 +341,20 @@ func (cfg udpDialerCfg) Run() error {
 	return nil
 }
 
+func (cfg udpDialerCfg) PreReload() error {
+	return cfg.Prepare()
+}
+
+func (cfg udpListenerCfg) PreReload() error {
+	return cfg.Prepare()
+}
+
 func (cfg udpDialerCfg) Reload() error {
-	return runFuncs([]func() error{cfg.Prepare, cfg.Run})
+	return cfg.Run()
 }
 
 func (cfg udpListenerCfg) Reload() error {
-	return runFuncs([]func() error{cfg.Prepare, cfg.Run})
+	return cfg.Run()
 }
 
 func init() {

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -115,16 +115,3 @@ func listenerSession(ctx context.Context, wg *sync.WaitGroup, lf listenFunc, af 
 
 	return sessChan, nil
 }
-
-func runFuncs(f []func() error) error {
-	// convenience for running an slice of functions and returning any
-	// errors along the way
-	for _, toRun := range f {
-		err := toRun()
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -340,12 +340,20 @@ func (cfg websocketDialerCfg) Run() error {
 	return nil
 }
 
+func (cfg websocketDialerCfg) PreReload() error {
+	return cfg.Prepare()
+}
+
+func (cfg websocketListenerCfg) PreReload() error {
+	return cfg.Prepare()
+}
+
 func (cfg websocketDialerCfg) Reload() error {
-	return runFuncs([]func() error{cfg.Prepare, cfg.Run})
+	return cfg.Run()
 }
 
 func (cfg websocketListenerCfg) Reload() error {
-	return runFuncs([]func() error{cfg.Prepare, cfg.Run})
+	return cfg.Run()
 }
 
 func init() {

--- a/pkg/controlsvc/reload.go
+++ b/pkg/controlsvc/reload.go
@@ -2,9 +2,12 @@ package controlsvc
 
 import (
 	"fmt"
+	"io/ioutil"
+	"strings"
 
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
+	"gopkg.in/yaml.v2"
 )
 
 type (
@@ -12,8 +15,126 @@ type (
 	reloadCommand     struct{}
 )
 
-// ReloadCL is ParseAndRun closure set with the initial receptor arguments.
-var ReloadCL func(bool) error
+var configPath = ""
+
+var reloadParseAndRun = func(toRun []string) error {
+	return fmt.Errorf("no configuration file was provided, reload function not set")
+}
+
+var cfgNotReloadable = make(map[string]bool)
+
+var reloadableActions = []string{
+	"tcp-peer",
+	"tcp-listener",
+	"ws-peer",
+	"ws-listener",
+	"udp-peer",
+	"udp-listener",
+	"local-only",
+}
+
+func isReloadable(cfg string) bool {
+	// checks if top-level keys (e.g. tcp-peer) are in the list of reloadable
+	// actions
+	for _, a := range reloadableActions {
+		if strings.HasPrefix(cfg, a) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getActionKeyword(cfg string) string {
+	// extracts top-level key from the full configuration item
+	cfgSplit := strings.Split(cfg, ":")
+	var action string
+	if len(cfgSplit) == 0 {
+		action = cfg
+	} else {
+		action = cfgSplit[0]
+	}
+
+	return action
+}
+
+func parseConfigForReload(filename string, checkReload bool) error {
+	// cfgNotReloadable is a map, each key being the full configuration item
+	// e.g. "work-command: worktype: echosleep command: bash params:..."
+	// Initially all values of map are set to false,
+	// e.g. cfgNotReloadable["work-command: worktype: echosleep..."] = false
+	//
+	// Upon reload, the config is reparsed and each item is checked.
+	// if item not in cfgNotReloadable, return error
+	// if item is in cfgNotReloadable, set it to true
+	// e.g. cfgNotReloadable["work-command: worktype: echosleep..."] = true
+	//
+	// Finally, cfgAbsent() will loop through the map and check for any remaining
+	// items that are still false. This means the original item is missing from
+	// the config, and an error will be thrown
+	data, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	m := make([]interface{}, 0)
+	err = yaml.Unmarshal(data, &m)
+	if err != nil {
+		return err
+	}
+	for i := range m {
+		cfgBytes, err := yaml.Marshal(&m[i])
+		if err != nil {
+			return err
+		}
+		cfg := string(cfgBytes)
+		if !isReloadable(cfg) {
+			if checkReload {
+				if _, ok := cfgNotReloadable[cfg]; !ok {
+					action := getActionKeyword(cfg)
+
+					return fmt.Errorf("a non-reloadable config action '%s' was modified or added. Must restart receptor for these changes to take effect", action)
+				}
+				cfgNotReloadable[cfg] = true
+			} else {
+				cfgNotReloadable[cfg] = false
+			}
+		}
+	}
+
+	return nil
+}
+
+func cfgAbsent() error {
+	// checks to see if any item in cfgNotReloadable has a value of false,
+	// if so, that means an unreloadable item has been removed from the config
+	defer func() {
+		for k := range cfgNotReloadable {
+			cfgNotReloadable[k] = false
+		}
+	}()
+
+	for cfg, v := range cfgNotReloadable {
+		if !v {
+			action := getActionKeyword(cfg)
+
+			return fmt.Errorf("a non-reloadable config action '%s' was removed. Must restart receptor for changes to take effect", action)
+		}
+	}
+
+	return nil
+}
+
+// InitReload initializes objects required before reload commands are issued.
+func InitReload(cPath string, fParseAndRun func([]string) error) error {
+	configPath = cPath
+	reloadParseAndRun = fParseAndRun
+
+	return parseConfigForReload(configPath, false)
+}
+
+func checkReload() error {
+	return parseConfigForReload(configPath, true)
+}
 
 func (t *reloadCommandType) InitFromString(params string) (ControlCommand, error) {
 	c := &reloadCommand{}
@@ -27,37 +148,47 @@ func (t *reloadCommandType) InitFromJSON(config map[string]interface{}) (Control
 	return c, nil
 }
 
-func (c *reloadCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
-	// Reload command stops all backends, and re-runs the ParseAndRun() on the
-	// initial config file
+func handleError(err error, errorcode int) (map[string]interface{}, error) {
 	cfr := make(map[string]interface{})
-	logger.Debug("Reloading")
-
-	// Do a quick check to catch any yaml errors before canceling backends
-	err := ReloadCL(true)
-	if err != nil {
-		cfr["Success"] = false
-		cfr["Error"] = err.Error()
-
-		return cfr, err
-	}
-
-	nc.CancelBackends()
-	// ReloadCL is a ParseAndRun closure, set in receptor.go/main()
-	err = ReloadCL(false)
-	if err != nil {
-		cfr["Success"] = false
-		cfr["Error"] = err.Error()
-
-		return cfr, err
-	}
-	cfr["Success"] = true
+	cfr["Success"] = false
+	cfr["Error"] = fmt.Sprintf("%s ERRORCODE %d", err.Error(), errorcode)
+	logger.Warning("Reload not successful: %s", err.Error())
 
 	return cfr, nil
 }
 
-func init() {
-	ReloadCL = func(dryRun bool) error {
-		return fmt.Errorf("reload function not set")
+func (c *reloadCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+	// Reload command stops all backends, and re-runs the ParseAndRun() on the
+	// initial config file
+	logger.Debug("Reloading")
+
+	// Do a quick check to catch any yaml errors before canceling backends
+	err := reloadParseAndRun([]string{"PreReload"})
+	if err != nil {
+		return handleError(err, 4)
 	}
+
+	// check if non-reloadable items have been added or modified
+	err = checkReload()
+	if err != nil {
+		return handleError(err, 3)
+	}
+
+	// check if non-reloadable items have been removed
+	err = cfgAbsent()
+	if err != nil {
+		return handleError(err, 3)
+	}
+
+	nc.CancelBackends()
+	// reloadParseAndRun is a ParseAndRun closure, set in receptor.go/main()
+	err = reloadParseAndRun([]string{"PreReload", "Reload"})
+	if err != nil {
+		return handleError(err, 4)
+	}
+
+	cfr := make(map[string]interface{})
+	cfr["Success"] = true
+
+	return cfr, nil
 }

--- a/pkg/controlsvc/reload_test.go
+++ b/pkg/controlsvc/reload_test.go
@@ -1,0 +1,43 @@
+package controlsvc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReload(t *testing.T) {
+	type yamltest struct {
+		filename    string
+		modifyError bool
+		absentError bool
+	}
+
+	scenarios := []yamltest{
+		{filename: "reload_test_yml/init.yml", modifyError: false, absentError: false},
+		{filename: "reload_test_yml/add_cfg.yml", modifyError: true, absentError: false},
+		{filename: "reload_test_yml/drop_cfg.yml", modifyError: false, absentError: true},
+		{filename: "reload_test_yml/modify_cfg.yml", modifyError: true, absentError: true},
+		{filename: "reload_test_yml/syntax_error.yml", modifyError: true, absentError: true},
+		{filename: "reload_test_yml/successful_reload.yml", modifyError: false, absentError: false},
+	}
+	err := parseConfigForReload("reload_test_yml/init.yml", false)
+	assert.NoError(t, err)
+	assert.Len(t, cfgNotReloadable, 5)
+
+	for _, s := range scenarios {
+		t.Logf("%s", s.filename)
+		err = parseConfigForReload(s.filename, true)
+		if s.modifyError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		err = cfgAbsent()
+		if s.absentError {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}

--- a/pkg/controlsvc/reload_test_yml/add_cfg.yml
+++ b/pkg/controlsvc/reload_test_yml/add_cfg.yml
@@ -1,0 +1,24 @@
+---
+- node:
+    id: foo
+    allowedpeers: bar
+
+- log-level: Info
+- trace
+
+- tcp-peer:
+    address: localhost:8001
+
+- control-service:
+    service: control
+    filename: /tmp/foo.sock
+
+- work-command:
+    workType: hello
+    command: bash
+    params: "-c \"echo hello\""
+
+- work-command: # not reloadable
+    workType: hello2
+    command: bash
+    params: "-c \"echo hello2\""

--- a/pkg/controlsvc/reload_test_yml/drop_cfg.yml
+++ b/pkg/controlsvc/reload_test_yml/drop_cfg.yml
@@ -1,0 +1,19 @@
+---
+- node:
+    id: foo
+    allowedpeers: bar
+
+- log-level: Info
+- trace
+
+- tcp-peer:
+    address: localhost:8001
+
+- control-service:
+    service: control
+    filename: /tmp/foo.sock
+
+# - work-command:
+#     workType: hello
+#     command: bash
+#     params: "-c \"echo hello\""

--- a/pkg/controlsvc/reload_test_yml/init.yml
+++ b/pkg/controlsvc/reload_test_yml/init.yml
@@ -1,0 +1,19 @@
+---
+- node:
+    id: foo
+    allowedpeers: bar
+
+- log-level: Info
+- trace
+
+- tcp-peer:
+    address: localhost:8001
+
+- control-service:
+    service: control
+    filename: /tmp/foo.sock
+
+- work-command:
+    workType: hello
+    command: bash
+    params: "-c \"echo hello\""

--- a/pkg/controlsvc/reload_test_yml/modify_cfg.yml
+++ b/pkg/controlsvc/reload_test_yml/modify_cfg.yml
@@ -1,0 +1,19 @@
+---
+- node:
+    id: foo
+    allowedpeers: bar
+
+- log-level: Info
+- trace
+
+- tcp-peer:
+    address: localhost:8001
+
+- control-service:
+    service: control
+    filename: /tmp/foo.sock
+
+- work-command:
+    workType: hello2 # changed workType name
+    command: bash
+    params: "-c \"echo hello\""

--- a/pkg/controlsvc/reload_test_yml/successful_reload.yml
+++ b/pkg/controlsvc/reload_test_yml/successful_reload.yml
@@ -1,0 +1,22 @@
+---
+- node:
+    id: foo
+    allowedpeers: bar
+
+- log-level: Info
+- trace
+
+- tcp-peer:
+    address: localhost:8001
+
+- tcp-peer:
+    address: localhost:8002 # is reloadable
+
+- control-service:
+    service: control
+    filename: /tmp/foo.sock
+
+- work-command:
+    workType: hello
+    command: bash
+    params: "-c \"echo hello\""

--- a/pkg/controlsvc/reload_test_yml/syntax_error.yml
+++ b/pkg/controlsvc/reload_test_yml/syntax_error.yml
@@ -1,0 +1,15 @@
+---
+1234syntaxerror # syntax error
+- node:
+    id: foo
+    allowedpeers: bar
+
+- log-level: Info
+- trace
+
+- tcp-peer:
+    address: localhost:8001
+
+- control-service:
+    service: control
+    filename: /tmp/foo.sock

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -406,21 +406,36 @@ func (s *Netceptor) MaxConnectionIdleTime() time.Duration {
 func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost map[string]float64) error {
 	ctxBackend, cancel := context.WithCancel(s.context)
 	s.backendCancel = append(s.backendCancel, cancel)
+	// Starts a go routine that attempts return a connection session on this
+	// backend. For listeners, this could result in multiple sessions at once.
 	sessChan, err := backend.Start(ctxBackend, &s.backendWaitGroup)
 	if err != nil {
 		return err
 	}
 	s.backendWaitGroup.Add(1)
 	s.backendCount++
+	// Outer go routine -- This go routine waits for new sessions to be written to the sessChan and
+	// run the runProtocol loop over this session.
 	go func() {
-		defer s.backendWaitGroup.Done()
+		runProtocolWg := sync.WaitGroup{}
+		defer func() {
+			// First wait for all session protocols to finish (the inner go routines)
+			// for this backend before exiting this outer go routine.
+			// It is important that the inner go routine is on a separate wait group
+			// from the outer go routine.
+			runProtocolWg.Wait()
+			s.backendWaitGroup.Done()
+		}()
 		for {
 			select {
 			case sess, ok := <-sessChan:
 				if ok {
-					s.backendWaitGroup.Add(1)
+					runProtocolWg.Add(1)
+					// Inner go routine -- start the runProtocol loop for the new session
+					// that was just passed to sessChan (which was written to from the
+					// Start method above)
 					go func() {
-						defer s.backendWaitGroup.Done()
+						defer runProtocolWg.Done()
 						err := s.runProtocol(ctxBackend, sess, connectionCost, nodeCost)
 						if err != nil {
 							logger.Error("Backend error: %s\n", err)
@@ -441,11 +456,6 @@ func (s *Netceptor) AddBackend(backend Backend, connectionCost float64, nodeCost
 // BackendWait waits for the backend wait group.
 func (s *Netceptor) BackendWait() {
 	s.backendWaitGroup.Wait()
-}
-
-// BackendWaitGroupAdd increments backendWaitGroup counter.
-func (s *Netceptor) BackendWaitGroupAdd() {
-	s.backendWaitGroup.Add(1)
 }
 
 // BackendDone calls Done on the backendWaitGroup.

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -171,7 +171,12 @@ def reload(ctx):
         print(f"Reload successful")
     else:
         print(f"Error: {results['Error']}")
-
+        if "ERRORCODE 3" in results['Error']:
+            sys.exit(3)
+        elif "ERRORCODE 4" in results['Error']:
+            sys.exit(4)
+        else:
+            sys.exit(4)
 
 @cli.command(help="Do a traceroute to a Receptor node.")
 @click.pass_context


### PR DESCRIPTION
If a user changes the configuration file that is not supported by a reload, then proper errors are returned.

reloadable config items include

```
tcp-peer
tcp-listener
ws-peer
ws-listener
udp-peer
udp-listener
local-only
```

Error message if a non-reloadable config item was added or modified,

```
$ receptorctl reload
Error: a non-reloabable config action 'work-command' was modified or added. Must restart receptor for these changes to take effect
```
Error message if a non-reloadable config item was removed,

```
$ receptorctl reload
Error: a non-reloadable config action 'work-command' was removed. Must restart receptor for changes to take effect
```

receptorctl will exit with a meaningful error code, can be view with `echo $?` 

exit code 0 -- receptor reload was successful
exit code 3 -- configuration file was fine, but cannot reload due to the non-reloadable changes mentioned above
exit code 4 -- new configuration file we are trying to reload is broken, even a restart is probably not going to work. Installer role should fail