### PR TITLE
Add prefixes to random strings

### DIFF
--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -147,7 +147,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(buf[:n]) != "hello" {
-		t.Fatal("Wrong message received")
+		t.Fatalf("Wrong message received: '%s'", string(buf[:n]))
 	}
 
 	// Shut down the nodes

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -46,7 +46,7 @@ type Listener struct {
 
 // Internal implementation of Listen and ListenAndAdvertise.
 func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Config, advertise bool, adTags map[string]string) (*Listener, error) {
-	if len(service) > 8 {
+	if len(service) > ServiceSizeinBytes {
 		return nil, fmt.Errorf("service name %s too long", service)
 	}
 	if service == "" {

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -42,7 +42,10 @@ const defaultMaxForwardingHops = 30
 const defaultMaxConnectionIdleTime = 2*defaultRouteUpdateTime + 1*time.Second
 
 // The size of bytes in a service name.
-const ServiceSizeinBytes = 8
+const (
+	ServicePrefix      = "svc-"
+	ServiceSizeinBytes = 8 + len(ServicePrefix)
+)
 
 // MainInstance is the global instance of Netceptor instantiated by the command-line main() function.
 var MainInstance *Netceptor
@@ -1196,7 +1199,7 @@ func (s *Netceptor) getEphemeralService() string {
 	s.listenerLock.RLock()
 	defer s.listenerLock.RUnlock()
 	for {
-		service := utils.RandomString(ServiceSizeinBytes)
+		service := utils.RandomStringWithPrefix(ServicePrefix, ServiceSizeinBytes-len(ServicePrefix))
 		_, ok := s.reservedServices[service]
 		if ok {
 			continue
@@ -1244,7 +1247,7 @@ func (s *Netceptor) makeRoutingUpdate(suspectedDuplicate uint64) *routingUpdate 
 	s.connLock.RUnlock()
 	update := &routingUpdate{
 		NodeID:             s.nodeID,
-		UpdateID:           utils.RandomString(8),
+		UpdateID:           utils.RandomStringWithPrefix("ru-", 8),
 		UpdateEpoch:        s.epoch,
 		UpdateSequence:     s.sequence,
 		Connections:        conns,

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/ansible/receptor/pkg/logger"
-	"github.com/ansible/receptor/pkg/randstr"
 	"github.com/ansible/receptor/pkg/tickrunner"
 	"github.com/ansible/receptor/pkg/utils"
 	priorityQueue "github.com/jupp0r/go-priority-queue"
@@ -1197,7 +1196,7 @@ func (s *Netceptor) getEphemeralService() string {
 	s.listenerLock.RLock()
 	defer s.listenerLock.RUnlock()
 	for {
-		service := randstr.RandomString(ServiceSizeinBytes)
+		service := utils.RandomString(ServiceSizeinBytes)
 		_, ok := s.reservedServices[service]
 		if ok {
 			continue
@@ -1245,7 +1244,7 @@ func (s *Netceptor) makeRoutingUpdate(suspectedDuplicate uint64) *routingUpdate 
 	s.connLock.RUnlock()
 	update := &routingUpdate{
 		NodeID:             s.nodeID,
-		UpdateID:           randstr.RandomString(8),
+		UpdateID:           utils.RandomString(8),
 		UpdateEpoch:        s.epoch,
 		UpdateSequence:     s.sequence,
 		Connections:        conns,

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -588,7 +588,7 @@ func TestFirewalling(t *testing.T) {
 		t.Fatal(err)
 	}
 	if string(buf[:n]) != "good" {
-		t.Fatal("incorrect message received")
+		t.Fatalf("incorrect message received: '%s'", string(buf[:n]))
 	}
 	time.Sleep(100 * time.Millisecond)
 	if lastUnreachMsg != nil {

--- a/pkg/netceptor/packetconn.go
+++ b/pkg/netceptor/packetconn.go
@@ -28,7 +28,7 @@ type PacketConn struct {
 // ListenPacket returns a datagram connection compatible with Go's net.PacketConn.
 // If service is blank, generates and uses an ephemeral service name.
 func (s *Netceptor) ListenPacket(service string) (*PacketConn, error) {
-	if len(service) > 8 {
+	if len(service) > ServiceSizeinBytes {
 		return nil, fmt.Errorf("service name %s too long", service)
 	}
 	if service == "" {

--- a/pkg/utils/randstr.go
+++ b/pkg/utils/randstr.go
@@ -1,4 +1,4 @@
-package randstr
+package utils
 
 import (
 	"crypto/rand"

--- a/pkg/utils/randstr.go
+++ b/pkg/utils/randstr.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"crypto/rand"
+	"fmt"
 	"math/big"
 )
 
@@ -15,4 +16,8 @@ func RandomString(length int) string {
 	}
 
 	return string(randbytes)
+}
+
+func RandomStringWithPrefix(prefix string, length int) string {
+	return fmt.Sprintf("%s%s", prefix, RandomString(length))
 }

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -176,7 +176,7 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 	if err != nil {
 		return fmt.Errorf("read error reading from %s: %s", red.RemoteNode, err)
 	}
-	submitIDRegex := regexp.MustCompile(`with ID ([a-zA-Z0-9]+)\.`)
+	submitIDRegex := regexp.MustCompile(fmt.Sprintf(`with ID (%s[a-zA-Z0-9]{%d})\.`, WorkUnitPrefix, WorkUnitSize))
 	match := submitIDRegex.FindSubmatch([]byte(response))
 	if match == nil || len(match) != 2 {
 		return fmt.Errorf("could not parse response: %s", strings.TrimRight(response, "\n"))

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -23,6 +23,11 @@ import (
 	"github.com/golang-jwt/jwt/v4"
 )
 
+const (
+	WorkUnitPrefix = "wu-"
+	WorkUnitSize   = 8
+)
+
 // Workceptor is the main object that handles unit-of-work management.
 type Workceptor struct {
 	ctx               context.Context
@@ -133,7 +138,7 @@ func (w *Workceptor) generateUnitID(lock bool) (string, error) {
 	}
 	var ident string
 	for {
-		ident = utils.RandomString(8)
+		ident = utils.RandomStringWithPrefix(WorkUnitPrefix, WorkUnitSize)
 		_, ok := w.activeUnits[ident]
 		if !ok {
 			unitdir := path.Join(w.dataDir, ident)

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ansible/receptor/pkg/controlsvc"
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
-	"github.com/ansible/receptor/pkg/randstr"
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/golang-jwt/jwt/v4"
 )
@@ -134,7 +133,7 @@ func (w *Workceptor) generateUnitID(lock bool) (string, error) {
 	}
 	var ident string
 	for {
-		ident = randstr.RandomString(8)
+		ident = utils.RandomString(8)
 		_, ok := w.activeUnits[ident]
 		if !ok {
 			unitdir := path.Join(w.dataDir, ident)


### PR DESCRIPTION
Move randstr into the utils directory.
Add a prefix option to the random string generator.
Modify work units, services and routing updates to have unique prefixes.
Make a constant for the size of the service name and remove hard coding of previous "8".

Addresses #475 