### PR TITLE
Adding 10m timeout to attempt to address linting issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,6 @@
+run:
+  timeout: 10m
+
 linters:
   disable-all: true
   enable:


### PR DESCRIPTION
We have been seeing timeouts in the linting process today. I've noticed in the past that the first time the linter is run and pulling down its packages this can take some time. This PR increases the timeout of the linter to 10 minutes.