### PR TITLE
sleep longer before killing cmd process

### DIFF
--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -38,7 +38,7 @@ func termThenKill(cmd *exec.Cmd) {
 		return
 	}
 	_ = cmd.Process.Signal(os.Interrupt)
-	time.Sleep(1 * time.Second)
+	time.Sleep(10 * time.Second)
 	if cmd.Process != nil {
 		_ = cmd.Process.Kill()
 	}


### PR DESCRIPTION
We are seeing cases where receptor is sent a `cancel` command and the `ansible-runner` process is exiting but is leaving behind a running container. Increasing the amount of time we sleep from one second to ten to give ansible-runner (and work units in general) longer to cleanup before forcefully killing the process.