### PR TITLE
Use golang 1.16 in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - uses: actions/cache@v2
         with:
@@ -71,7 +71,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Setup up python
         uses: actions/setup-python@v2


### PR DESCRIPTION
Updating this to match the version available in RHEL 8.

RHEL 8 shipped Golang 1.16 a little over a week ago: https://access.redhat.com/errata/RHSA-2021:4156