### PR TITLE
Fix various goroutine leaks and open file descriptor leak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,15 @@ else
 	TAGPARAM=--tags $(TAGS)
 endif
 
+DEBUG ?=
+ifeq ($(DEBUG),1)
+	DEBUGFLAGS=-gcflags=all="-N -l"
+else
+	DEBUGFLAGS=
+endif
+
 receptor: $(shell find pkg -type f -name '*.go') ./cmd/receptor-cl/receptor.go
-	CGO_ENABLED=0 go build -o receptor -ldflags "-X 'github.com/ansible/receptor/internal/version.Version=$(APPVER)'" $(TAGPARAM) ./cmd/receptor-cl
+	CGO_ENABLED=0 go build -o receptor $(DEBUGFLAGS) -ldflags "-X 'github.com/ansible/receptor/internal/version.Version=$(APPVER)'" $(TAGPARAM) ./cmd/receptor-cl
 
 lint:
 	@golint cmd/... pkg/... example/...

--- a/pkg/controlsvc/connect.go
+++ b/pkg/controlsvc/connect.go
@@ -1,6 +1,7 @@
 package controlsvc
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -73,7 +74,7 @@ func (t *connectCommandType) InitFromJSON(config map[string]interface{}) (Contro
 	return c, nil
 }
 
-func (c *connectCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+func (c *connectCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
 	tlscfg, err := nc.GetClientTLSConfig(c.tlsConfigName, c.targetNode, "receptor")
 	if err != nil {
 		return nil, err

--- a/pkg/controlsvc/interfaces.go
+++ b/pkg/controlsvc/interfaces.go
@@ -1,6 +1,7 @@
 package controlsvc
 
 import (
+	"context"
 	"io"
 	"net"
 
@@ -15,7 +16,7 @@ type ControlCommandType interface {
 
 // ControlCommand is an instance of a command that is being run from the control service.
 type ControlCommand interface {
-	ControlFunc(*netceptor.Netceptor, ControlFuncOperations) (map[string]interface{}, error)
+	ControlFunc(context.Context, *netceptor.Netceptor, ControlFuncOperations) (map[string]interface{}, error)
 }
 
 // ControlFuncOperations provides callbacks for control services to take actions.

--- a/pkg/controlsvc/reload.go
+++ b/pkg/controlsvc/reload.go
@@ -1,6 +1,7 @@
 package controlsvc
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -157,7 +158,7 @@ func handleError(err error, errorcode int) (map[string]interface{}, error) {
 	return cfr, nil
 }
 
-func (c *reloadCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+func (c *reloadCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
 	// Reload command stops all backends, and re-runs the ParseAndRun() on the
 	// initial config file
 	logger.Debug("Reloading")

--- a/pkg/controlsvc/status.go
+++ b/pkg/controlsvc/status.go
@@ -1,6 +1,7 @@
 package controlsvc
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/ansible/receptor/internal/version"
@@ -46,7 +47,7 @@ func (t *statusCommandType) InitFromJSON(config map[string]interface{}) (Control
 	return c, nil
 }
 
-func (c *statusCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+func (c *statusCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
 	status := nc.Status()
 	statusGetters := make(map[string]func() interface{})
 	statusGetters["Version"] = func() interface{} { return version.Version }

--- a/pkg/controlsvc/traceroute.go
+++ b/pkg/controlsvc/traceroute.go
@@ -1,6 +1,7 @@
 package controlsvc
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -41,7 +42,7 @@ func (t *tracerouteCommandType) InitFromJSON(config map[string]interface{}) (Con
 	return c, nil
 }
 
-func (c *tracerouteCommand) ControlFunc(nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
+func (c *tracerouteCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
 	cfr := make(map[string]interface{})
 	for i := 0; i <= int(nc.MaxForwardingHops()); i++ {
 		thisResult := make(map[string]interface{})

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -556,7 +556,8 @@ func TestFirewalling(t *testing.T) {
 	}
 
 	// Subscribe for unreachable messages
-	unreach2chan := pc2.SubscribeUnreachable()
+	doneChan := make(chan struct{})
+	unreach2chan := pc2.SubscribeUnreachable(doneChan)
 
 	// Save received unreachable messages to a variable
 	var lastUnreachMsg *UnreachableNotification
@@ -715,7 +716,8 @@ func TestAllowedPeers(t *testing.T) {
 	}
 
 	// Subscribe for unreachable messages
-	unreach2chan := pc2.SubscribeUnreachable()
+	doneChan := make(chan struct{})
+	unreach2chan := pc2.SubscribeUnreachable(doneChan)
 
 	// Save received unreachable messages to a variable
 	var lastUnreachMsg *UnreachableNotification

--- a/pkg/utils/readstring_context.go
+++ b/pkg/utils/readstring_context.go
@@ -15,7 +15,7 @@ type readStringResult = struct {
 // important for callers to error out of further use of the bufio.  Also, the goroutine will not
 // exit until the bufio's underlying connection is closed.
 func ReadStringContext(ctx context.Context, reader *bufio.Reader, delim byte) (string, error) {
-	result := make(chan *readStringResult)
+	result := make(chan *readStringResult, 1)
 	go func() {
 		str, err := reader.ReadString(delim)
 		result <- &readStringResult{

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -4,6 +4,7 @@
 package workceptor
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -211,7 +212,7 @@ func (c *workceptorCommand) processSignature(workType, signature string, connIsU
 }
 
 // Worker function called by the control service to process a "work" command.
-func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.ControlFuncOperations) (map[string]interface{}, error) {
+func (c *workceptorCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo controlsvc.ControlFuncOperations) (map[string]interface{}, error) {
 	addr := cfo.RemoteAddr()
 	connIsUnix := false
 	if addr.Network() == "unix" {
@@ -411,11 +412,8 @@ func (c *workceptorCommand) ControlFunc(nc *netceptor.Netceptor, cfo controlsvc.
 		if err != nil {
 			return nil, err
 		}
-		doneChan := make(chan struct{})
-		defer func() {
-			close(doneChan)
-		}()
-		resultChan, err := c.w.GetResults(unitid, startPos, doneChan)
+
+		resultChan, err := c.w.GetResults(ctx, unitid, startPos)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -445,29 +445,44 @@ func sleepOrDone(doneChan <-chan struct{}, interval time.Duration) bool {
 }
 
 // GetResults returns a live stream of the results of a unit.
-func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan struct{}) (chan []byte, error) {
+func (w *Workceptor) GetResults(ctx context.Context, unitID string, startPos int64) (chan []byte, error) {
 	unit, err := w.findUnit(unitID)
 	if err != nil {
 		return nil, err
 	}
 	resultChan := make(chan []byte)
+	closeOnce := sync.Once{}
+	resultClose := func() {
+		closeOnce.Do(func() {
+			close(resultChan)
+		})
+	}
+	unitdir := path.Join(w.dataDir, unitID)
+	stdoutFilename := path.Join(unitdir, "stdout")
+	var stdout *os.File
+	ctxChild, cancel := context.WithCancel(ctx)
 	go func() {
-		unitdir := path.Join(w.dataDir, unitID)
-		stdoutFilename := path.Join(unitdir, "stdout")
+		defer func() {
+			err = stdout.Close()
+			if err != nil {
+				logger.Error("Error closing stdout %s", stdoutFilename)
+			}
+			resultClose()
+			cancel()
+		}()
+
 		// Wait for stdout file to exist
 		for {
-			_, err := os.Stat(stdoutFilename)
-
+			stdout, err = os.Open(stdoutFilename)
 			switch {
 			case err == nil:
 			case os.IsNotExist(err):
 				if IsComplete(unit.Status().State) {
-					close(resultChan)
 					logger.Warning("Unit completed without producing any stdout\n")
 
 					return
 				}
-				if sleepOrDone(doneChan, 250*time.Millisecond) {
+				if sleepOrDone(ctx.Done(), 500*time.Millisecond) {
 					return
 				}
 
@@ -480,57 +495,79 @@ func (w *Workceptor) GetResults(unitID string, startPos int64, doneChan chan str
 
 			break
 		}
-		var stdout *os.File
-		var err error
 		filePos := startPos
+		statChan := make(chan struct{}, 1)
+		go func() {
+			failures := 0
+			for {
+				select {
+				case <-ctxChild.Done():
+					return
+				case <-time.After(1 * time.Second):
+					_, err := os.Stat(stdoutFilename)
+					if os.IsNotExist(err) {
+						failures++
+						if failures > 3 {
+							logger.Error("Exceeded retries for reading stdout %s", stdoutFilename)
+							statChan <- struct{}{}
+
+							return
+						}
+					} else {
+						failures = 0
+					}
+				}
+			}
+		}()
 		for {
-			if sleepOrDone(doneChan, 250*time.Millisecond) {
+			if sleepOrDone(ctx.Done(), 250*time.Millisecond) {
 				return
 			}
-			if stdout == nil {
-				stdout, err = os.Open(stdoutFilename)
-				if err != nil {
-					continue
-				}
-			}
-			for err == nil {
-				var newPos int64
-				newPos, err = stdout.Seek(filePos, 0)
-				if err != nil {
-					logger.Warning("Seek error processing stdout: %s\n", err)
-
+			for {
+				if unit.Status().State == WorkStateFailed {
 					return
 				}
-				if newPos != filePos {
-					logger.Warning("Seek error processing stdout\n")
-
+				select {
+				case <-ctx.Done():
 					return
+				case <-statChan:
+					return
+				default:
+					var newPos int64
+					newPos, err = stdout.Seek(filePos, 0)
+					if err != nil {
+						logger.Warning("Seek error processing stdout: %s\n", err)
+
+						return
+					}
+					if newPos != filePos {
+						logger.Warning("Seek error processing stdout\n")
+
+						return
+					}
+					var n int
+					buf := make([]byte, utils.NormalBufferSize)
+					n, err = stdout.Read(buf)
+					if n > 0 {
+						filePos += int64(n)
+						select {
+						case <-ctx.Done():
+							return
+						case resultChan <- buf[:n]:
+						}
+					}
 				}
-				var n int
-				buf := make([]byte, utils.NormalBufferSize)
-				n, err = stdout.Read(buf)
-				if n > 0 {
-					filePos += int64(n)
-					resultChan <- buf[:n]
+				if err != nil {
+					break
 				}
 			}
 			if err == io.EOF {
-				err = stdout.Close()
-				if err != nil {
-					logger.Error("Error closing stdout\n")
-
-					return
-				}
-				stdout = nil
 				stdoutSize := stdoutSize(unitdir)
 				if IsComplete(unit.Status().State) && stdoutSize >= unit.Status().StdoutSize {
-					close(resultChan)
 					logger.Info("Stdout complete - closing channel for: %s \n", unitID)
 
 					return
 				}
-
-				continue
 			} else if err != nil {
 				logger.Error("Error reading stdout: %s\n", err)
 


### PR DESCRIPTION
This does a lot of things, but the main problem was go routine leaks surrounding our pub/sub broker. I've made changes to make sure we are guaranteed to exit those goroutines when we shutdown a connection.

The other big change is that we explicitly close the quic connection after use (on the dialer side). 

`err = conn.(interface{ CloseConnection() error }).CloseConnection()`

conn.Close() only shuts down the write side of the quic stream. The underlying connection was hanging around, and with it lots of goroutines.

There might still be an avenue for connection leaks -- if the dialer closes a connection but the server never gets that close signal, then it might remain open indefinitely. We may need to find a way to auto-close a connection if it has been inactive for some period of time.