### PR TITLE
Fix get results returning when unit failed

### DIFF
--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -524,9 +524,6 @@ func (w *Workceptor) GetResults(ctx context.Context, unitID string, startPos int
 				return
 			}
 			for {
-				if unit.Status().State == WorkStateFailed {
-					return
-				}
 				select {
 				case <-ctx.Done():
 					return


### PR DESCRIPTION
Ansible-runner will return a non-zero code if the tasks failed. This results in a receptor unit with a Failed status State. We still want to get the full stdout from this ansible playbook, thus we shouldn't early-exit from GetResults.

This early exit was mostly put in place to prevent a situation where we exited out of monitorRemoteStdout in remote_work.go, but hung around in GetResults indefinitely because Status reported a stdout size greater than what we had on disk. This scenario is probably less of an issue for AWX, as it will close out of the socket when a job is cancelled. This closing of the socket should trigger the GetResults to return.