### PR TITLE
Adding warning to all commands in receptorctl

### DIFF
--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -85,12 +85,12 @@ def print_error(message, nl=True):
 )
 def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
     ctx.obj = {
-        'rc': None,
-        'receptorctlVersion': pkg_resources.get_distribution('receptorctl').version,
-        'receptorVersion': "Unknown",
+        "rc": None,
+        "receptorctlVersion": pkg_resources.get_distribution("receptorctl").version,
+        "receptorVersion": "Unknown",
     }
     # If we got a socket parameter we can make a ReceptorControl object
-    if ctx.params.get("socket", None) != None:
+    if ctx.params.get("socket", None) is not None:
         ctx.obj["rc"] = ReceptorControl(
             socket,
             config=config,
@@ -101,10 +101,19 @@ def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
             insecureskipverify=insecureskipverify,
         )
         # Load and stash the versions
-        ctx.obj['receptorVersion'] = ctx.obj['rc'].simple_command('{"command":"status","requested_fields":["Version"]}')["Version"]
+        ctx.obj["receptorVersion"] = ctx.obj["rc"].simple_command(
+            '{"command":"status","requested_fields":["Version"]}'
+        )["Version"]
         # If they mismatch throw a stderr warning
-        if ctx.obj['receptorVersion'] != ctx.obj['receptorctlVersion']:
-            click.echo(click.style("Warning: receptorctl and receptor are different versions, they may not be compatible", fg='magenta'), err=True)
+        if ctx.obj["receptorVersion"] != ctx.obj["receptorctlVersion"]:
+            click.echo(
+                click.style(
+                    "Warning: receptorctl and receptor are different versions, they may not be compatible",  # noqa E501
+                    fg="magenta",
+                ),
+                err=True,
+            )
+
 
 def get_rc(ctx):
     return ctx.obj["rc"]

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -27,6 +27,7 @@ class IgnoreRequiredWithHelp(click.Group):
                 param.required = False
             return super(IgnoreRequiredWithHelp, self).parse_args(ctx, args)
 
+
 def print_json(json_data):
     click.echo(json.dumps(json_data, indent=4, sort_keys=True))
 

--- a/receptorctl/tests/conftest.py
+++ b/receptorctl/tests/conftest.py
@@ -356,7 +356,8 @@ def invoke(receptor_control_args):
                     arg_list.append(str(v))
             return arg_list
 
-        runner = CliRunner()
+        # Since we may log errors/warnings on stderr we want to split stdout and stderr
+        runner = CliRunner(mix_stderr=False)
 
         out = runner.invoke(
             receptorctl.cli.cli,
@@ -381,7 +382,8 @@ def invoke_as_json(invoke):
         """
         result = invoke(command, ["--json"] + args)
         try:
-            json_output = json.loads(result.output)
+            # JSON data should only be on stdout
+            json_output = json.loads(result.stdout)
         except json.decoder.JSONDecodeError:
             pytest.fail("The command is not in json format")
         return result, json_output


### PR DESCRIPTION
Fixes #477

This moves the version check into the code that initialized the ReceptorControl so that all commands will warn if the versions are out of sync. Also, move the warning to std.err instead of std.out. Adding checking to make sure socket option is passed before actually making the connection.