### PR TITLE
Change how receptor handles an undefined host id

### DIFF
--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	_ "github.com/ansible/receptor/pkg/services"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ansible/receptor/pkg/workceptor"
 	"github.com/ghjm/cmdline"
 )
@@ -27,15 +28,7 @@ type nodeCfg struct {
 func (cfg nodeCfg) Init() error {
 	var err error
 	if cfg.ID == "" {
-		host, err := os.Hostname()
-		if err != nil {
-			return err
-		}
-		lchost := strings.ToLower(host)
-		if lchost == "localhost" || strings.HasPrefix(lchost, "localhost.") {
-			return fmt.Errorf("no node ID specified and local host name is localhost")
-		}
-		cfg.ID = host
+		cfg.ID = utils.GenerateHostID()
 	}
 	if strings.ToLower(cfg.ID) == "localhost" {
 		return fmt.Errorf("node ID \"localhost\" is reserved")

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/ansible/receptor/pkg/backends"
 	"github.com/ansible/receptor/pkg/controlsvc"
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/services"
+	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ansible/receptor/pkg/workceptor"
 )
 
@@ -51,14 +50,7 @@ func (r Receptor) Serve(ctx context.Context) error {
 	var id string
 	var err error
 	if r.ID == nil {
-		id, err = os.Hostname()
-		if err != nil {
-			return fmt.Errorf("node id is not set in serve config and could not get hostname: %w", err)
-		}
-		lchost := strings.ToLower(id)
-		if lchost == "localhost" || strings.HasPrefix(lchost, "localhost.") {
-			return fmt.Errorf("node id is not set in serve config and hostname is invalid (don't use localhost please): %w", err)
-		}
+		id = utils.GenerateHostID()
 	} else {
 		id = *r.ID
 	}

--- a/pkg/randstr/randstr.go
+++ b/pkg/randstr/randstr.go
@@ -2,6 +2,7 @@ package randstr
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 )
 
@@ -15,4 +16,8 @@ func RandomString(length int) string {
 	}
 
 	return string(randbytes)
+}
+
+func RandomStringWithPrefixAndSuffix(prefix string, length int, suffix string) string {
+	return fmt.Sprintf("%s%s%s", prefix, RandomString(length), suffix)
 }

--- a/pkg/utils/misc.go
+++ b/pkg/utils/misc.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/randstr"
+)
+
+// A generated host ID will be node-<8 char string> optionally with @<host identifier> where <host identifier will be either a hostname or an IP.
+func GenerateHostID() string {
+	var suffix string
+	spacer := "@"
+
+	hostname, err := os.Hostname()
+	// If we got a hostname and its not like 'localhost' we will use that hostname as our suffix.
+	if err == nil {
+		lchost := strings.ToLower(hostname)
+		if lchost != "localhost" && !strings.HasPrefix(lchost, "localhost.") {
+			suffix = fmt.Sprintf("%s%s", spacer, hostname)
+		}
+	}
+	// If our suffix is still empty lets try and get an IP for this machine
+	if suffix == "" {
+		// We didn't get a hostname as a suffix so lets see if we can find an IP
+		if addrs, err := net.InterfaceAddrs(); err == nil {
+			for _, address := range addrs {
+				// check the address type and if it is not a loopback we will just use the first one
+				if ip, ok := address.(*net.IPNet); ok {
+					if ip.IP.IsLoopback() {
+						continue
+					}
+					suffix = fmt.Sprintf("%s%s", spacer, ip.IP.String())
+
+					break
+				}
+			}
+		}
+	}
+
+	generatedName := randstr.RandomStringWithPrefixAndSuffix("node-", 8, suffix)
+	logger.Warning("node id is not set in the serve config generated an id of %s", generatedName)
+
+	return generatedName
+}


### PR DESCRIPTION
Fixes #470
This implementation will create a change in the existing behavior.

 Previously it attempted to take the hostname of a machine as the ID and would fail if the hostname matched /^localhost.?.*$/.
 
Now it will generate a node name like `node-<8 character string>` followed by an optional @<identifier>. The first identifier attempted will be the hostname. However, if the hostname matches the regex above it will scan the interfaces looking for a non-loopback IP and use @<ip> instead of @<hostname>. If we fail for any reason (can't get the host name or cant get an address of an interface) it will drop the @ notation and just use `node-<8 character string>`.
 
The 8 character string itself should have been enough to fix the issue but I was attempting to get some kind of machine info so that you know where the node is coming from. i.e. in `receptorctl status` it will show something like:
```
Known Node                  Known Connections
node-UuUTDwBH@10.0.0.34     {'node-dCdDbCqd@ansible-devel': 1}
node-dCdDbCqd@ansible-devel {'node-UuUTDwBH@10.0.0.34': 1}
```
This would hopefully give an admin an idea of where those nodes connected from.

This fact the node ID is missing and one had to be auto-generated is indicated in the logs as :
`WARNING 2021/11/11 09:47:13 node id is not set in the serve config generated an id of node-dCdDbCqd@ansible-devel`

Finally, this enables you to launch multiple receptor processes on the same node without an ID as the likely hood of the 8 character string being duplicated is very low. Previously, both processes would attempt to use the hostname as their identifier causing the second process will be kicked out with the error:
`ERROR 2021/11/11 10:31:33 Backend error: rejected connection with node ansible-devel because it tried to connect using our own node ID`