### PR TITLE
[devel] do not exit monitorremotestdout too early in case of failed job

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -393,9 +393,6 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 		status := rw.Status()
 		diskStdoutSize := stdoutSize(rw.UnitDir())
 		remoteStdoutSize := status.StdoutSize
-		if status.State == WorkStateFailed {
-			return
-		}
 		if IsComplete(status.State) && diskStdoutSize >= remoteStdoutSize {
 			return
 		} else if diskStdoutSize < remoteStdoutSize {


### PR DESCRIPTION
related https://github.com/ansible/receptor/pull/496