### PR TITLE
Forcing receptor into path on make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,9 @@ else
 TESTCMD = -run $(RUNTEST)
 endif
 
-test:
-	@go test ./... -p 1 -parallel=16 $(TESTCMD) -count=1
+test: receptor
+	PATH=${PWD}:${PATH} \
+	go test ./... -p 1 -parallel=16 $(TESTCMD) -count=1
 
 receptorctl-test:
 	@cd receptorctl && tox -e py3


### PR DESCRIPTION
@shanemcd, second attempt at modifying the Makefile to ensure receptor is in the path. In the last PR you mentioned putting PWD before ${PATH}. Based on that, I thought the easiest way to ensure receptor would be in the path would to have test target depend on the receptor target. This would preclude testing with a receptor binary from a "random" location but I didn't really have a good scenario for doing that other than testing a random binary against the current tests. But I think this could be accomplished by just doing a `cp ```which receptor``` .`. Let me know what you think. Is there any reason you can think of that we wouldn't want to test with ./receptor?