### PR TITLE
Signed work submissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ TESTCMD = -run $(RUNTEST)
 endif
 
 test:
-	@go test ./... -p 1 -parallel=16 $(TESTCMD) -count=1 -v
+	@go test ./... -p 1 -parallel=16 $(TESTCMD) -count=1
 
 testloop: receptor
 	@i=1; while echo "------ $$i" && \

--- a/docs/source/tls.rst
+++ b/docs/source/tls.rst
@@ -22,10 +22,10 @@ foo.yml
 
     - tls-server:
         name: myserver
-        cert: foo.crt
-        key: foo.key
+        cert: /full/path/foo.crt
+        key: /full/path/foo.key
         requireclientcert: true
-        clientcas: ca.crt
+        clientcas: /full/path/ca.crt
 
     - tcp-listener:
         port: 2222

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/ghjm/cmdline v0.1.0
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/websocket v1.4.2
 	github.com/jupp0r/go-priority-queue v0.0.0-20160601094913-ab1073853bde

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -223,6 +223,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 				cfr, err = cc.ControlFunc(s.nc, cfo)
 			}
 			if err != nil {
+				logger.Error(err.Error())
 				_, err = conn.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
 				if err != nil {
 					logger.Error("Write error in control service: %s\n", err)

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -221,9 +221,11 @@ const (
 	ConnTypeStreamTLS = 2
 )
 
+// WorkCommand tracks available work types and whether they verify work submissions.
 type WorkCommand struct {
 	WorkType string
-	Secure   bool
+	// Secure true means receptor will verify the signature of the work submit payload
+	Secure bool
 }
 
 // ServiceAdvertisement is the data associated with a service advertisement.
@@ -233,7 +235,7 @@ type ServiceAdvertisement struct {
 	Time         time.Time
 	ConnType     byte
 	Tags         map[string]string
-	WorkCommands string
+	WorkCommands []WorkCommand
 }
 
 // serviceAdvertisementFull is the whole message from the network.
@@ -569,8 +571,7 @@ func (s *Netceptor) Status() Status {
 			if adCopy.NodeID == s.nodeID {
 				adCopy.Time = time.Now()
 				if len(s.workCommands) > 0 {
-					wCBytes, _ := json.Marshal(s.workCommands)
-					adCopy.WorkCommands = string(wCBytes)
+					adCopy.WorkCommands = s.workCommands
 				}
 			}
 			serviceAds = append(serviceAds, &adCopy)
@@ -697,8 +698,7 @@ func (s *Netceptor) sendServiceAds() {
 			if svcType, ok := sa.Tags["type"]; ok {
 				if svcType == "Control Service" {
 					if len(s.workCommands) > 0 {
-						wCBytes, _ := json.Marshal(s.workCommands)
-						sa.WorkCommands = string(wCBytes)
+						sa.WorkCommands = s.workCommands
 					}
 				}
 			}

--- a/pkg/workceptor/interfaces.go
+++ b/pkg/workceptor/interfaces.go
@@ -18,6 +18,7 @@ type WorkUnit interface {
 	Restart() error
 	Cancel() error
 	Release(force bool) error
+	SetSignWork(signWork bool)
 }
 
 // NewWorkerFunc represents a factory of WorkUnit instances.

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -39,11 +39,12 @@ func TestWorkceptorJson(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = w.RegisterWorker("command", newCommandWorker)
+	err = w.RegisterWorker("command", newCommandWorker, false)
 	if err != nil {
 		t.Fatal(err)
 	}
-	cw, err := w.AllocateUnit("command", make(map[string]string))
+	signature := ""
+	cw, err := w.AllocateUnit("command", signature, make(map[string]string))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/workceptor/python.go
+++ b/pkg/workceptor/python.go
@@ -69,7 +69,7 @@ func (cfg workPythonCfg) newWorker(w *Workceptor, unitID string, workType string
 
 // Run runs the action.
 func (cfg workPythonCfg) Run() error {
-	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker)
+	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker, false)
 
 	return err
 }
@@ -106,5 +106,5 @@ func (p Python) setup(wc *Workceptor) error {
 		return cw
 	}
 
-	return wc.RegisterWorker(p.WorkType, factory)
+	return wc.RegisterWorker(p.WorkType, factory, false)
 }

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -177,7 +177,7 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 		}
 		rsaPrivateKey, err := certificates.LoadPrivateKey(rw.w.signingkey)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not load signing key file: %s", err.Error())
 		}
 		token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
 		tokenString, err := token.SignedString(rsaPrivateKey)

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -17,8 +17,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/certificates"
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/utils"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // remoteUnit implements the WorkUnit interface for the Receptor remote worker plugin.
@@ -163,6 +165,27 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 	workSubmitCmd["node"] = red.RemoteNode
 	workSubmitCmd["worktype"] = red.RemoteWorkType
 	workSubmitCmd["tlsclient"] = red.TLSClient
+	if rw.signWork {
+		if rw.w.signingkey == "" {
+			return fmt.Errorf("cannot sign work: signing key is empty")
+		}
+		exp := time.Now().Add(rw.w.signingexpiration)
+
+		claims := &jwt.StandardClaims{
+			ExpiresAt: exp.Unix(),
+			Audience:  red.RemoteNode,
+		}
+		rsaPrivateKey, err := certificates.LoadPrivateKey(rw.w.signingkey)
+		if err != nil {
+			return err
+		}
+		token := jwt.NewWithClaims(jwt.SigningMethodRS512, claims)
+		tokenString, err := token.SignedString(rsaPrivateKey)
+		if err != nil {
+			return err
+		}
+		workSubmitCmd["signature"] = tokenString
+	}
 	wscBytes, err := json.Marshal(workSubmitCmd)
 	if err != nil {
 		return fmt.Errorf("error constructing work submit command: %s", err)
@@ -619,7 +642,7 @@ func (rw *remoteUnit) Release(force bool) error {
 	return rw.cancelOrRelease(true, force)
 }
 
-func newRemoteWorker(w *Workceptor, unitID string, workType string) WorkUnit {
+func newRemoteWorker(w *Workceptor, unitID, workType string) WorkUnit {
 	rw := &remoteUnit{}
 	rw.BaseWorkUnit.Init(w, unitID, workType)
 	red := &remoteExtraData{}

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -162,9 +162,12 @@ func (w *Workceptor) AllocateUnit(workTypeName, signature string, params map[str
 		if signature == "" {
 			return nil, fmt.Errorf("could not verify signature: signature is empty")
 		}
+		if w.verifyingkey == "" {
+			return nil, fmt.Errorf("could not verify signature: verifying key not specified")
+		}
 		rsaPublicKey, err := certificates.LoadPublicKey(w.verifyingkey)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("could not load verifying key file: %s", err.Error())
 		}
 		token, err := jwt.ParseWithClaims(signature, &jwt.StandardClaims{}, func(token *jwt.Token) (interface{}, error) {
 			return rsaPublicKey, nil

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -15,27 +15,33 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/certificates"
 	"github.com/ansible/receptor/pkg/controlsvc"
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/randstr"
 	"github.com/ansible/receptor/pkg/utils"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 // Workceptor is the main object that handles unit-of-work management.
 type Workceptor struct {
-	ctx             context.Context
-	nc              *netceptor.Netceptor
-	dataDir         string
-	workTypesLock   *sync.RWMutex
-	workTypes       map[string]*workType
-	activeUnitsLock *sync.RWMutex
-	activeUnits     map[string]WorkUnit
+	ctx               context.Context
+	nc                *netceptor.Netceptor
+	dataDir           string
+	workTypesLock     *sync.RWMutex
+	workTypes         map[string]*workType
+	activeUnitsLock   *sync.RWMutex
+	activeUnits       map[string]WorkUnit
+	signingkey        string
+	signingexpiration time.Duration
+	verifyingkey      string
 }
 
 // workType is the record for a registered type of work.
 type workType struct {
-	newWorkerFunc NewWorkerFunc
+	newWorkerFunc   NewWorkerFunc
+	verifySignature bool
 }
 
 // New constructs a new Workceptor instance.
@@ -45,15 +51,18 @@ func New(ctx context.Context, nc *netceptor.Netceptor, dataDir string) (*Workcep
 	}
 	dataDir = path.Join(dataDir, nc.NodeID())
 	w := &Workceptor{
-		ctx:             ctx,
-		nc:              nc,
-		dataDir:         dataDir,
-		workTypesLock:   &sync.RWMutex{},
-		workTypes:       make(map[string]*workType),
-		activeUnitsLock: &sync.RWMutex{},
-		activeUnits:     make(map[string]WorkUnit),
+		ctx:               ctx,
+		nc:                nc,
+		dataDir:           dataDir,
+		workTypesLock:     &sync.RWMutex{},
+		workTypes:         make(map[string]*workType),
+		activeUnitsLock:   &sync.RWMutex{},
+		activeUnits:       make(map[string]WorkUnit),
+		signingkey:        "",
+		signingexpiration: 5 * time.Minute,
+		verifyingkey:      "",
 	}
-	err := w.RegisterWorker("remote", newRemoteWorker)
+	err := w.RegisterWorker("remote", newRemoteWorker, false)
 	if err != nil {
 		return nil, fmt.Errorf("could not register remote worker function: %s", err)
 	}
@@ -87,7 +96,7 @@ func (w *Workceptor) RegisterWithControlService(cs *controlsvc.Server) error {
 }
 
 // RegisterWorker notifies the Workceptor of a new kind of work that can be done.
-func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc) error {
+func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc, verifySignature bool) error {
 	w.workTypesLock.Lock()
 	_, ok := w.workTypes[typeName]
 	if ok {
@@ -96,10 +105,11 @@ func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc
 		return fmt.Errorf("work type %s already registered", typeName)
 	}
 	w.workTypes[typeName] = &workType{
-		newWorkerFunc: newWorkerFunc,
+		newWorkerFunc:   newWorkerFunc,
+		verifySignature: verifySignature,
 	}
 	if typeName != "remote" { // all workceptors get a remote command by default
-		w.nc.AddWorkCommand(typeName)
+		w.nc.AddWorkCommand(typeName, verifySignature)
 	}
 	w.workTypesLock.Unlock()
 
@@ -139,7 +149,7 @@ func (w *Workceptor) generateUnitID(lock bool) (string, error) {
 }
 
 // AllocateUnit creates a new local work unit and generates an identifier for it.
-func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string) (WorkUnit, error) {
+func (w *Workceptor) AllocateUnit(workTypeName, signature string, params map[string]string) (WorkUnit, error) {
 	w.workTypesLock.RLock()
 	wt, ok := w.workTypes[workTypeName]
 	w.workTypesLock.RUnlock()
@@ -148,6 +158,29 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 	}
 	w.activeUnitsLock.Lock()
 	defer w.activeUnitsLock.Unlock()
+	if wt.verifySignature {
+		if signature == "" {
+			return nil, fmt.Errorf("could not verify signature: signature is empty")
+		}
+		rsaPublicKey, err := certificates.LoadPublicKey(w.verifyingkey)
+		if err != nil {
+			return nil, err
+		}
+		token, err := jwt.ParseWithClaims(signature, &jwt.StandardClaims{}, func(token *jwt.Token) (interface{}, error) {
+			return rsaPublicKey, nil
+		})
+		if err != nil {
+			return nil, fmt.Errorf("could not verify signature: %s", err.Error())
+		}
+		if !token.Valid {
+			return nil, fmt.Errorf("token not valid")
+		}
+		claims := token.Claims.(*jwt.StandardClaims)
+		ok := claims.VerifyAudience(w.nc.NodeID(), true)
+		if !ok {
+			return nil, fmt.Errorf("token audience did not match node ID")
+		}
+	}
 	ident, err := w.generateUnitID(false)
 	if err != nil {
 		return nil, err
@@ -166,7 +199,7 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 }
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it.
-func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsclient, ttl string, params map[string]string) (WorkUnit, error) {
+func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsclient, ttl string, signWork bool, params map[string]string) (WorkUnit, error) {
 	if tlsclient != "" {
 		_, err := w.nc.GetClientTLSConfig(tlsclient, "testhost", "receptor")
 		if err != nil {
@@ -184,7 +217,9 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsclient, t
 	if hasSecrets && tlsclient == "" {
 		return nil, fmt.Errorf("cannot send secrets over a non-TLS connection")
 	}
-	rw, err := w.AllocateUnit("remote", params)
+	signature := ""
+	rw, err := w.AllocateUnit("remote", signature, params)
+	rw.SetSignWork(signWork)
 	if err != nil {
 		return nil, err
 	}
@@ -195,6 +230,9 @@ func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsclient, t
 			logger.Error("Failed to parse provided ttl -- valid examples include '1.5h', '30m', '30m10s'")
 
 			return nil, err
+		}
+		if signWork && duration > w.signingexpiration {
+			logger.Warning("json web token expires before ttl")
 		}
 		expiration = time.Now().Add(duration)
 	} else {

--- a/pkg/workceptor/workceptor_stub.go
+++ b/pkg/workceptor/workceptor_stub.go
@@ -33,17 +33,17 @@ func (w *Workceptor) RegisterWithControlService(cs *controlsvc.Server) error {
 }
 
 // RegisterWorker notifies the Workceptor of a new kind of work that can be done
-func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc) error {
+func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc, verifySignature bool) error {
 	return ErrNotImplemented
 }
 
 // AllocateUnit creates a new local work unit and generates an identifier for it
-func (w *Workceptor) AllocateUnit(workTypeName string, params string) (WorkUnit, error) {
+func (w *Workceptor) AllocateUnit(workTypeName, signature string, params string) (WorkUnit, error) {
 	return nil, ErrNotImplemented
 }
 
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it
-func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, tlsclient string, ttl string, params string) (WorkUnit, error) {
+func (w *Workceptor) AllocateRemoteUnit(remoteNode string, remoteWorkType string, tlsclient string, ttl string, signWork bool, params string) (WorkUnit, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -74,6 +74,7 @@ type BaseWorkUnit struct {
 	lastUpdateError error
 	ctx             context.Context
 	cancel          context.CancelFunc
+	signWork        bool
 }
 
 // Init initializes the basic work unit data, in memory only.
@@ -89,6 +90,11 @@ func (bwu *BaseWorkUnit) Init(w *Workceptor, unitID string, workType string) {
 	bwu.stdoutFileName = path.Join(bwu.unitDir, "stdout")
 	bwu.statusLock = &sync.RWMutex{}
 	bwu.ctx, bwu.cancel = context.WithCancel(w.ctx)
+	bwu.signWork = false
+}
+
+func (bwu *BaseWorkUnit) SetSignWork(signWork bool) {
+	bwu.signWork = signWork
 }
 
 // SetFromParams sets the in-memory state from parameters.

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -127,7 +127,6 @@ def status(ctx, printjson):
             commands = ad["WorkCommands"]
             if not commands:
                 continue
-            commands = json.loads(commands)
             workTypes = []
             for c in commands:
                 wT = c["WorkType"]

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -140,7 +140,7 @@ class ReceptorControl:
         if not str.startswith(text, "Connecting"):
             raise RuntimeError(text)
 
-    def submit_work(self, worktype, payload, node=None, tlsclient=None, ttl=None, params=None):
+    def submit_work(self, worktype, payload, node=None, tlsclient=None, ttl=None, signwork=False, params=None):
         self.connect()
         if node is None:
             node = "localhost"
@@ -157,6 +157,9 @@ class ReceptorControl:
 
         if ttl:
             commandMap['ttl'] = ttl
+
+        if signwork:
+            commandMap['signwork'] = "true"
 
         if params:
             for k,v in params.items():

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -2,7 +2,6 @@ package mesh
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -571,9 +570,7 @@ func (m *CLIMesh) CheckAdvertisements() bool {
 		actual := map[string][]string{}
 		for _, ad := range status.Advertisements {
 			if len(ad.WorkCommands) > 0 {
-				wcs := []netceptor.WorkCommand{}
-				json.Unmarshal([]byte(ad.WorkCommands), &wcs)
-				for _, workCommand := range wcs {
+				for _, workCommand := range ad.WorkCommands {
 					actual[ad.NodeID] = append(actual[ad.NodeID], workCommand.WorkType)
 				}
 			}

--- a/tests/functional/lib/mesh/climesh.go
+++ b/tests/functional/lib/mesh/climesh.go
@@ -2,6 +2,7 @@ package mesh
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -570,7 +571,11 @@ func (m *CLIMesh) CheckAdvertisements() bool {
 		actual := map[string][]string{}
 		for _, ad := range status.Advertisements {
 			if len(ad.WorkCommands) > 0 {
-				actual[ad.NodeID] = ad.WorkCommands
+				wcs := []netceptor.WorkCommand{}
+				json.Unmarshal([]byte(ad.WorkCommands), &wcs)
+				for _, workCommand := range wcs {
+					actual[ad.NodeID] = append(actual[ad.NodeID], workCommand.WorkType)
+				}
 			}
 		}
 		expected := map[string][]string{}


### PR DESCRIPTION
#### Overview
Adds ability for work submissions to be digitally signed.

https://github.com/ansible/receptor/issues/377

#### Details

An RSA private key is added to any node authorized to submit secure work.

```
---
- node:
    id: foo
- work-signing: 
    privatekey: /home/sbf/sockceptor/certs/signworkprivate.pem
    tokenexpiration: 10h30m
```

The corresponding RSA public key is added to any node that receives secure work.

```
---
- node:
    id: bar
- work-verification:
    publickey: /home/sbf/sockceptor/certs/verifyworkpublic.pem
```

Any work command in bar.yml that expects secure work submissions can set `verifysignature` to be true.

```
- work-command:
    workType: echosleep
    command: bash
    params: "-c \"while read -r line; do echo $line; sleep 1; done\""
    verifysignature: true
```

Tell receptor to sign the work submission using the `--signwork` parameter.

(on foo) `receptorctl work submit echosleep --node bar --signwork`

Only nodes with the correct `work-signing` key is able to start `echosleep` on bar.

#### Notes

receptorctl status now lists secure work types. Nodes must use `--signwork` to run these work units.

```
Node         Work Types
bar          sleepcat, 100cat

Node         Secure Work Types
bar          echosleep
```

Verification occurs for locally submitted work as well. This is because currently the receptor control service does not know the origin of the incoming connection. Therefore, it cannot distinguish between commands submitted from remote nodes, or locally via the unix socket.

Each generated json web token is set to expire in 5 minutes.