### PR TITLE
Firewall Rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ kubectl
 /receptor-python-worker/ChangeLog
 /receptor-python-worker/AUTHORS
 .vagrant/
+/docs/build

--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -19,9 +19,9 @@ import (
 )
 
 type nodeCfg struct {
-	ID            string   `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
-	DataDir       string   `description:"Directory in which to store node data"`
-	FirewallRules []string `description:"Firewall Rules (see documentation for syntax)"`
+	ID            string                       `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
+	DataDir       string                       `description:"Directory in which to store node data"`
+	FirewallRules []netceptor.FirewallRuleData `description:"Firewall Rules (see documentation for syntax)"`
 }
 
 func (cfg nodeCfg) Init() error {
@@ -41,6 +41,7 @@ func (cfg nodeCfg) Init() error {
 		return fmt.Errorf("node ID \"localhost\" is reserved")
 	}
 	netceptor.MainInstance = netceptor.New(context.Background(), cfg.ID)
+
 	if len(cfg.FirewallRules) > 0 {
 		rules, err := netceptor.ParseFirewallRules(cfg.FirewallRules)
 		if err != nil {
@@ -51,6 +52,7 @@ func (cfg nodeCfg) Init() error {
 			return err
 		}
 	}
+
 	workceptor.MainInstance, err = workceptor.New(context.Background(), netceptor.MainInstance, cfg.DataDir)
 	if err != nil {
 		return err

--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -19,8 +19,9 @@ import (
 )
 
 type nodeCfg struct {
-	ID      string `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
-	DataDir string `description:"Directory in which to store node data"`
+	ID            string   `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
+	DataDir       string   `description:"Directory in which to store node data"`
+	FirewallRules []string `description:"Firewall Rules (see documentation for syntax)"`
 }
 
 func (cfg nodeCfg) Init() error {
@@ -40,6 +41,16 @@ func (cfg nodeCfg) Init() error {
 		return fmt.Errorf("node ID \"localhost\" is reserved")
 	}
 	netceptor.MainInstance = netceptor.New(context.Background(), cfg.ID)
+	if len(cfg.FirewallRules) > 0 {
+		rules, err := netceptor.ParseFirewallRules(cfg.FirewallRules)
+		if err != nil {
+			return err
+		}
+		err = netceptor.MainInstance.AddFirewallRules(rules, true)
+		if err != nil {
+			return err
+		}
+	}
 	workceptor.MainInstance, err = workceptor.New(context.Background(), netceptor.MainInstance, cfg.DataDir)
 	if err != nil {
 		return err

--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -19,9 +19,8 @@ import (
 )
 
 type nodeCfg struct {
-	ID           string `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
-	AllowedPeers string `description:"Comma separated list of peer node-IDs to allow"`
-	DataDir      string `description:"Directory in which to store node data"`
+	ID      string `description:"Node ID. Defaults to local hostname." barevalue:"yes"`
+	DataDir string `description:"Directory in which to store node data"`
 }
 
 func (cfg nodeCfg) Init() error {
@@ -40,14 +39,7 @@ func (cfg nodeCfg) Init() error {
 	if strings.ToLower(cfg.ID) == "localhost" {
 		return fmt.Errorf("node ID \"localhost\" is reserved")
 	}
-	var allowedPeers []string
-	if cfg.AllowedPeers != "" {
-		allowedPeers = strings.Split(cfg.AllowedPeers, ",")
-		for i := range allowedPeers {
-			allowedPeers[i] = strings.TrimSpace(allowedPeers[i])
-		}
-	}
-	netceptor.MainInstance = netceptor.New(context.Background(), cfg.ID, allowedPeers)
+	netceptor.MainInstance = netceptor.New(context.Background(), cfg.ID)
 	workceptor.MainInstance, err = workceptor.New(context.Background(), netceptor.MainInstance, cfg.DataDir)
 	if err != nil {
 		return err
@@ -76,7 +68,7 @@ func (cfg nullBackendCfg) Start(ctx context.Context, wg *sync.WaitGroup) (chan n
 
 // Run runs the action, in this case adding a null backend to keep the wait group alive.
 func (cfg nullBackendCfg) Run() error {
-	err := netceptor.MainInstance.AddBackend(&nullBackendCfg{}, 1.0, nil)
+	err := netceptor.MainInstance.AddBackend(&nullBackendCfg{})
 	if err != nil {
 		return err
 	}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 sidebar_collapse = False
 

--- a/docs/source/firewall.rst
+++ b/docs/source/firewall.rst
@@ -1,41 +1,48 @@
 Firewall Rules
 ==============
 
+Receptor has the ability to accept, drop, or reject traffic based on any combination of the following:
 
-Blah blah blah
+- ``FromNode``
+- ``ToNode``
+- ``FromService``
+- ``ToService``
+
+Firewall rules are added under the ``node`` entry in a Receptor configuration file:
 
 .. code-block:: yaml
-    
-    # Accepts everything
 
+    # Accepts everything
     ---
     node:
-    firewallrules:
+      firewallrules:
         - action: "accept"
 
-
 .. code-block:: yaml
+
     # Drops traffic from `foo` to `bar`'s control service
-
     ---
     node:
-    firewallrules:
+      firewallrules:
         - action: "drop"
-        fromnode: "foo"
-        tonode: "bar"
-        toservice: "control"
-    # Rejects traffic originating from nodes like abcb, adfb, etc
+          fromnode: "foo"
+          tonode: "bar"
+          toservice: "control"
 
 .. code-block:: yaml
-    ---
-    node:
-    firewallrules:
-        - action: "reject"
-        fromnode: "/a.*b/"
-    # Rejects traffic destined for nodes like abcb, AdfB, etc
 
+    # Rejects traffic originating from nodes like abcb, adfb, etc
     ---
     node:
-    firewallrules:
+      firewallrules:
         - action: "reject"
-        tonode: "/(?i)a.*b/"
+          fromnode: "/a.*b/"
+
+.. code-block:: yaml
+
+    # Rejects traffic destined for nodes like abcb, AdfB, etc
+    ---
+    node:
+      firewallrules:
+        - action: "reject"
+          tonode: "/(?i)a.*b/"

--- a/docs/source/firewall.rst
+++ b/docs/source/firewall.rst
@@ -1,0 +1,41 @@
+Firewall Rules
+==============
+
+
+Blah blah blah
+
+.. code-block:: yaml
+    
+    # Accepts everything
+
+    ---
+    node:
+    firewallrules:
+        - action: "accept"
+
+
+.. code-block:: yaml
+    # Drops traffic from `foo` to `bar`'s control service
+
+    ---
+    node:
+    firewallrules:
+        - action: "drop"
+        fromnode: "foo"
+        tonode: "bar"
+        toservice: "control"
+    # Rejects traffic originating from nodes like abcb, adfb, etc
+
+.. code-block:: yaml
+    ---
+    node:
+    firewallrules:
+        - action: "reject"
+        fromnode: "/a.*b/"
+    # Rejects traffic destined for nodes like abcb, AdfB, etc
+
+    ---
+    node:
+    firewallrules:
+        - action: "reject"
+        tonode: "/(?i)a.*b/"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -123,4 +123,5 @@ Note: the config file does not specify a node ID, so the hostname (on the contai
    workceptor
    k8s
    tls
+   firewall
    developer_guide

--- a/example/net.go
+++ b/example/net.go
@@ -22,8 +22,8 @@ func main() {
 	logger.QuietMode()
 
 	// Create two nodes of the Receptor network-layer protocol (Netceptors).
-	n1 := netceptor.New(context.Background(), "node1", nil)
-	n2 := netceptor.New(context.Background(), "node2", nil)
+	n1 := netceptor.New(context.Background(), "node1")
+	n2 := netceptor.New(context.Background(), "node2")
 
 	// Start a TCP listener on the first node
 	b1, err := backends.NewTCPListener("localhost:3333", nil)
@@ -31,7 +31,7 @@ func main() {
 		fmt.Printf("Error listening on TCP: %s\n", err)
 		os.Exit(1)
 	}
-	err = n1.AddBackend(b1, 1.0, nil)
+	err = n1.AddBackend(b1)
 	if err != nil {
 		fmt.Printf("Error starting backend: %s\n", err)
 		os.Exit(1)
@@ -43,7 +43,7 @@ func main() {
 		fmt.Printf("Error dialing on TCP: %s\n", err)
 		os.Exit(1)
 	}
-	err = n2.AddBackend(b2, 1.0, nil)
+	err = n2.AddBackend(b2)
 	if err != nil {
 		fmt.Printf("Error starting backend: %s\n", err)
 		os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ansible/receptor
 go 1.15
 
 require (
-	github.com/alecthomas/participle/v2 v2.0.0-alpha6
 	github.com/creack/pty v1.1.11
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ansible/receptor
 go 1.15
 
 require (
+	github.com/alecthomas/participle/v2 v2.0.0-alpha6
 	github.com/creack/pty v1.1.11
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,10 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
+github.com/alecthomas/participle/v2 v2.0.0-alpha6 h1:6IeFBBLWi0xcTk4ModH9UKkLBYf5l5OzaYkJOjZW1rg=
+github.com/alecthomas/participle/v2 v2.0.0-alpha6/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
+github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
-github.com/alecthomas/participle/v2 v2.0.0-alpha6 h1:6IeFBBLWi0xcTk4ModH9UKkLBYf5l5OzaYkJOjZW1rg=
-github.com/alecthomas/participle/v2 v2.0.0-alpha6/go.mod h1:Z1zPLDbcGsVsBYsThKXY00i84575bN/nMczzIrU4rWU=
-github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1 h1:GDQdwm/gAcJcLAKQQZGOJ4knlw+7rfEQQcmwTbt4p5E=
-github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1/go.mod h1:xTS7Pm1pD1mvyM075QCDSRqH6qRLXylzS24ZTpRiSzQ=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -527,10 +523,6 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
-golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d h1:LO7XpTYMwTqxjLcGWPijK3vRXg1aWdlNOVOHRq45d7c=
-golang.org/x/net v0.0.0-20210813160813-60bc85c4be6d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -609,7 +601,6 @@ golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -371,7 +371,7 @@ func (c TCPListen) setup(nc *netceptor.Netceptor) error {
 		return fmt.Errorf("invalid tcp listener config for %s: %w", c.Address, err)
 	}
 
-	if err := nc.AddBackend(b, cost, nodeCosts); err != nil {
+	if err := nc.AddBackend(b, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCosts)); err != nil {
 		return fmt.Errorf("error creating backend for tcp listener %s: %w", c.Address, err)
 	}
 
@@ -410,7 +410,7 @@ func (c TCPDial) setup(nc *netceptor.Netceptor) error {
 		return fmt.Errorf("invalid cost for tcp dial %s: %w", c.Address, err)
 	}
 
-	if err := nc.AddBackend(b, cost, nil); err != nil {
+	if err := nc.AddBackend(b, netceptor.BackendConnectionCost(cost), nil); err != nil {
 		return fmt.Errorf("error creating backend for tcp dial %s: %w", c.Address, err)
 	}
 

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -225,11 +225,12 @@ func (ns *TCPSession) Close() error {
 
 // tcpListenerCfg is the cmdline configuration object for a TCP listener.
 type tcpListenerCfg struct {
-	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
-	Port     int                `description:"Local TCP port to listen on" barevalue:"yes" required:"yes"`
-	TLS      string             `description:"Name of TLS server config"`
-	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
-	NodeCost map[string]float64 `description:"Per-node costs"`
+	BindAddr     string             `description:"Local address to bind to" default:"0.0.0.0"`
+	Port         int                `description:"Local TCP port to listen on" barevalue:"yes" required:"yes"`
+	TLS          string             `description:"Name of TLS server config"`
+	Cost         float64            `description:"Connection cost (weight)" default:"1.0"`
+	NodeCost     map[string]float64 `description:"Per-node costs"`
+	AllowedPeers []string           `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies the parameters are correct.
@@ -259,7 +260,10 @@ func (cfg tcpListenerCfg) Run() error {
 
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCost)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendNodeCost(cfg.NodeCost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		return err
 	}
@@ -269,10 +273,11 @@ func (cfg tcpListenerCfg) Run() error {
 
 // tcpDialerCfg is the cmdline configuration object for a TCP dialer.
 type tcpDialerCfg struct {
-	Address string  `description:"Remote address (Host:Port) to connect to" barevalue:"yes" required:"yes"`
-	Redial  bool    `description:"Keep redialing on lost connection" default:"true"`
-	TLS     string  `description:"Name of TLS client config"`
-	Cost    float64 `description:"Connection cost (weight)" default:"1.0"`
+	Address      string   `description:"Remote address (Host:Port) to connect to" barevalue:"yes" required:"yes"`
+	Redial       bool     `description:"Keep redialing on lost connection" default:"true"`
+	TLS          string   `description:"Name of TLS client config"`
+	Cost         float64  `description:"Connection cost (weight)" default:"1.0"`
+	AllowedPeers []string `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies the parameters are correct.
@@ -301,7 +306,9 @@ func (cfg tcpDialerCfg) Run() error {
 
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, nil)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -392,7 +392,7 @@ func (c UDPListen) setup(nc *netceptor.Netceptor) error {
 		return fmt.Errorf("invalid udp listener config for %s: %w", c.Address, err)
 	}
 
-	if err := nc.AddBackend(b, cost, nodeCosts); err != nil {
+	if err := nc.AddBackend(b, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCosts)); err != nil {
 		return fmt.Errorf("error creating backend for udp listener %s: %w", c.Address, err)
 	}
 
@@ -420,7 +420,7 @@ func (c UDPDial) setup(nc *netceptor.Netceptor) error {
 		return fmt.Errorf("invalid udp listener connection for %s: %w", c.Address, err)
 	}
 
-	if err := nc.AddBackend(b, cost, nil); err != nil {
+	if err := nc.AddBackend(b, netceptor.BackendConnectionCost(cost), nil); err != nil {
 		return fmt.Errorf("error creating backend for udp connection %s: %w", c.Address, err)
 	}
 

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -267,10 +267,11 @@ func (ns *UDPListenerSession) Close() error {
 
 // udpListenerCfg is the cmdline configuration object for a UDP listener.
 type udpListenerCfg struct {
-	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
-	Port     int                `description:"Local UDP port to listen on" barevalue:"yes" required:"yes"`
-	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
-	NodeCost map[string]float64 `description:"Per-node costs"`
+	BindAddr     string             `description:"Local address to bind to" default:"0.0.0.0"`
+	Port         int                `description:"Local UDP port to listen on" barevalue:"yes" required:"yes"`
+	Cost         float64            `description:"Connection cost (weight)" default:"1.0"`
+	NodeCost     map[string]float64 `description:"Per-node costs"`
+	AllowedPeers []string           `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies the parameters are correct.
@@ -296,7 +297,10 @@ func (cfg udpListenerCfg) Run() error {
 
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCost)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendNodeCost(cfg.NodeCost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		logger.Error("Error creating backend for %s: %s\n", address, err)
 
@@ -308,9 +312,10 @@ func (cfg udpListenerCfg) Run() error {
 
 // udpDialerCfg is the cmdline configuration object for a UDP listener.
 type udpDialerCfg struct {
-	Address string  `description:"Host:Port to connect to" barevalue:"yes" required:"yes"`
-	Redial  bool    `description:"Keep redialing on lost connection" default:"true"`
-	Cost    float64 `description:"Connection cost (weight)" default:"1.0"`
+	Address      string   `description:"Host:Port to connect to" barevalue:"yes" required:"yes"`
+	Redial       bool     `description:"Keep redialing on lost connection" default:"true"`
+	Cost         float64  `description:"Connection cost (weight)" default:"1.0"`
+	AllowedPeers []string `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies the parameters are correct.
@@ -331,7 +336,9 @@ func (cfg udpDialerCfg) Run() error {
 
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, nil)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		logger.Error("Error creating backend for %s: %s\n", cfg.Address, err)
 

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -22,12 +22,12 @@ import (
 // external backend running the websockets protocol.
 func TestWebsocketExternalInterop(t *testing.T) {
 	// Create a Netceptor with an external backend
-	n1 := netceptor.New(context.Background(), "node1", nil)
+	n1 := netceptor.New(context.Background(), "node1")
 	b1, err := netceptor.NewExternalBackend()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n1.AddBackend(b1, 1.0, nil)
+	err = n1.AddBackend(b1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,7 +94,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 	}()
 
 	// Create a Netceptor websocket client that connects to our server
-	n2 := netceptor.New(context.Background(), "node2", nil)
+	n2 := netceptor.New(context.Background(), "node2")
 	CAcerts := x509.NewCertPool()
 	CAcerts.AppendCertsFromPEM(certPEM)
 	tls2 := &tls.Config{
@@ -107,7 +107,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n2.AddBackend(b2, 1.0, nil)
+	err = n2.AddBackend(b2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -243,12 +243,13 @@ func (ns *WebsocketSession) Close() error {
 
 // websocketListenerCfg is the cmdline configuration object for a websocket listener.
 type websocketListenerCfg struct {
-	BindAddr string             `description:"Local address to bind to" default:"0.0.0.0"`
-	Port     int                `description:"Local TCP port to run http server on" barevalue:"yes" required:"yes"`
-	Path     string             `description:"URI path to the websocket server" default:"/"`
-	TLS      string             `description:"Name of TLS server config"`
-	Cost     float64            `description:"Connection cost (weight)" default:"1.0"`
-	NodeCost map[string]float64 `description:"Per-node costs"`
+	BindAddr     string             `description:"Local address to bind to" default:"0.0.0.0"`
+	Port         int                `description:"Local TCP port to run http server on" barevalue:"yes" required:"yes"`
+	Path         string             `description:"URI path to the websocket server" default:"/"`
+	TLS          string             `description:"Name of TLS server config"`
+	Cost         float64            `description:"Connection cost (weight)" default:"1.0"`
+	NodeCost     map[string]float64 `description:"Per-node costs"`
+	AllowedPeers []string           `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies the parameters are correct.
@@ -279,7 +280,10 @@ func (cfg websocketListenerCfg) Run() error {
 		return err
 	}
 	b.SetPath(cfg.Path)
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, cfg.NodeCost)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendNodeCost(cfg.NodeCost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		return err
 	}
@@ -289,11 +293,12 @@ func (cfg websocketListenerCfg) Run() error {
 
 // websocketDialerCfg is the cmdline configuration object for a Websocket listener.
 type websocketDialerCfg struct {
-	Address     string  `description:"URL to connect to" barevalue:"yes" required:"yes"`
-	Redial      bool    `description:"Keep redialing on lost connection" default:"true"`
-	ExtraHeader string  `description:"Sends extra HTTP header on initial connection"`
-	TLS         string  `description:"Name of TLS client config"`
-	Cost        float64 `description:"Connection cost (weight)" default:"1.0"`
+	Address      string   `description:"URL to connect to" barevalue:"yes" required:"yes"`
+	Redial       bool     `description:"Keep redialing on lost connection" default:"true"`
+	ExtraHeader  string   `description:"Sends extra HTTP header on initial connection"`
+	TLS          string   `description:"Name of TLS client config"`
+	Cost         float64  `description:"Connection cost (weight)" default:"1.0"`
+	AllowedPeers []string `description:"Peer node IDs to allow via this connection"`
 }
 
 // Prepare verifies that we are reasonably ready to go.
@@ -332,7 +337,9 @@ func (cfg websocketDialerCfg) Run() error {
 
 		return err
 	}
-	err = netceptor.MainInstance.AddBackend(b, cfg.Cost, nil)
+	err = netceptor.MainInstance.AddBackend(b,
+		netceptor.BackendConnectionCost(cfg.Cost),
+		netceptor.BackendAllowedPeers(cfg.AllowedPeers))
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -408,7 +408,7 @@ func (c WSListen) setup(nc *netceptor.Netceptor) error {
 		return fmt.Errorf("invalid ws listener config for %s: %w", c.Address, err)
 	}
 
-	if err := nc.AddBackend(b, cost, nodeCosts); err != nil {
+	if err := nc.AddBackend(b, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCosts)); err != nil {
 		return fmt.Errorf("error creating backend for ws listener %s: %w", c.Address, err)
 	}
 
@@ -456,7 +456,7 @@ func (c WSDial) setup(nc *netceptor.Netceptor) error {
 		return fmt.Errorf("invalid ws listener dialer for %s: %w", c.URL, err)
 	}
 
-	if err := nc.AddBackend(b, cost, nil); err != nil {
+	if err := nc.AddBackend(b, netceptor.BackendConnectionCost(cost), nil); err != nil {
 		return fmt.Errorf("error creating backend for ws dialer %s: %w", c.URL, err)
 	}
 

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -71,7 +71,7 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 	pc := &PacketConn{
 		s:            s,
 		localService: service,
-		recvChan:     make(chan *messageData),
+		recvChan:     make(chan *MessageData),
 		advertise:    advertise,
 		adTags:       adTags,
 		connType:     connType,

--- a/pkg/netceptor/firewall_rules.go
+++ b/pkg/netceptor/firewall_rules.go
@@ -177,26 +177,26 @@ func regexCompare(field string, value string) (compareFunc, error) {
 
 //goland:noinspection GoVetStructTag
 type ruleString struct {
-	RuleSpec *ruleSpec `@@`
-	Action   string    `":" @Ident`
+	RuleSpec *ruleSpec `@@`         //nolint
+	Action   string    `":" @Ident` //nolint
 }
 
 //goland:noinspection GoVetStructTag
 type ruleSpec struct {
-	All   string  `@"all"`
-	Rules []*rule `| @@ ( "," @@ )*`
+	All   string  `@"all"`           //nolint
+	Rules []*rule `| @@ ( "," @@ )*` //nolint
 }
 
 //goland:noinspection GoVetStructTag
 type rule struct {
-	Field string     `@Ident`
-	Value *ruleValue `@@`
+	Field string     `@Ident` //nolint
+	Value *ruleValue `@@`     //nolint
 }
 
 //goland:noinspection GoVetStructTag
 type ruleValue struct {
-	Value string `"=" (@Ident|@Text)`
-	Regex string `| "=" @Regex`
+	Value string `"=" (@Ident|@Text)` //nolint
+	Regex string `| "=" @Regex`       //nolint
 }
 
 var (

--- a/pkg/netceptor/firewall_rules.go
+++ b/pkg/netceptor/firewall_rules.go
@@ -1,0 +1,206 @@
+package netceptor
+
+import (
+	"fmt"
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer/stateful"
+	"regexp"
+	"strings"
+)
+
+/*
+
+This file provides a parser for firewall rules provided by the CLI.  It takes strings
+and returns rule functions suitable for passing to AddFirewallRules().
+
+The firewall language is as follows:
+
+RULE[, RULE, ...]: ACTION
+
+Each RULE is either the word "all", or an expression of the form field=value or field=/regex/, where field
+can be FromNode, FromService, ToNode or ToService.  Regular expressions must match the whole string, not
+a substring.  A special RULE of "all" matches everything.  ACTION can be one of Accept, Reject or Drop.
+All tokens are case insensitive and all whitespace is optional; field values contents are case sensitive.
+
+Example rules:
+
+all:accept
+  Accepts everything
+
+FromNode=foo, ToNode=bar, ToService=control: drop
+  Silently drops messages from foo to bar's control service
+  Note that "foo", "bar" and "control" are case sensitive
+
+fromnode = /a.*b/ : reject
+  Rejects messages originating from any node whose node ID starts with a and ends with b
+
+TONODE = /(?i)a.*b/ : reject
+  Rejects messages destined for any node whose node ID starts with a or A and ends with b or B
+
+*/
+
+// ParseFirewallRule takes a single string describing a firewall rule, and returns a FirewallRule function
+func ParseFirewallRule(rule string) (FirewallRule, error) {
+	parsedRule := &ruleString{}
+	err := ruleParser.ParseString("rule", rule, parsedRule)
+	if err != nil {
+		return nil, err
+	}
+	comps := make([]compareFunc, 0)
+	for _, pr := range parsedRule.RuleSpec.Rules {
+		if pr.Value.Value != "" {
+			comp, err := stringCompare(pr.Field, pr.Value.Value)
+			if err != nil {
+				return nil, err
+			}
+			comps = append(comps, comp)
+		} else if pr.Value.Regex != "" {
+			comp, err := regexCompare(pr.Field, pr.Value.Regex)
+			if err != nil {
+				return nil, err
+			}
+			comps = append(comps, comp)
+		} else {
+			return nil, fmt.Errorf("no value or regex provided for field %s", pr.Field)
+		}
+	}
+	fwr, err := firewallRule(comps, parsedRule.Action)
+	if err != nil {
+		return nil, err
+	}
+	return fwr, nil
+}
+
+// ParseFirewallRules takes a slice of string describing firewall rules, and returns a slice of FirewallRule functions
+func ParseFirewallRules(rules []string) ([]FirewallRule, error) {
+	results := make([]FirewallRule, 0)
+	for i, rule := range rules {
+		result, err := ParseFirewallRule(rule)
+		if err != nil {
+			return nil, fmt.Errorf("error in rule %d: %s", i, err)
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+type compareFunc func(md *MessageData) bool
+
+func firewallRule(comparers []compareFunc, action string) (FirewallRule, error) {
+	var result FirewallResult
+	switch strings.ToLower(action) {
+	case "accept":
+		result = FirewallResultAccept
+	case "reject":
+		result = FirewallResultReject
+	case "drop":
+		result = FirewallResultDrop
+	default:
+		return nil, fmt.Errorf("unknown action: %s", action)
+	}
+	if len(comparers) == 0 {
+		return func(md *MessageData) FirewallResult {
+			return result
+		}, nil
+	}
+	return func(md *MessageData) FirewallResult {
+		matched := true
+		for _, comp := range comparers {
+			matched = matched && comp(md)
+		}
+		if matched {
+			return result
+		}
+		return FirewallResultContinue
+	}, nil
+}
+
+func stringCompare(field string, value string) (compareFunc, error) {
+	switch strings.ToLower(field) {
+	case "fromnode":
+		return func(md *MessageData) bool {
+			return md.FromNode == value
+		}, nil
+	case "fromservice":
+		return func(md *MessageData) bool {
+			return md.FromService == value
+		}, nil
+	case "tonode":
+		return func(md *MessageData) bool {
+			return md.ToNode == value
+		}, nil
+	case "toservice":
+		return func(md *MessageData) bool {
+			return md.ToService == value
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown field: %s", field)
+}
+
+func regexCompare(field string, value string) (compareFunc, error) {
+	if value[0] != '/' || value[len(value)-1] != '/' {
+		return nil, fmt.Errorf("regex not enclosed in //")
+	}
+	value = fmt.Sprintf("^%s$", value[1:len(value)-1])
+	re, err := regexp.Compile(value)
+	if err != nil {
+		return nil, fmt.Errorf("regex failed to compile: %s", value)
+	}
+	switch strings.ToLower(field) {
+	case "fromnode":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.FromNode)
+		}, nil
+	case "fromservice":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.FromService)
+		}, nil
+	case "tonode":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.ToNode)
+		}, nil
+	case "toservice":
+		return func(md *MessageData) bool {
+			return re.MatchString(md.ToService)
+		}, nil
+	}
+	return nil, fmt.Errorf("unknown field: %s", field)
+}
+
+//goland:noinspection GoVetStructTag
+type ruleString struct {
+	RuleSpec *ruleSpec `@@`
+	Action   string    `":" @Ident`
+}
+
+//goland:noinspection GoVetStructTag
+type ruleSpec struct {
+	All   string  `@"all"`
+	Rules []*rule `| @@ ( "," @@ )*`
+}
+
+//goland:noinspection GoVetStructTag
+type rule struct {
+	Field string     `@Ident`
+	Value *ruleValue `@@`
+}
+
+//goland:noinspection GoVetStructTag
+type ruleValue struct {
+	Value string `"=" (@Ident|@Text)`
+	Regex string `| "=" @Regex`
+}
+
+var (
+	ruleLexer = stateful.MustSimple([]stateful.Rule{
+		{"Ident", `\w+`, nil},
+		{"Regex", `\/((?:[^/\\]|\\.)*)\/`, nil},
+		{"Text", `[^/,:= \t\r\n][^,:= \t\r\n]*`, nil},
+		{"Whitespace", `\s+`, nil},
+		{"Punctuation", `[-[~!@#$%^&*()+_={}\|:;"'<,>.?/]|]`, nil},
+	})
+	ruleParser = participle.MustBuild(&ruleString{},
+		participle.Lexer(ruleLexer),
+		participle.Elide("Whitespace"),
+		participle.UseLookahead(2))
+)

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -1,0 +1,72 @@
+package netceptor
+
+import (
+	"testing"
+)
+
+func TestFirewallRules(t *testing.T) {
+
+	// Rule #1
+	rule, err := ParseFirewallRule("all:accept")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultAccept {
+		t.Fatal("rule #1 did not return Accept")
+	}
+
+	// Rule #2
+	rule, err = ParseFirewallRule("FromNode=foo, ToNode=bar, ToService=control: drop")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultContinue {
+		t.Fatal("rule #2 did not return Continue")
+	}
+	if rule(&MessageData{
+		FromNode:  "foo",
+		ToNode:    "bar",
+		ToService: "control",
+	}) != FirewallResultDrop {
+		t.Fatal("rule #2 did not return Drop")
+	}
+
+	// Rule #3
+	rule, err = ParseFirewallRule("fromnode = /a.*b/ : reject")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultContinue {
+		t.Fatal("rule #3 did not return Continue")
+	}
+	if rule(&MessageData{
+		FromNode: "appleb",
+	}) != FirewallResultReject {
+		t.Fatal("rule #3 did not return Reject")
+	}
+	if rule(&MessageData{
+		FromNode: "Appleb",
+	}) != FirewallResultContinue {
+		t.Fatal("rule #3 did not return Continue")
+	}
+
+	// Rule #4
+	rule, err = ParseFirewallRule("TONODE = /(?i)a.*b/ : reject")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rule(&MessageData{}) != FirewallResultContinue {
+		t.Fatal("rule #4 did not return Continue")
+	}
+	if rule(&MessageData{
+		ToNode: "appleb",
+	}) != FirewallResultReject {
+		t.Fatal("rule #4 did not return Reject")
+	}
+	if rule(&MessageData{
+		ToNode: "Appleb",
+	}) != FirewallResultReject {
+		t.Fatal("rule #4 did not return Reject")
+	}
+
+}

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -5,8 +5,12 @@ import (
 )
 
 func TestFirewallRules(t *testing.T) {
+	var frd FirewallRuleData
+
 	// Rule #1
-	rule, err := ParseFirewallRule("all:accept")
+	frd = FirewallRuleData{}
+	frd["action"] = "accept"
+	rule, err := frd.ParseFirewallRule()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -14,8 +18,13 @@ func TestFirewallRules(t *testing.T) {
 		t.Fatal("rule #1 did not return Accept")
 	}
 
-	// Rule #2
-	rule, err = ParseFirewallRule("FromNode=foo, ToNode=bar, ToService=control: drop")
+	// // Rule #2
+	frd = FirewallRuleData{}
+	frd["Action"] = "drop"
+	frd["FromNode"] = "foo"
+	frd["ToNode"] = "bar"
+	frd["ToService"] = "control"
+	rule, err = frd.ParseFirewallRule()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -31,7 +40,10 @@ func TestFirewallRules(t *testing.T) {
 	}
 
 	// Rule #3
-	rule, err = ParseFirewallRule("fromnode = /a.*b/ : reject")
+	frd = FirewallRuleData{}
+	frd["fromnode"] = "/a.*b/"
+	frd["action"] = "reject"
+	rule, err = frd.ParseFirewallRule()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +62,10 @@ func TestFirewallRules(t *testing.T) {
 	}
 
 	// Rule #4
-	rule, err = ParseFirewallRule("TONODE = /(?i)a.*b/ : reject")
+	frd = FirewallRuleData{}
+	frd["TONODE"] = "/(?i)a.*b/"
+	frd["ACTION"] = "reject"
+	rule, err = frd.ParseFirewallRule()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -5,7 +5,6 @@ import (
 )
 
 func TestFirewallRules(t *testing.T) {
-
 	// Rule #1
 	rule, err := ParseFirewallRule("all:accept")
 	if err != nil {
@@ -68,5 +67,4 @@ func TestFirewallRules(t *testing.T) {
 	}) != FirewallResultReject {
 		t.Fatal("rule #4 did not return Reject")
 	}
-
 }

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -1445,13 +1445,15 @@ func (s *Netceptor) handleMessageData(md *MessageData) error {
 	case FirewallResultDrop:
 		return nil
 	case FirewallResultReject:
-		_ = s.sendUnreachable(md.FromNode, &UnreachableMessage{
-			FromNode:    md.FromNode,
-			ToNode:      md.ToNode,
-			FromService: md.FromService,
-			ToService:   md.ToService,
-			Problem:     ProblemRejected,
-		})
+		if md.FromService != "unreach" {
+			_ = s.sendUnreachable(md.FromNode, &UnreachableMessage{
+				FromNode:    md.FromNode,
+				ToNode:      md.ToNode,
+				FromService: md.FromService,
+				ToService:   md.ToService,
+				Problem:     ProblemRejected,
+			})
+		}
 
 		return nil
 	}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -86,8 +86,10 @@ type FirewallRule func(*MessageData) FirewallResult
 type FirewallResult int
 
 const (
+	// FirewallResultContinue continues processing further rules (no result)
+	FirewallResultContinue FirewallResult = iota
 	// FirewallResultAccept accepts the message for normal processing
-	FirewallResultAccept FirewallResult = iota
+	FirewallResultAccept
 	// FirewallResultReject denies the message, sending an unreachable message to the originator
 	FirewallResultReject
 	// FirewallResultDrop denies the message silently, leaving the originator to time out
@@ -1429,26 +1431,29 @@ func (s *Netceptor) handleMessageData(md *MessageData) error {
 
 	// Check firewall rules for this packet
 	s.firewallLock.RLock()
+	result := FirewallResultAccept
 	for _, rule := range s.firewallRules {
-		switch rule(md) {
-		case FirewallResultAccept:
-			// do nothing
-		case FirewallResultDrop:
-			s.firewallLock.RUnlock()
-			return nil
-		case FirewallResultReject:
-			_ = s.sendUnreachable(md.FromNode, &UnreachableMessage{
-				FromNode:    md.FromNode,
-				ToNode:      md.ToNode,
-				FromService: md.FromService,
-				ToService:   md.ToService,
-				Problem:     ProblemRejected,
-			})
-			s.firewallLock.RUnlock()
-			return nil
+		result = rule(md)
+		if result != FirewallResultContinue {
+			break
 		}
 	}
 	s.firewallLock.RUnlock()
+	switch result {
+	case FirewallResultAccept:
+		// do nothing
+	case FirewallResultDrop:
+		return nil
+	case FirewallResultReject:
+		_ = s.sendUnreachable(md.FromNode, &UnreachableMessage{
+			FromNode:    md.FromNode,
+			ToNode:      md.ToNode,
+			FromService: md.FromService,
+			ToService:   md.ToService,
+			Problem:     ProblemRejected,
+		})
+		return nil
+	}
 
 	// If the destination is local, then dispatch the message to a service
 	if md.ToNode == s.nodeID {

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -79,8 +79,8 @@ type BackendSession interface {
 	Close() error
 }
 
-// FirewallRule is a function that takes a message and returns a firewall decision.
-type FirewallRule func(*MessageData) FirewallResult
+// FirewallRuleFunc is a function that takes a message and returns a firewall decision.
+type FirewallRuleFunc func(*MessageData) FirewallResult
 
 // FirewallResult enumerates the actions that can be taken as a result of a firewall rule.
 type FirewallResult int
@@ -139,7 +139,7 @@ type Netceptor struct {
 	unreachableBroker      *utils.Broker
 	routingUpdateBroker    *utils.Broker
 	firewallLock           *sync.RWMutex
-	firewallRules          []FirewallRule
+	firewallRules          []FirewallRuleFunc
 }
 
 // ConnStatus holds information about a single connection in the Status struct.
@@ -601,7 +601,7 @@ func (s *Netceptor) PathCost(nodeID string) (float64, error) {
 }
 
 // AddFirewallRules adds firewall rules, optionally clearing existing rules first.
-func (s *Netceptor) AddFirewallRules(rules []FirewallRule, clearExisting bool) error {
+func (s *Netceptor) AddFirewallRules(rules []FirewallRuleFunc, clearExisting bool) error {
 	s.firewallLock.Lock()
 	defer s.firewallLock.Unlock()
 	if clearExisting {

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -82,17 +82,17 @@ type BackendSession interface {
 // FirewallRule is a function that takes a message and returns a firewall decision.
 type FirewallRule func(*MessageData) FirewallResult
 
-// FirewallResult enumerates the actions that can be taken as a result of a firewall rule
+// FirewallResult enumerates the actions that can be taken as a result of a firewall rule.
 type FirewallResult int
 
 const (
-	// FirewallResultContinue continues processing further rules (no result)
+	// FirewallResultContinue continues processing further rules (no result).
 	FirewallResultContinue FirewallResult = iota
-	// FirewallResultAccept accepts the message for normal processing
+	// FirewallResultAccept accepts the message for normal processing.
 	FirewallResultAccept
-	// FirewallResultReject denies the message, sending an unreachable message to the originator
+	// FirewallResultReject denies the message, sending an unreachable message to the originator.
 	FirewallResultReject
-	// FirewallResultDrop denies the message silently, leaving the originator to time out
+	// FirewallResultDrop denies the message silently, leaving the originator to time out.
 	FirewallResultDrop
 )
 
@@ -174,11 +174,11 @@ const (
 	ProblemServiceUnknown = "service unknown"
 	// ProblemExpiredInTransit occurs when a message's HopsToLive expires in transit.
 	ProblemExpiredInTransit = "message expired"
-	// ProblemRejected occurs when a packet is rejected by a firewall rule
+	// ProblemRejected occurs when a packet is rejected by a firewall rule.
 	ProblemRejected = "blocked by firewall"
 )
 
-// MessageData contains a single message packet from the network
+// MessageData contains a single message packet from the network.
 type MessageData struct {
 	FromNode    string
 	FromService string
@@ -360,9 +360,9 @@ func NewWithConsts(ctx context.Context, nodeID string,
 	return &s
 }
 
-// New constructs a new Receptor network protocol instance
-func New(ctx context.Context, NodeID string) *Netceptor {
-	return NewWithConsts(ctx, NodeID, defaultMTU, defaultRouteUpdateTime, defaultServiceAdTime,
+// New constructs a new Receptor network protocol instance.
+func New(ctx context.Context, nodeID string) *Netceptor {
+	return NewWithConsts(ctx, nodeID, defaultMTU, defaultRouteUpdateTime, defaultServiceAdTime,
 		defaultSeenUpdateExpireTime, defaultMaxForwardingHops, defaultMaxConnectionIdleTime)
 }
 
@@ -431,21 +431,21 @@ type backendInfo struct {
 	allowedPeers   []string
 }
 
-// BackendConnectionCost is a modifier for AddBackend, which sets the global connection cost
+// BackendConnectionCost is a modifier for AddBackend, which sets the global connection cost.
 func BackendConnectionCost(cost float64) func(*backendInfo) {
 	return func(bi *backendInfo) {
 		bi.connectionCost = cost
 	}
 }
 
-// BackendNodeCost is a modifier for AddBackend, which sets the per-node connection costs
+// BackendNodeCost is a modifier for AddBackend, which sets the per-node connection costs.
 func BackendNodeCost(nodeCost map[string]float64) func(*backendInfo) {
 	return func(bi *backendInfo) {
 		bi.nodeCost = nodeCost
 	}
 }
 
-// BackendAllowedPeers is a modifier for AddBackend, which sets the list of peers allowed to connect
+// BackendAllowedPeers is a modifier for AddBackend, which sets the list of peers allowed to connect.
 func BackendAllowedPeers(peers []string) func(*backendInfo) {
 	return func(bi *backendInfo) {
 		bi.allowedPeers = peers
@@ -608,6 +608,7 @@ func (s *Netceptor) AddFirewallRules(rules []FirewallRule, clearExisting bool) e
 		s.firewallRules = nil
 	}
 	s.firewallRules = append(s.firewallRules, rules...)
+
 	return nil
 }
 
@@ -1428,7 +1429,6 @@ func (s *Netceptor) dispatchReservedService(md *MessageData) (bool, error) {
 
 // Handles incoming data and dispatches it to a service listener.
 func (s *Netceptor) handleMessageData(md *MessageData) error {
-
 	// Check firewall rules for this packet
 	s.firewallLock.RLock()
 	result := FirewallResultAccept
@@ -1452,6 +1452,7 @@ func (s *Netceptor) handleMessageData(md *MessageData) error {
 			ToService:   md.ToService,
 			Problem:     ProblemRejected,
 		})
+
 		return nil
 	}
 

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -495,7 +495,7 @@ func TestFirewalling(t *testing.T) {
 	}
 
 	// Add a firewall to node 1 that rejects messages whose data is "bad"
-	err = n1.AddFirewallRules([]FirewallRule{
+	err = n1.AddFirewallRules([]FirewallRuleFunc{
 		func(md *MessageData) FirewallResult {
 			if string(md.Data) == "bad" {
 				return FirewallResultReject
@@ -654,7 +654,7 @@ func TestAllowedPeers(t *testing.T) {
 	}
 
 	// Add a firewall to node 1 that rejects messages whose data is "bad"
-	err = n1.AddFirewallRules([]FirewallRule{
+	err = n1.AddFirewallRules([]FirewallRuleFunc{
 		func(md *MessageData) FirewallResult {
 			if string(md.Data) == "bad" {
 				return FirewallResultReject

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -233,6 +233,7 @@ func TestLotsOfPings(t *testing.T) {
 				pc, err := sender.ListenPacket("")
 				if err != nil {
 					errorChan <- err
+
 					return
 				}
 				go func() {
@@ -242,6 +243,7 @@ func TestLotsOfPings(t *testing.T) {
 						err := pc.SetReadDeadline(time.Now().Add(1 * time.Second))
 						if err != nil {
 							errorChan <- fmt.Errorf("error in SetReadDeadline: %s", err)
+
 							return
 						}
 						_, addr, err := pc.ReadFrom(buf)
@@ -254,10 +256,12 @@ func TestLotsOfPings(t *testing.T) {
 						ncAddr, ok := addr.(Addr)
 						if !ok {
 							errorChan <- fmt.Errorf("addr was not a Netceptor address")
+
 							return
 						}
 						if ncAddr.node != recipient.nodeID {
 							errorChan <- fmt.Errorf("received response from wrong node")
+
 							return
 						}
 						t.Logf("%s received response from %s", sender.nodeID, recipient.nodeID)
@@ -496,6 +500,7 @@ func TestFirewalling(t *testing.T) {
 			if string(md.Data) == "bad" {
 				return FirewallResultReject
 			}
+
 			return FirewallResultAccept
 		},
 	}, true)
@@ -598,7 +603,7 @@ func TestFirewalling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n, _, err = pc1.ReadFrom(buf)
+	_, _, err = pc1.ReadFrom(buf)
 	if err != ErrTimeout {
 		if err == nil {
 			err = fmt.Errorf("received message that should have been firewalled")
@@ -654,6 +659,7 @@ func TestAllowedPeers(t *testing.T) {
 			if string(md.Data) == "bad" {
 				return FirewallResultReject
 			}
+
 			return FirewallResultAccept
 		},
 	}, true)
@@ -756,7 +762,7 @@ func TestAllowedPeers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	n, _, err = pc1.ReadFrom(buf)
+	_, _, err = pc1.ReadFrom(buf)
 	if err != ErrTimeout {
 		if err == nil {
 			err = fmt.Errorf("received message that should have been firewalled")

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -162,7 +162,7 @@ func TestLotsOfPings(t *testing.T) {
 
 	nodes := []*Netceptor{}
 	for i := 0; i < numBackboneNodes; i++ {
-		nodes = append(nodes, New(context.Background(), fmt.Sprintf("backbone_%d", i), nil))
+		nodes = append(nodes, New(context.Background(), fmt.Sprintf("backbone_%d", i)))
 	}
 	for i := 0; i < numBackboneNodes; i++ {
 		for j := 0; j < i; j++ {

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -53,21 +53,21 @@ func TestHopCountLimit(t *testing.T) {
 	}()
 
 	// Create two Netceptor nodes using external backends
-	n1 := New(context.Background(), "node1", nil)
+	n1 := New(context.Background(), "node1")
 	b1, err := NewExternalBackend()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n1.AddBackend(b1, 1.0, nil)
+	err = n1.AddBackend(b1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	n2 := New(context.Background(), "node2", nil)
+	n2 := New(context.Background(), "node2")
 	b2, err := NewExternalBackend()
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = n2.AddBackend(b2, 1.0, nil)
+	err = n2.AddBackend(b2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -89,7 +89,8 @@ func TestHopCountLimit(t *testing.T) {
 	// Wait for the nodes to establish routing to each other
 	var routes1 map[string]string
 	var routes2 map[string]string
-	timeout, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 	for {
 		select {
 		case <-timeout.Done():
@@ -129,7 +130,8 @@ func TestHopCountLimit(t *testing.T) {
 	}
 
 	// If the hop count limit is not working, the connections will never become inactive
-	timeout, _ = context.WithTimeout(context.Background(), 2*time.Second)
+	timeout, cancel = context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	for {
 		c, ok := n1.connections["node2"]
 		if !ok {
@@ -168,14 +170,14 @@ func TestLotsOfPings(t *testing.T) {
 		for j := 0; j < i; j++ {
 			b1, err := NewExternalBackend()
 			if err == nil {
-				err = nodes[i].AddBackend(b1, 1.0, nil)
+				err = nodes[i].AddBackend(b1)
 			}
 			if err != nil {
 				t.Fatal(err)
 			}
 			b2, err := NewExternalBackend()
 			if err == nil {
-				err = nodes[j].AddBackend(b2, 1.0, nil)
+				err = nodes[j].AddBackend(b2)
 			}
 			if err != nil {
 				t.Fatal(err)
@@ -193,16 +195,16 @@ func TestLotsOfPings(t *testing.T) {
 		for j := 0; j < numLeafNodesPerBackbone; j++ {
 			b1, err := NewExternalBackend()
 			if err == nil {
-				err = nodes[i].AddBackend(b1, 1.0, nil)
+				err = nodes[i].AddBackend(b1)
 			}
 			if err != nil {
 				t.Fatal(err)
 			}
-			newNode := New(context.Background(), fmt.Sprintf("leaf_%d_%d", i, j), nil)
+			newNode := New(context.Background(), fmt.Sprintf("leaf_%d_%d", i, j))
 			nodes = append(nodes, newNode)
 			b2, err := NewExternalBackend()
 			if err == nil {
-				err = newNode.AddBackend(b2, 1.0, nil)
+				err = newNode.AddBackend(b2)
 			}
 			if err != nil {
 				t.Fatal(err)
@@ -221,6 +223,7 @@ func TestLotsOfPings(t *testing.T) {
 		responses[i] = make([]bool, len(nodes))
 	}
 
+	errorChan := make(chan error)
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	wg := sync.WaitGroup{}
 	for i := range nodes {
@@ -229,7 +232,8 @@ func TestLotsOfPings(t *testing.T) {
 			go func(sender *Netceptor, recipient *Netceptor, response *bool) {
 				pc, err := sender.ListenPacket("")
 				if err != nil {
-					t.Fatal(err)
+					errorChan <- err
+					return
 				}
 				go func() {
 					defer wg.Done()
@@ -237,7 +241,8 @@ func TestLotsOfPings(t *testing.T) {
 						buf := make([]byte, 1024)
 						err := pc.SetReadDeadline(time.Now().Add(1 * time.Second))
 						if err != nil {
-							t.Fatalf("error in SetReadDeadline: %s", err)
+							errorChan <- fmt.Errorf("error in SetReadDeadline: %s", err)
+							return
 						}
 						_, addr, err := pc.ReadFrom(buf)
 						if ctx.Err() != nil {
@@ -248,10 +253,12 @@ func TestLotsOfPings(t *testing.T) {
 						}
 						ncAddr, ok := addr.(Addr)
 						if !ok {
-							t.Fatal("addr was not a Netceptor address")
+							errorChan <- fmt.Errorf("addr was not a Netceptor address")
+							return
 						}
 						if ncAddr.node != recipient.nodeID {
-							t.Fatal("Received response from wrong node")
+							errorChan <- fmt.Errorf("received response from wrong node")
+							return
 						}
 						t.Logf("%s received response from %s", sender.nodeID, recipient.nodeID)
 						*response = true
@@ -309,7 +316,11 @@ func TestLotsOfPings(t *testing.T) {
 	}()
 
 	t.Log("waiting for done")
-	<-ctx.Done()
+	select {
+	case err := <-errorChan:
+		t.Fatal(err)
+	case <-ctx.Done():
+	}
 	t.Log("waiting for waitgroup")
 	wg.Wait()
 
@@ -330,14 +341,14 @@ func TestDuplicateNodeDetection(t *testing.T) {
 	backends := make([]*ExternalBackend, netsize)
 	routingChans := make([]chan map[string]string, netsize)
 	for i := 0; i < netsize; i++ {
-		nodes[i] = New(context.Background(), fmt.Sprintf("node%d", i), nil)
+		nodes[i] = New(context.Background(), fmt.Sprintf("node%d", i))
 		routingChans[i] = nodes[i].SubscribeRoutingUpdates()
 		var err error
 		backends[i], err = NewExternalBackend()
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = nodes[i].AddBackend(backends[i], 1.0, nil)
+		err = nodes[i].AddBackend(backends[i])
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -372,7 +383,8 @@ func TestDuplicateNodeDetection(t *testing.T) {
 			}
 		}(i)
 	}
-	timeout, _ := context.WithTimeout(context.Background(), 10*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 	for {
 		select {
 		case <-timeout.Done():
@@ -405,13 +417,13 @@ func TestDuplicateNodeDetection(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		// Create and connect a new node with a duplicate name
-		n := New(context.Background(), "node0", nil)
+		n := New(context.Background(), "node0")
 		logger.Info("Duplicate node0 has epoch %d\n", n.epoch)
 		b, err := NewExternalBackend()
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = n.AddBackend(b, 1.0, nil)
+		err = n.AddBackend(b)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -445,4 +457,320 @@ func TestDuplicateNodeDetection(t *testing.T) {
 	for i := 0; i < netsize; i++ {
 		nodes[i].BackendWait()
 	}
+}
+
+func TestFirewalling(t *testing.T) {
+	lw := &logWriter{
+		t: t,
+	}
+	log.SetOutput(lw)
+	logger.SetShowTrace(true)
+	defer func() {
+		log.SetOutput(os.Stdout)
+		logger.SetShowTrace(false)
+	}()
+
+	// Create two Netceptor nodes using external backends
+	n1 := New(context.Background(), "node1")
+	b1, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n1.AddBackend(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2 := New(context.Background(), "node2")
+	b2, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n2.AddBackend(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a firewall to node 1 that rejects messages whose data is "bad"
+	err = n1.AddFirewallRules([]FirewallRule{
+		func(md *MessageData) FirewallResult {
+			if string(md.Data) == "bad" {
+				return FirewallResultReject
+			}
+			return FirewallResultAccept
+		},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a Unix socket pair and use it to connect the backends
+	c1, c2, err := socketpair.New("unix")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for node list updates
+	nCh1 := n1.SubscribeRoutingUpdates()
+	nCh2 := n2.SubscribeRoutingUpdates()
+
+	// Connect the two nodes
+	b1.NewConnection(MessageConnFromNetConn(c1), true)
+	b2.NewConnection(MessageConnFromNetConn(c2), true)
+
+	// Wait for the nodes to establish routing to each other
+	var routes1 map[string]string
+	var routes2 map[string]string
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-timeout.Done():
+			t.Fatal("timed out waiting for nodes to connect")
+		case routes1 = <-nCh1:
+		case routes2 = <-nCh2:
+		}
+		if routes1 != nil && routes2 != nil {
+			_, ok := routes1["node2"]
+			if ok {
+				_, ok := routes2["node1"]
+				if ok {
+					break
+				}
+			}
+		}
+	}
+
+	// Set up packet connection
+	pc1, err := n1.ListenPacket("testsvc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc2, err := n2.ListenPacket("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for unreachable messages
+	unreach2chan := pc2.SubscribeUnreachable()
+
+	// Save received unreachable messages to a variable
+	var lastUnreachMsg *UnreachableNotification
+	go func() {
+		for {
+			select {
+			case <-timeout.Done():
+				return
+			case unreach := <-unreach2chan:
+				lastUnreachMsg = &unreach
+			}
+		}
+	}()
+
+	// Send a good message
+	lastUnreachMsg = nil
+	_, err = pc2.WriteTo([]byte("good"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 256)
+	n, _, err := pc1.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:n]) != "good" {
+		t.Fatal("incorrect message received")
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg != nil {
+		t.Fatalf("unexpected unreachable message received: %v", lastUnreachMsg)
+	}
+
+	// Send a bad message
+	_, err = pc2.WriteTo([]byte("bad"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, _, err = pc1.ReadFrom(buf)
+	if err != ErrTimeout {
+		if err == nil {
+			err = fmt.Errorf("received message that should have been firewalled")
+		}
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg == nil {
+		t.Fatal("did not receive expected unreachable message")
+	}
+
+	// Shut down the network
+	n1.Shutdown()
+	n2.Shutdown()
+	n1.BackendWait()
+	n2.BackendWait()
+}
+
+func TestAllowedPeers(t *testing.T) {
+	lw := &logWriter{
+		t: t,
+	}
+	log.SetOutput(lw)
+	logger.SetShowTrace(true)
+	defer func() {
+		log.SetOutput(os.Stdout)
+		logger.SetShowTrace(false)
+	}()
+
+	// Create two Netceptor nodes using external backends
+	n1 := New(context.Background(), "node1")
+	b1, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n1.AddBackend(b1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	n2 := New(context.Background(), "node2")
+	b2, err := NewExternalBackend()
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = n2.AddBackend(b2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a firewall to node 1 that rejects messages whose data is "bad"
+	err = n1.AddFirewallRules([]FirewallRule{
+		func(md *MessageData) FirewallResult {
+			if string(md.Data) == "bad" {
+				return FirewallResultReject
+			}
+			return FirewallResultAccept
+		},
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a Unix socket pair and use it to connect the backends
+	c1, c2, err := socketpair.New("unix")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for node list updates
+	nCh1 := n1.SubscribeRoutingUpdates()
+	nCh2 := n2.SubscribeRoutingUpdates()
+
+	// Connect the two nodes
+	b1.NewConnection(MessageConnFromNetConn(c1), true)
+	b2.NewConnection(MessageConnFromNetConn(c2), true)
+
+	// Wait for the nodes to establish routing to each other
+	var routes1 map[string]string
+	var routes2 map[string]string
+	timeout, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	for {
+		select {
+		case <-timeout.Done():
+			t.Fatal("timed out waiting for nodes to connect")
+		case routes1 = <-nCh1:
+		case routes2 = <-nCh2:
+		}
+		if routes1 != nil && routes2 != nil {
+			_, ok := routes1["node2"]
+			if ok {
+				_, ok := routes2["node1"]
+				if ok {
+					break
+				}
+			}
+		}
+	}
+
+	// Set up packet connection
+	pc1, err := n1.ListenPacket("testsvc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc2, err := n2.ListenPacket("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Subscribe for unreachable messages
+	unreach2chan := pc2.SubscribeUnreachable()
+
+	// Save received unreachable messages to a variable
+	var lastUnreachMsg *UnreachableNotification
+	go func() {
+		for {
+			select {
+			case <-timeout.Done():
+				return
+			case unreach := <-unreach2chan:
+				lastUnreachMsg = &unreach
+			}
+		}
+	}()
+
+	// Send a good message
+	lastUnreachMsg = nil
+	_, err = pc2.WriteTo([]byte("good"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 256)
+	n, _, err := pc1.ReadFrom(buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(buf[:n]) != "good" {
+		t.Fatal("incorrect message received")
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg != nil {
+		t.Fatalf("unexpected unreachable message received: %v", lastUnreachMsg)
+	}
+
+	// Send a bad message
+	_, err = pc2.WriteTo([]byte("bad"), n2.NewAddr("node1", "testsvc"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pc1.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	n, _, err = pc1.ReadFrom(buf)
+	if err != ErrTimeout {
+		if err == nil {
+			err = fmt.Errorf("received message that should have been firewalled")
+		}
+		t.Fatal(err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if lastUnreachMsg == nil {
+		t.Fatal("did not receive expected unreachable message")
+	}
+
+	// Shut down the network
+	n1.Shutdown()
+	n2.Shutdown()
+	n1.BackendWait()
+	n2.BackendWait()
 }

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -14,7 +14,7 @@ import (
 type PacketConn struct {
 	s                  *Netceptor
 	localService       string
-	recvChan           chan *messageData
+	recvChan           chan *MessageData
 	readDeadline       time.Time
 	advertise          bool
 	adTags             map[string]string
@@ -46,7 +46,7 @@ func (s *Netceptor) ListenPacket(service string) (*PacketConn, error) {
 	pc := &PacketConn{
 		s:            s,
 		localService: service,
-		recvChan:     make(chan *messageData),
+		recvChan:     make(chan *MessageData),
 		advertise:    false,
 		adTags:       nil,
 		connType:     ConnTypeDatagram,
@@ -128,7 +128,7 @@ func (pc *PacketConn) SubscribeUnreachable() chan UnreachableNotification {
 
 // ReadFrom reads a packet from the network and returns its data and address.
 func (pc *PacketConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
-	var m *messageData
+	var m *MessageData
 	if pc.readDeadline.IsZero() {
 		m = <-pc.recvChan
 	} else {

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -63,7 +63,7 @@ func (r Receptor) Serve(ctx context.Context) error {
 		id = *r.ID
 	}
 
-	nc := netceptor.New(ctx, id, r.AllowedPeers)
+	nc := netceptor.New(ctx, id)
 	wc, err := workceptor.New(ctx, nc, r.DataDir)
 	if err != nil {
 		return fmt.Errorf("could not setup workceptor from serve config: %w", err)

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -34,7 +34,7 @@ func TestWorkceptorJson(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpdir)
-	nc := netceptor.New(context.Background(), "test", nil)
+	nc := netceptor.New(nil, "test")
 	w, err := New(context.Background(), nc, tmpdir)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -34,7 +34,7 @@ func TestWorkceptorJson(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpdir)
-	nc := netceptor.New(nil, "test")
+	nc := netceptor.New(context.TODO(), "test")
 	w, err := New(context.Background(), nc, tmpdir)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -43,8 +43,7 @@ type LibMesh struct {
 
 // NewLibNode builds a node with the name passed as the argument.
 func NewLibNode(name string) *LibNode {
-	n1 := netceptor.New(context.Background(), name, nil)
-
+	n1 := netceptor.New(context.Background(), name)
 	return &LibNode{
 		NetceptorInstance: n1,
 		serverTLSConfigs:  make(map[string]*tls.Config),
@@ -108,8 +107,7 @@ func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]fl
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
-
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
 	return err
 }
 
@@ -120,8 +118,7 @@ func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) erro
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
-
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
 	return err
 }
 
@@ -133,8 +130,7 @@ func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]fl
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
-
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
 	return err
 }
 
@@ -145,8 +141,7 @@ func (n *LibNode) UDPDial(address string, cost float64) error {
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
-
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
 	return err
 }
 
@@ -159,8 +154,7 @@ func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[str
 		return err
 	}
 	n.Backends = append(n.Backends, b1)
-	err = n.NetceptorInstance.AddBackend(b1, cost, nodeCost)
-
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
 	return err
 }
 
@@ -172,8 +166,7 @@ func (n *LibNode) WebsocketDial(address string, cost float64, tlsCfg *tls.Config
 	if err != nil {
 		return err
 	}
-	err = n.NetceptorInstance.AddBackend(b1, cost, nil)
-
+	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
 	return err
 }
 

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -44,6 +44,7 @@ type LibMesh struct {
 // NewLibNode builds a node with the name passed as the argument.
 func NewLibNode(name string) *LibNode {
 	n1 := netceptor.New(context.Background(), name)
+
 	return &LibNode{
 		NetceptorInstance: n1,
 		serverTLSConfigs:  make(map[string]*tls.Config),
@@ -108,6 +109,7 @@ func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]fl
 	}
 	n.Backends = append(n.Backends, b1)
 	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
+
 	return err
 }
 
@@ -119,6 +121,7 @@ func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) erro
 		return err
 	}
 	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
+
 	return err
 }
 
@@ -131,6 +134,7 @@ func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]fl
 	}
 	n.Backends = append(n.Backends, b1)
 	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
+
 	return err
 }
 
@@ -142,6 +146,7 @@ func (n *LibNode) UDPDial(address string, cost float64) error {
 		return err
 	}
 	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
+
 	return err
 }
 
@@ -155,6 +160,7 @@ func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[str
 	}
 	n.Backends = append(n.Backends, b1)
 	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost), netceptor.BackendNodeCost(nodeCost))
+
 	return err
 }
 
@@ -167,6 +173,7 @@ func (n *LibNode) WebsocketDial(address string, cost float64, tlsCfg *tls.Config
 		return err
 	}
 	err = n.NetceptorInstance.AddBackend(b1, netceptor.BackendConnectionCost(cost))
+
 	return err
 }
 

--- a/tests/functional/mesh/firewall_test.go
+++ b/tests/functional/mesh/firewall_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ansible/receptor/tests/functional/lib/mesh"
+	"github.com/ansible/receptor/tests/functional/lib/receptorcontrol"
 	_ "github.com/fortytw2/leaktest"
-	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
-	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
 )
 
 func TestFirewall(t *testing.T) {

--- a/tests/functional/mesh/firewall_test.go
+++ b/tests/functional/mesh/firewall_test.go
@@ -2,11 +2,12 @@ package mesh
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	_ "github.com/fortytw2/leaktest"
 	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
 	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
-	"testing"
-	"time"
 )
 
 func TestFirewall(t *testing.T) {
@@ -29,7 +30,7 @@ func TestFirewall(t *testing.T) {
 			// but node1 and node3 can't talk to each other because node2 blocks the traffic
 			data.Nodes["node1"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node2": mesh.YamlConnection{
+					"node2": {
 						Index: 0,
 					},
 				},
@@ -58,7 +59,7 @@ func TestFirewall(t *testing.T) {
 			}
 			data.Nodes["node3"] = &mesh.YamlNode{
 				Connections: map[string]mesh.YamlConnection{
-					"node2": mesh.YamlConnection{
+					"node2": {
 						Index: 0,
 					},
 				},
@@ -113,7 +114,6 @@ func TestFirewall(t *testing.T) {
 				t.Logf("%v", err)
 				controller.Close()
 			}
-
 		})
 	}
 }

--- a/tests/functional/mesh/firewall_test.go
+++ b/tests/functional/mesh/firewall_test.go
@@ -1,0 +1,119 @@
+package mesh
+
+import (
+	"context"
+	_ "github.com/fortytw2/leaktest"
+	"github.com/project-receptor/receptor/tests/functional/lib/mesh"
+	"github.com/project-receptor/receptor/tests/functional/lib/receptorcontrol"
+	"testing"
+	"time"
+)
+
+func TestFirewall(t *testing.T) {
+	t.Parallel()
+	testTable := []struct {
+		listener string
+	}{
+		{"tcp-listener"},
+		{"ws-listener"},
+	}
+	for _, data := range testTable {
+		listener := data.listener
+		t.Run(listener, func(t *testing.T) {
+			t.Parallel()
+			// Setup our mesh yaml data
+			data := mesh.YamlData{}
+			data.Nodes = make(map[string]*mesh.YamlNode)
+
+			// Generate a mesh of node1->node2->node3 with firewall rules so node2 can talk to node1 and node3,
+			// but node1 and node3 can't talk to each other because node2 blocks the traffic
+			data.Nodes["node1"] = &mesh.YamlNode{
+				Connections: map[string]mesh.YamlConnection{
+					"node2": mesh.YamlConnection{
+						Index: 0,
+					},
+				},
+				Nodedef: []interface{}{
+					map[interface{}]interface{}{
+						listener: map[interface{}]interface{}{},
+					},
+				},
+			}
+			data.Nodes["node2"] = &mesh.YamlNode{
+				Nodedef: []interface{}{
+					map[interface{}]interface{}{
+						listener: map[interface{}]interface{}{},
+					},
+					map[interface{}]interface{}{
+						"node": map[interface{}]interface{}{
+							"id": "node2",
+							"firewallrules": []interface{}{
+								"FromNode=node2:accept",
+								"ToNode=node3:reject",
+								"ToNode=node1:reject",
+							},
+						},
+					},
+				},
+			}
+			data.Nodes["node3"] = &mesh.YamlNode{
+				Connections: map[string]mesh.YamlConnection{
+					"node2": mesh.YamlConnection{
+						Index: 0,
+					},
+				},
+				Nodedef: []interface{}{
+					map[interface{}]interface{}{
+						listener: map[interface{}]interface{}{},
+					},
+				},
+			}
+			m, err := mesh.NewCLIMeshFromYaml(data, t.Name())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer m.WaitForShutdown()
+			defer m.Destroy()
+
+			ctx, _ := context.WithTimeout(context.Background(), 20*time.Second)
+			err = m.WaitForReady(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Test that node1 and node3 can ping node2
+			for _, nodeSender := range []mesh.Node{m.Nodes()["node1"], m.Nodes()["node3"]} {
+				controller := receptorcontrol.New()
+				err = controller.Connect(nodeSender.ControlSocket())
+				if err != nil {
+					t.Fatal(err)
+				}
+				response, err := controller.Ping("node2")
+				if err != nil {
+					t.Error(err)
+				}
+				t.Logf("%v", response)
+				controller.Close()
+			}
+
+			// Test that node1 and node3 cannot ping each other
+			for strSender, strReceiver := range map[string]string{"node1": "node3", "node3": "node1"} {
+				controller := receptorcontrol.New()
+				err = controller.Connect(m.Nodes()[strSender].ControlSocket())
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err := controller.Ping(strReceiver)
+				if err == nil {
+					t.Error("firewall failed to block ping")
+				} else if err.Error() != "blocked by firewall" {
+					t.Errorf("got wrong error: %s", err)
+				}
+
+				t.Logf("%v", err)
+				controller.Close()
+			}
+
+		})
+	}
+}

--- a/tests/functional/mesh/firewall_test.go
+++ b/tests/functional/mesh/firewall_test.go
@@ -48,10 +48,10 @@ func TestFirewall(t *testing.T) {
 					map[interface{}]interface{}{
 						"node": map[interface{}]interface{}{
 							"id": "node2",
-							"firewallrules": []interface{}{
-								"FromNode=node2:accept",
-								"ToNode=node3:reject",
-								"ToNode=node1:reject",
+							"firewallrules": []map[string]string{
+								{"Action": "accept", "FromNode": "node2"},
+								{"Action": "reject", "ToNode": "node3"},
+								{"Action": "reject", "ToNode": "node1"},
 							},
 						},
 					},

--- a/tests/functional/mesh/firewall_test.go
+++ b/tests/functional/mesh/firewall_test.go
@@ -34,21 +34,21 @@ func TestFirewall(t *testing.T) {
 						Index: 0,
 					},
 				},
-				Nodedef: []interface{}{
+				NodedefBase: []interface{}{
 					map[interface{}]interface{}{
 						listener: map[interface{}]interface{}{},
 					},
 				},
 			}
 			data.Nodes["node2"] = &mesh.YamlNode{
-				Nodedef: []interface{}{
+				NodedefBase: []interface{}{
 					map[interface{}]interface{}{
 						listener: map[interface{}]interface{}{},
 					},
 					map[interface{}]interface{}{
 						"node": map[interface{}]interface{}{
 							"id": "node2",
-							"firewallrules": []map[string]string{
+							"firewallrules": []map[interface{}]interface{}{
 								{"Action": "accept", "FromNode": "node2"},
 								{"Action": "reject", "ToNode": "node3"},
 								{"Action": "reject", "ToNode": "node1"},
@@ -63,7 +63,7 @@ func TestFirewall(t *testing.T) {
 						Index: 0,
 					},
 				},
-				Nodedef: []interface{}{
+				NodedefBase: []interface{}{
 					map[interface{}]interface{}{
 						listener: map[interface{}]interface{}{},
 					},


### PR DESCRIPTION
This PR adds the following security features to Receptor:

### Firewall rules

The firewall feature for adds a new method `netceptor.AddFirewallRules()`, which attaches a list of rules to this Netceptor instance.  Once attached, the rules are checked for every `MsgTypeData` packet, including both local and to-be-forwarded packets.  Firewall rules are processed just before dispatching the packet to a local service or router.

A firewall rule is simply a Go function that takes a `*MessageData` and returns a decision, which can be `FirewallResultAccept` (allow the packet), `FirewallResultReject` (deny the packet with an unreachable message), or `FirewallResultDrop` (deny the packet silently).

This PR changes the visibility of `MessageData` from private to public, so that it can be passed to firewall functions in other packages.

### Firewall CLI language & parser

A new option `firewallrules` is added to the `node` CLI struct.  This takes a list of hashes/dictionaries/objects, each describing a firewall rule to be created.  Rules can match simple strings or regular expressions.  Example rules

```yaml
# Accepts everything

---
node:
  firewallrules:
    - action: "accept"
```

```yaml
# Drops traffic from `foo` to `bar`'s control service

---
node:
  firewallrules:
    - action: "drop"
      fromnode: "foo"
      tonode: "bar"
      toservice: "control"
```

```yaml
# Rejects traffic originating from nodes like abcb, adfb, etc

---
node:
  firewallrules:
    - action: "reject"
      fromnode: "/a.*b/"
```

```yaml
# Rejects traffic destined for nodes like abcb, AdfB, etc

---
node:
  firewallrules:
    - action: "reject"
      tonode: "/(?i)a.*b/"
```

### Per-connection AllowedPeers

The existing AllowedPeers command applies to the whole Receptor node, with no regard to which connection a peer is connecting through.  In circumstances where control is desired over the node IDs allowed to connect, it is likely that the user will also want to control which connection they can connect through.

To accomplish this, the `AllowedPeers` parameter is removed from `netceptor.New()` and moved to `AddBackend()`.  **This is a breaking change** because we can't change the signature of these functions without breaking callers.  The `AddBackend()` function is changed to use the modifier pattern, which provides the ability to non-breakingly add more options in future.

#### TODOs

---

- [x] Add documentation