### PR TITLE
actually checkout the branch specified

### DIFF
--- a/.github/workflows/build_binary_from_ref.yml
+++ b/.github/workflows/build_binary_from_ref.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref }}
 
       - name: build-all target
         run: make build-all


### PR DESCRIPTION
Manually tested https://github.com/ansible/receptor/runs/4256111007?check_suite_focus=true

Note that I specified the branch `release_1.1`. I expect commit `a69413befc9b1a689da86c34e5342d250a8366db` to be checked out. With this fix it does

**After:**
![image](https://user-images.githubusercontent.com/722880/142486141-176db265-9274-4f22-bf80-9d3cfd57bc56.png)

**Before** this change `devel` was always being checked out.
![image](https://user-images.githubusercontent.com/722880/142486258-7bc1cf86-e5ec-4bb7-b7eb-098c5faa300a.png)
