### PR TITLE
Verify signature for work cancel, release, and results

### DIFF
--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -27,6 +27,10 @@ type sockControl struct {
 	conn net.Conn
 }
 
+func (s *sockControl) RemoteAddr() net.Addr {
+	return s.conn.RemoteAddr()
+}
+
 // BridgeConn bridges the socket to another socket.
 func (s *sockControl) BridgeConn(message string, bc io.ReadWriteCloser, bcName string) error {
 	if message != "" {

--- a/pkg/controlsvc/interfaces.go
+++ b/pkg/controlsvc/interfaces.go
@@ -2,6 +2,7 @@ package controlsvc
 
 import (
 	"io"
+	"net"
 
 	"github.com/ansible/receptor/pkg/netceptor"
 )
@@ -23,4 +24,5 @@ type ControlFuncOperations interface {
 	ReadFromConn(message string, out io.Writer) error
 	WriteToConn(message string, in chan []byte) error
 	Close() error
+	RemoteAddr() net.Addr
 }

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -310,7 +310,7 @@ func (cfg commandCfg) newWorker(w *Workceptor, unitID string, workType string) W
 
 // Run runs the action.
 func (cfg commandCfg) Run() error {
-	if cfg.VerifySignature && MainInstance.verifyingkey == "" {
+	if cfg.VerifySignature && MainInstance.verifyingKey == "" {
 		return fmt.Errorf("VerifySignature for work command '%s' is true, but the work verification public key is not specified", cfg.WorkType)
 	}
 	err := MainInstance.RegisterWorker(cfg.WorkType, cfg.newWorker, cfg.VerifySignature)
@@ -374,9 +374,9 @@ func (cfg signingKeyPrivateCfg) Prepare() error {
 		if err != nil {
 			return fmt.Errorf("failed to parse TokenExpiration -- valid examples include '1.5h', '30m', '30m10s'")
 		}
-		MainInstance.signingexpiration = duration
+		MainInstance.signingExpiration = duration
 	}
-	MainInstance.signingkey = cfg.PrivateKey
+	MainInstance.signingKey = cfg.PrivateKey
 
 	return nil
 }
@@ -386,7 +386,7 @@ func (cfg verifyingKeyPublicCfg) Prepare() error {
 	if err != nil {
 		return err
 	}
-	MainInstance.verifyingkey = cfg.PublicKey
+	MainInstance.verifyingKey = cfg.PublicKey
 
 	return nil
 }

--- a/pkg/workceptor/interfaces.go
+++ b/pkg/workceptor/interfaces.go
@@ -18,7 +18,6 @@ type WorkUnit interface {
 	Restart() error
 	Cancel() error
 	Release(force bool) error
-	SetSignWork(signWork bool)
 }
 
 // NewWorkerFunc represents a factory of WorkUnit instances.

--- a/pkg/workceptor/json_test.go
+++ b/pkg/workceptor/json_test.go
@@ -43,8 +43,7 @@ func TestWorkceptorJson(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signature := ""
-	cw, err := w.AllocateUnit("command", signature, make(map[string]string))
+	cw, err := w.AllocateUnit("command", make(map[string]string))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -62,7 +62,7 @@ func New(ctx context.Context, nc *netceptor.Netceptor, dataDir string) (*Workcep
 		signingExpiration: 5 * time.Minute,
 		verifyingKey:      "",
 	}
-	err := w.RegisterWorker("remote", newRemoteWorker, false)
+	err := w.RegisterWorker("remote", newRemoteWorker, true)
 	if err != nil {
 		return nil, fmt.Errorf("could not register remote worker function: %s", err)
 	}

--- a/pkg/workceptor/workceptor_stub.go
+++ b/pkg/workceptor/workceptor_stub.go
@@ -38,7 +38,7 @@ func (w *Workceptor) RegisterWorker(typeName string, newWorkerFunc NewWorkerFunc
 }
 
 // AllocateUnit creates a new local work unit and generates an identifier for it
-func (w *Workceptor) AllocateUnit(workTypeName, signature string, params string) (WorkUnit, error) {
+func (w *Workceptor) AllocateUnit(workTypeName, params string) (WorkUnit, error) {
 	return nil, ErrNotImplemented
 }
 

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -74,7 +74,6 @@ type BaseWorkUnit struct {
 	lastUpdateError error
 	ctx             context.Context
 	cancel          context.CancelFunc
-	signWork        bool
 }
 
 // Init initializes the basic work unit data, in memory only.
@@ -90,11 +89,6 @@ func (bwu *BaseWorkUnit) Init(w *Workceptor, unitID string, workType string) {
 	bwu.stdoutFileName = path.Join(bwu.unitDir, "stdout")
 	bwu.statusLock = &sync.RWMutex{}
 	bwu.ctx, bwu.cancel = context.WithCancel(w.ctx)
-	bwu.signWork = false
-}
-
-func (bwu *BaseWorkUnit) SetSignWork(signWork bool) {
-	bwu.signWork = signWork
 }
 
 // SetFromParams sets the in-memory state from parameters.


### PR DESCRIPTION
This extends the work signing and verification to `work cancel`, `work release`, and `work results`

In the case of `work submit`, clients are required to issue a "signwork=true" as part of the payload (if the target work expects signed work). Since the cancel, release, and results commands operate on an _existing_ work unit, the clients don't need to include a "signwork=true" as part of the payload. Instead, receptor will track which units should expect signed work, and automatically sign the commands.

Another big change -- we don't enforce verification if the commands are coming from a unix socket. This should be helpful for debugging purposes.

Additionally, work will now fail if the client sends a signature and the receiver was not expecting one.

Testing this PR:

1. Start 3 node mesh: e.g. foo, baz, fish
2. foo should have a work-signing set up with a private key
3. fish should have a work-verification set up with the public key. verifySignature set to true on a work-command, `echosleep`
4. On foo, submit work on fish
5. Now, on bar, use the connect command, `connect fish control`
6. Before this PR, we could do a `work cancel`, `work results`, or `work release` here and succeed. This is bad. With this PR, work cancel, results, or release should fail.