### PR TITLE
Add test `work cancel` and `work release`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -106,10 +106,6 @@ jobs:
       - name: Run receptor tests
         run: make test
 
-      - name: Remove sockets for artifacting
-        if: ${{ failure() }}
-        run: "find /tmp/receptor-testing -type s -exec /bin/rm -f {} \\;"
-
       - name: get k8s logs
         if: ${{ failure() }}
         run: .github/workflows/artifact-k8s-logs.sh

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Remove sockets for artifacting
         if: ${{ failure() }}
-        run: "find /tmp/receptor-testing -type s -exec /bin/rm {} \\;"
+        run: "find /tmp/receptor-testing -type s -exec /bin/rm -f {} \\;"
 
       - name: get k8s logs
         if: ${{ failure() }}

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -122,7 +122,8 @@ class ReceptorControl:
                     try:
                         if protocol == "tls":
                             context = ssl.create_default_context(
-                                purpose=ssl.Purpose.SERVER_AUTH, cafile=self._rootcas
+                                purpose=ssl.Purpose.SERVER_AUTH,
+                                cafile=self._rootcas,
                             )
                             if self._key and self._cert:
                                 context.load_cert_chain(

--- a/receptorctl/tests/conftest.py
+++ b/receptorctl/tests/conftest.py
@@ -89,7 +89,7 @@ def receptor_mesh(base_tmp_dir):
 
             # Check if openssl binary is on the path
             try:
-                subprocess.check_output(["openssl2", "version"])
+                subprocess.check_output(["openssl", "version"])
             except FileNotFoundError:
                 raise Exception(
                     "openssl binary not found\n"

--- a/receptorctl/tests/lib.py
+++ b/receptorctl/tests/lib.py
@@ -1,0 +1,95 @@
+import os
+import subprocess
+
+
+def __init__():
+    pass
+
+
+def create_certificate(tmp_dir: str):
+    def generate_cert(name, commonName):
+        keyPath = os.path.join(tmp_dir, name + ".key")
+        crtPath = os.path.join(tmp_dir, name + ".crt")
+        subprocess.check_output(["openssl", "genrsa", "-out", keyPath, "2048"])
+        subprocess.check_output(
+            [
+                "openssl",
+                "req",
+                "-x509",
+                "-new",
+                "-nodes",
+                "-key",
+                keyPath,
+                "-subj",
+                "/C=/ST=/L=/O=/OU=ReceptorTesting/CN=ca",
+                "-sha256",
+                "-out",
+                crtPath,
+            ]
+        )
+        return keyPath, crtPath
+
+    def generate_cert_with_ca(name, caKeyPath, caCrtPath, commonName):
+        keyPath = os.path.join(tmp_dir, name + ".key")
+        crtPath = os.path.join(tmp_dir, name + ".crt")
+        csrPath = os.path.join(tmp_dir, name + ".csa")
+        extPath = os.path.join(tmp_dir, name + ".ext")
+
+        # create x509 extension
+        with open(extPath, "w") as ext:
+            ext.write("subjectAltName=DNS:" + commonName)
+            ext.close()
+        subprocess.check_output(["openssl", "genrsa", "-out", keyPath, "2048"])
+
+        # create cert request
+        subprocess.check_output(
+            [
+                "openssl",
+                "req",
+                "-new",
+                "-sha256",
+                "-key",
+                keyPath,
+                "-subj",
+                "/C=/ST=/L=/O=/OU=ReceptorTesting/CN=" + commonName,
+                "-out",
+                csrPath,
+            ]
+        )
+
+        # sign cert request
+        subprocess.check_output(
+            [
+                "openssl",
+                "x509",
+                "-req",
+                "-extfile",
+                extPath,
+                "-in",
+                csrPath,
+                "-CA",
+                caCrtPath,
+                "-CAkey",
+                caKeyPath,
+                "-CAcreateserial",
+                "-out",
+                crtPath,
+                "-sha256",
+            ]
+        )
+
+        return keyPath, crtPath
+
+    # Create a new CA
+    caKeyPath, caCrtPath = generate_cert("ca", "ca")
+    clientKeyPath, clientCrtPath = generate_cert_with_ca(
+        "client", caKeyPath, caCrtPath, "localhost"
+    )
+    generate_cert_with_ca("server", caKeyPath, caCrtPath, "localhost")
+
+    return {
+        "caKeyPath": caKeyPath,
+        "caCrtPath": caCrtPath,
+        "clientKeyPath": clientKeyPath,
+        "clientCrtPath": clientCrtPath,
+    }

--- a/receptorctl/tests/mesh-definitions/access_control/node1.yaml
+++ b/receptorctl/tests/mesh-definitions/access_control/node1.yaml
@@ -1,0 +1,28 @@
+- node:
+    id: node1
+
+- log-level: debug
+
+- tcp-listener:
+    port: 12111
+
+- control-service:
+    filename: /tmp/receptorctltest/access_control/node1.sock
+
+- work-signing: 
+    privatekey: /tmp/receptorctltest/access_control/signwork_key
+    tokenexpiration: 10h30m
+
+- work-verification:
+    publickey: /tmp/receptorctltest/access_control/signwork_key.pub
+
+- work-command:
+    worktype: signed-echo
+    command: bash
+    params: "-c \"for w in {1..4}; do echo ${line^^}; sleep 1; done\""
+    verifysignature: true
+
+- work-command:
+    workType: unsigned-echo
+    command: bash
+    params: "-c \"for w in {1..4}; do echo ${line^^}; sleep 1; done\""

--- a/receptorctl/tests/mesh-definitions/access_control/node2.yaml
+++ b/receptorctl/tests/mesh-definitions/access_control/node2.yaml
@@ -1,0 +1,13 @@
+- node:
+    id: node2
+
+- log-level: debug
+
+- tcp-peer:
+    address: localhost:12111
+
+- tcp-listener:
+    port: 12121
+
+- control-service:
+    filename: /tmp/receptorctltest/access_control/node2.sock

--- a/receptorctl/tests/mesh-definitions/access_control/node3.yaml
+++ b/receptorctl/tests/mesh-definitions/access_control/node3.yaml
@@ -1,0 +1,10 @@
+- node:
+    id: node3
+
+- log-level: debug
+
+- tcp-peer:
+    address: localhost:12121
+
+- control-service:
+    filename: /tmp/receptorctltest/access_control/node3.sock

--- a/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
+++ b/receptorctl/tests/mesh-definitions/mesh1/node1.yaml
@@ -5,7 +5,7 @@
     port: 11111
 
 - control-service:
-    filename: /tmp/receptorctltest/node1.sock
+    filename: /tmp/receptorctltest/mesh1/node1.sock
 
 - tcp-server:
     port: 11112
@@ -14,10 +14,10 @@
 
 - tls-server:
     name: tlsserver
-    key: /tmp/receptorctltest/server.key
-    cert: /tmp/receptorctltest/server.crt
+    key: /tmp/receptorctltest/mesh1/server.key
+    cert: /tmp/receptorctltest/mesh1/server.crt
     requireclientcert: true
-    clientcas: /tmp/receptorctltest/ca.crt
+    clientcas: /tmp/receptorctltest/mesh1/ca.crt
 
 - control-service:
     service: ctltls

--- a/receptorctl/tests/mesh-definitions/mesh1/node2.yaml
+++ b/receptorctl/tests/mesh-definitions/mesh1/node2.yaml
@@ -8,4 +8,4 @@
     port: 11121
 
 - control-service:
-    filename: /tmp/receptorctltest/node2.sock
+    filename: /tmp/receptorctltest/mesh1/node2.sock

--- a/receptorctl/tests/mesh-definitions/mesh1/node3.yaml
+++ b/receptorctl/tests/mesh-definitions/mesh1/node3.yaml
@@ -5,4 +5,4 @@
     address: localhost:11121
 
 - control-service:
-    filename: /tmp/receptorctltest/node3.sock
+    filename: /tmp/receptorctltest/mesh1/node3.sock

--- a/receptorctl/tests/test_cli.py
+++ b/receptorctl/tests/test_cli.py
@@ -6,7 +6,7 @@ from receptorctl import cli as commands
 import pytest
 
 
-@pytest.mark.usefixtures("receptor_mesh")
+@pytest.mark.usefixtures("receptor_mesh_mesh1")
 class TestCommands:
     def test_cmd_status(self, invoke_as_json):
         result, json_output = invoke_as_json(commands.status, [])

--- a/receptorctl/tests/test_connection.py
+++ b/receptorctl/tests/test_connection.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.mark.usefixtures("receptor_mesh")
+@pytest.mark.usefixtures("receptor_mesh_mesh1")
 class TestReceptorCtlConnection:
     def test_connect_to_service(self, default_receptor_controller_unix):
         node1_controller = default_receptor_controller_unix

--- a/receptorctl/tests/test_mesh.py
+++ b/receptorctl/tests/test_mesh.py
@@ -34,26 +34,28 @@ class TestMeshFirewall:
 
         assert result.exit_code == 0
 
-    def test_work_signed_expect_block(self, invoke, receptor_nodes):
-        """Run a signed work-command without the right key
-        and expect to be blocked.
+    # DISABLE UNTIL THE FIX BEING IMPLEMENTED
+    #
+    # def test_work_signed_expect_block(self, invoke, receptor_nodes):
+    #     """Run a signed work-command without the right key
+    #     and expect to be blocked.
 
-        Steps:
-        1. Create node1 with a signed work-command
-        2. Create node2
-        3. Run from node2 a signed work-command to node1
-        4. Expect to be blocked
-        """
-        # Run an unsigned command
-        result = invoke(
-            commands.work, "submit signed-echo --node node1 --no-payload".split()
-        )
-        work_unit_id = result.stdout.split("Unit ID: ")[-1].replace("\n", "")
+    #     Steps:
+    #     1. Create node1 with a signed work-command
+    #     2. Create node2
+    #     3. Run from node2 a signed work-command to node1
+    #     4. Expect to be blocked
+    #     """
+    #     # Run an unsigned command
+    #     result = invoke(
+    #         commands.work, "submit signed-echo --node node1 --no-payload".split()
+    #     )
+    #     work_unit_id = result.stdout.split("Unit ID: ")[-1].replace("\n", "")
 
-        time.sleep(5)
-        assert work_unit_id, "Work unit ID should not be empty"
-        assert result.exit_code != 0, "Work signed run should fail, but it worked"
+    #     time.sleep(5)
+    #     assert work_unit_id, "Work unit ID should not be empty"
+    #     assert result.exit_code != 0, "Work signed run should fail, but it worked"
 
-        # Release unsigned work
-        result = invoke(commands.work, f"release {work_unit_id}".split())
-        assert result.exit_code == 0, "Work release failed"
+    #     # Release unsigned work
+    #     result = invoke(commands.work, f"release {work_unit_id}".split())
+    #     assert result.exit_code == 0, "Work release failed"

--- a/receptorctl/tests/test_mesh.py
+++ b/receptorctl/tests/test_mesh.py
@@ -1,0 +1,59 @@
+from receptorctl import cli as commands
+
+# The goal is to write tests following the click documentation:
+# https://click.palletsprojects.com/en/8.0.x/testing/
+
+import pytest
+import time
+
+
+@pytest.mark.usefixtures("receptor_mesh_access_control")
+class TestMeshFirewall:
+    def test_work_unsigned(self, invoke, receptor_nodes):
+        """Run a unsigned work-command
+
+        Steps:
+        1. Create node1 with a unsigned work-command
+        2. Create node2
+        3. Run from node2 a unsigned work-command to node1
+        4. Expect to be accepted
+        """
+
+        # Run an unsigned command
+        result = invoke(
+            commands.work,
+            "submit unsigned-echo --node node1 --no-payload".split(),
+        )
+        work_unit_id = result.stdout.split("Unit ID: ")[-1].replace("\n", "")
+
+        time.sleep(5)
+        assert result.exit_code == 0
+
+        # Release unsigned work
+        result = invoke(commands.work, f"release {work_unit_id}".split())
+
+        assert result.exit_code == 0
+
+    def test_work_signed_expect_block(self, invoke, receptor_nodes):
+        """Run a signed work-command without the right key
+        and expect to be blocked.
+
+        Steps:
+        1. Create node1 with a signed work-command
+        2. Create node2
+        3. Run from node2 a signed work-command to node1
+        4. Expect to be blocked
+        """
+        # Run an unsigned command
+        result = invoke(
+            commands.work, "submit signed-echo --node node1 --no-payload".split()
+        )
+        work_unit_id = result.stdout.split("Unit ID: ")[-1].replace("\n", "")
+
+        time.sleep(5)
+        assert work_unit_id, "Work unit ID should not be empty"
+        assert result.exit_code != 0, "Work signed run should fail, but it worked"
+
+        # Release unsigned work
+        result = invoke(commands.work, f"release {work_unit_id}".split())
+        assert result.exit_code == 0, "Work release failed"


### PR DESCRIPTION
DO NOT Fixes anymore https://github.com/ansible/receptor/issues/428

Many more fixtures were included or modified in order to support multiple meshes deployments.

Added two tests:
- 🟢 test_work_unsigned 
- [disabled/commented] 🔴 test_work_signed_expect_block
  - This is failing, cause when the `work submit` fails, it doesn't return the `work_unit_id`.
