### PR TITLE
[release_1.1] do not exit monitorRemoteStdout too early in case of failed job

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -393,9 +393,6 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 		status := rw.Status()
 		diskStdoutSize := stdoutSize(rw.UnitDir())
 		remoteStdoutSize := status.StdoutSize
-		if status.State == WorkStateFailed {
-			return
-		}
 		if IsComplete(status.State) && diskStdoutSize >= remoteStdoutSize {
 			return
 		} else if diskStdoutSize < remoteStdoutSize {


### PR DESCRIPTION
we still want stdout if work unit fails

This causes a bug where we don't get the full stdout from a failed controller job. The job stays in running state indefinitely.

The original reason for adding this exit condition was in the case where node1 sees the job is failed on node2, and attempts to download the rest of the stdout, but the node2 goes down for some reason. The work unit appears to be in a finished state (has a failed status), and thus it's not apparent that go routines are still running. I think we may want to add work unit information to indicate whether receptor is actively monitoring a work unit. This would cue to the user to call release or cancel on that work unit.