### PR TITLE
purge command to remove internal data related to disconnected nodes

### DIFF
--- a/docs/source/interacting_with_nodes.rst
+++ b/docs/source/interacting_with_nodes.rst
@@ -133,6 +133,9 @@ The order of the parameters (from left to right) in the following table matter, 
     * - reload
       -
       -
+    * - purge
+      -
+      - node
     * - ping
       - target
       -
@@ -188,3 +191,36 @@ After saving the configuration file to disk, connect to a control service and is
 This command will cancel all running backend connections and sessions, re-parse the configuration file, and start the backends once more.
 
 This allows users to add or remove backend connections without disrupting ongoing receptor operations. For example, sending payloads or getting work results will only momentarily pause after a reload and will resume once the connections are reestablished.
+
+Purge
+^^^^^
+
+If the "status" command displays information related to nodes that are disconnected or no longer part of the mesh, the ``purge`` command can be used to clean up this information.
+
+Purge will not forcibly remove nodes from the mesh. If the target node still has an active connection to the mesh, purge will fail.
+
+The following status shows that `baz` is no longer connected to the mesh.
+
+.. code::
+
+    Known Node   Known Connections
+    bar          {'fish': 1, 'foo': 1}
+    baz          {}
+    fish         {'bar': 1}
+    foo          {'bar': 1}
+
+.. code::
+
+    receptorctl --socket /tmp/foo.sock purge --node baz
+
+After purge, `baz` no longer shows up in the status.
+
+.. code::
+
+    Known Node   Known Connections
+    bar          {'fish': 1, 'foo': 1}
+    fish         {'bar': 1}
+    foo          {'bar': 1}
+
+
+Use the `--all` parameter to clean up all disconnected or unreachable nodes on the mesh.

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -102,6 +102,7 @@ func New(stdServices bool, nc *netceptor.Netceptor) *Server {
 		s.controlTypes["connect"] = &connectCommandType{}
 		s.controlTypes["traceroute"] = &tracerouteCommandType{}
 		s.controlTypes["reload"] = &reloadCommandType{}
+		s.controlTypes["purge"] = &purgeCommandType{}
 	}
 
 	return s

--- a/pkg/controlsvc/purge.go
+++ b/pkg/controlsvc/purge.go
@@ -1,0 +1,56 @@
+package controlsvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
+)
+
+type (
+	purgeCommandType struct{}
+	purgeCommand     struct {
+		node string
+	}
+)
+
+func (t *purgeCommandType) InitFromString(params string) (ControlCommand, error) {
+	c := &purgeCommand{
+		node: params,
+	}
+
+	return c, nil
+}
+
+func (t *purgeCommandType) InitFromJSON(config map[string]interface{}) (ControlCommand, error) {
+	c := &purgeCommand{
+		node: "",
+	}
+	node, ok := config["node"]
+	if !ok {
+		return c, nil
+	}
+	nodeStr, ok := node.(string)
+	if !ok {
+		return nil, fmt.Errorf("node must be string")
+	}
+	c.node = nodeStr
+
+	return c, nil
+}
+
+func (c *purgeCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+	logger.Debug("Purging all unreachable nodes")
+
+	cfr := make(map[string]interface{})
+	cfr["Success"] = true
+	purgedNodes, err := nc.PurgeUnreachableNodes(c.node)
+	if err != nil {
+		cfr["Success"] = false
+		cfr["Error"] = err.Error()
+	}
+	cfr["PurgedNodes"] = purgedNodes
+
+	return cfr, nil
+}


### PR DESCRIPTION
`receptorctl purge --all`
or
`receptorctl purge --node baz`

cleans up the following internal data structures in netceptor

```
knownConnectionCosts
routingPathCosts
knownNodeInfo
serviceAdsReceived
```

Useful to cleanup the status output

```
Known Node   Known Connections
bar          {'fish': 1, 'foo': 1}
baz          {}
fish         {'bar': 1}
foo          {'bar': 1}
```

In this case `baz` is a disconnected node. After running purge

```
$ receptorctlfoo purge
Purged baz
```

in status output
```
Known Node   Known Connections
bar          {'fish': 1, 'foo': 1}
fish         {'bar': 1}
foo          {'bar': 1}
```

Note: only affects the receptor node you run the purge command on. 