### PR TITLE
Use shlex instead of strings.split for command

### DIFF
--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
-	"strings"
 
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
@@ -15,10 +14,14 @@ import (
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/creack/pty"
 	"github.com/ghjm/cmdline"
+	"github.com/google/shlex"
 )
 
 func runCommand(qc net.Conn, command string) error {
-	args := strings.Split(command, " ")
+	args, err := shlex.Split(command)
+	if err != nil {
+		return err
+	}
 	cmd := exec.Command(args[0], args[1:]...)
 	tty, err := pty.Start(cmd)
 	if err != nil {


### PR DESCRIPTION
Currently, `--command-service` uses `strings.Split()` to split the provided command, and then executes the first component with the remaining components as parameters.  This means that parameters cannot be grouped using quotes.  For example, you cannot do things like:

```
- command-service:
        service: test
        command: sh -c "/my/noisy/script.sh 2> /dev/null"
```

This PR switches to using `shlex.Split()`, which splits the string into tokens using shell semantics, respecting quotes.