### PR TITLE
Give receptor subprocess a nodeID

### DIFF
--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -229,7 +229,9 @@ func (cw *commandUnit) Start() error {
 	level := logger.GetLogLevel()
 	levelName, _ := logger.LogLevelToName(level)
 	cw.UpdateBasicStatus(WorkStatePending, "Launching command runner", 0)
-	cmd := exec.Command(os.Args[0], "--log-level", levelName, "--command-runner",
+	cmd := exec.Command(os.Args[0], "--node", "id=worker",
+		"--log-level", levelName,
+		"--command-runner",
 		fmt.Sprintf("command=%s", cw.command),
 		fmt.Sprintf("params=%s", cw.Status().ExtraData.(*commandExtraData).Params),
 		fmt.Sprintf("unitdir=%s", cw.UnitDir()))


### PR DESCRIPTION
related issue https://github.com/ansible/receptor/issues/470

When work units are started, a separate receptor process is started to run the command (that way if the main receptor process goes down, we can still monitor whatever command is running, i.e. ansible-runner)

If this receptor process does not have a node ID, receptor will try to use os.hostname. If hostname begins with "localhost", receptor will error out, as "localhost" is a reserved keyword in receptor to mean "this node".

To avoid this scenario, we should just give the receptor a nodeID. Since this receptor process is not joining a mesh, the name really doesn't matter, so I just chose `worker`. We could also give it the same name as the parent receptor node.