### PR TITLE
Change nightly wheel file name to use verson 0.0.0

### DIFF
--- a/.github/workflows/devel_whl.yml
+++ b/.github/workflows/devel_whl.yml
@@ -26,4 +26,4 @@ jobs:
         run: |
           pip install boto3
           ansible -i localhost, -c local all -m aws_s3 \
-            -a "bucket=receptor-nightlies object=receptorctl/receptorctl-latest-py3-none-any.whl src=$(ls receptorctl/dist/*.whl | head -n 1) mode=put"
+            -a "bucket=receptor-nightlies object=receptorctl/receptorctl-0.0.0-py3-none-any.whl src=$(ls receptorctl/dist/*.whl | head -n 1) mode=put"


### PR DESCRIPTION
`receptorctl-latest-py3-none-any.whl` isn't considered a valid wheel file name and building offline mode rpm fails.