### PR TITLE
Cleanup error messages in log

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -393,7 +393,7 @@ func monitorUnreachable(pc *PacketConn, doneChan chan struct{}, remoteAddr Addr,
 	// read from channel until closed
 	for msg := range msgCh {
 		if msg.Problem == ProblemServiceUnknown && msg.ToNode == remoteAddr.node && msg.ToService == remoteAddr.service {
-			logger.Error("remote service unreachable")
+			logger.Warning("remote service %s to node %s is unreachable", msg.ToService, msg.ToNode)
 			cancel()
 		}
 	}

--- a/pkg/pkg.go
+++ b/pkg/pkg.go
@@ -36,7 +36,7 @@ type Receptor struct {
 	Controllers *controlsvc.Controllers `mapstructure:"controllers"`
 }
 
-// Serve launches an receptor instance and blocks until canceled or failed.
+// Serve launches an receptor instance and blocks until cancelled or failed.
 func (r Receptor) Serve(ctx context.Context) error {
 	logger.SetShowTrace(r.EnableTracing)
 

--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -421,6 +421,7 @@ func (c *workceptorCommand) ControlFunc(ctx context.Context, nc *netceptor.Netce
 		if err != nil {
 			return nil, err
 		}
+
 		err = cfo.Close()
 		if err != nil {
 			return nil, err

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -83,7 +83,7 @@ func (rw *remoteUnit) getConnection(ctx context.Context) (net.Conn, *bufio.Reade
 		if err == nil {
 			return conn, reader
 		}
-		logger.Warning("Connection to %s failed with error: %s",
+		logger.Debug("Connection to %s failed with error: %s",
 			rw.Status().ExtraData.(*remoteExtraData).RemoteNode, err)
 		errStr := err.Error()
 		if strings.Contains(errStr, "CRYPTO_ERROR") {
@@ -470,7 +470,13 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 			_, err = io.Copy(stdout, conn)
 			close(doneChan)
 			if err != nil {
-				logger.Warning("Error copying to stdout file %s: %s\n", rw.stdoutFileName, err)
+				var errmsg string
+				if strings.HasSuffix(err.Error(), "error code 499") {
+					errmsg = "read operation cancelled"
+				} else {
+					errmsg = err.Error()
+				}
+				logger.Warning("Could not copy to stdout file %s: %s\n", rw.stdoutFileName, errmsg)
 
 				continue
 			}

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -561,7 +561,7 @@ func (w *Workceptor) GetResults(ctx context.Context, unitID string, startPos int
 			if err == io.EOF {
 				stdoutSize := stdoutSize(unitdir)
 				if IsComplete(unit.Status().State) && stdoutSize >= unit.Status().StdoutSize {
-					logger.Info("Stdout complete - closing channel for: %s \n", unitID)
+					logger.Debug("Stdout complete - closing channel for: %s \n", unitID)
 
 					return
 				}


### PR DESCRIPTION
related https://github.com/ansible/receptor/issues/510

cleaned up some excessive error messages that would occur even under normal and expected situations.

CloseConnection() in conn.go returns an Error message (the normal way to close a quic connection is via a CloseWithError, see https://github.com/lucas-clemente/quic-go/issues/3270). Therefore, we should check to see if Write or Read attempts on a closed connection returns this normal error, and only log a message if it is not normal.

Also moved some of the more repetitive log messages from Info to Debug.