### PR TITLE
Support pinned certificates

### DIFF
--- a/docs/source/tls.rst
+++ b/docs/source/tls.rst
@@ -77,6 +77,42 @@ makecerts.sh
 
 The above script will create a CA, and for each node `foo` and `bar`, create a certificate request and sign it with the CA. These certs and keys can then be used to create ``tls-server`` and ``tls-client`` definitions in the receptor config files.
 
+Pinned Certificates
+^^^^^^^^^^^^^^^^^^^
+
+In a case where a TLS connection is only ever going to be made between two well-known nodes, it may be preferable to
+require a specific certificate rather than accepting any certificate signed by a CA.  Receptor supports certificate
+pinning for this purpose.  Here is an example of a pinned certificate configuration:
+
+.. code-block:: yaml
+
+    ---
+    - node:
+        id: foo
+
+    - tls-server:
+        name: myserver
+        cert: /full/path/foo.crt
+        key: /full/path/foo.key
+        requireclientcert: true
+        clientcas: /full/path/ca.crt
+        pinnedclientcert:
+          - E6:9B:98:A7:A5:DB:17:D6:E4:2C:DE:76:45:42:A8:79:A3:0A:C5:6D:10:42:7A:6A:C4:54:57:83:F1:0F:E2:95
+
+    - tcp-listener:
+        port: 2222
+        tls: myserver
+
+Certificate pinning is an added requirement, and does not eliminate the need to meet other stated requirements.  In the above example, the client certificate must both be signed by a CA in the `ca.crt` bundle, and also have the listed fingerprint.  Multiple fingerprints may be specified, in which case a certificate matching any one of them will be accepted.
+
+To find the fingerprint of a given certificate, use the following OpenSSL command:
+
+.. code::
+
+   openssl x509 -in my-cert.pem -noout -fingerprint -sha256
+
+SHA256 and SHA512 fingerprints are supported.  SHA1 fingerprints are not supported due to the insecurity of the SHA1 algorithm.
+
 Above the mesh TLS
 ^^^^^^^^^^^^^^^^^^
 

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -152,7 +152,6 @@ func (li *Listener) sendResult(conn net.Conn, err error) {
 		err:  err,
 	}:
 	case <-li.doneChan:
-	case <-li.doneChan:
 	}
 }
 

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -933,7 +933,15 @@ const (
 // receptorVerifyFunc generates a function that verifies a Receptor node ID.
 func (s *Netceptor) receptorVerifyFunc(tlscfg *tls.Config, expectedNodeID string,
 	verifyType int) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	oldVerifyFunc := tlscfg.VerifyPeerCertificate
+
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if oldVerifyFunc != nil {
+			err := oldVerifyFunc(rawCerts, verifiedChains)
+			if err != nil {
+				return err
+			}
+		}
 		certs := make([]*x509.Certificate, len(rawCerts))
 		for i, asn1Data := range rawCerts {
 			cert, err := x509.ParseCertificate(asn1Data)

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -4,10 +4,15 @@
 package netceptor
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"crypto/sha512"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/ghjm/cmdline"
 )
@@ -23,18 +28,19 @@ var configSection = &cmdline.ConfigSection{
 
 // tlsServerCfg stores the configuration options for a TLS server.
 type tlsServerCfg struct {
-	Name              string `required:"true" description:"Name of this TLS server configuration"`
-	Cert              string `required:"true" description:"Server certificate filename"`
-	Key               string `required:"true" description:"Server private key filename"`
-	RequireClientCert bool   `description:"Require client certificates" default:"false"`
-	ClientCAs         string `description:"Filename of CA bundle to verify client certs with"`
+	Name              string   `required:"true" description:"Name of this TLS server configuration"`
+	Cert              string   `required:"true" description:"Server certificate filename"`
+	Key               string   `required:"true" description:"Server private key filename"`
+	RequireClientCert bool     `description:"Require client certificates" default:"false"`
+	ClientCAs         string   `description:"Filename of CA bundle to verify client certs with"`
+	PinnedClientCert  []string `description:"Pinned fingerprint of required client certificate"`
 }
 
 // Prepare creates the tls.config and stores it in the global map.
 func (cfg tlsServerCfg) Prepare() error {
 	tlscfg := &tls.Config{
-		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
+		MinVersion:               tls.VersionTLS12,
 	}
 
 	certbytes, err := ioutil.ReadFile(cfg.Cert)
@@ -53,13 +59,20 @@ func (cfg tlsServerCfg) Prepare() error {
 	tlscfg.Certificates = []tls.Certificate{cert}
 
 	if cfg.ClientCAs != "" {
-		bytes, err := ioutil.ReadFile(cfg.ClientCAs)
+		caBytes, err := ioutil.ReadFile(cfg.ClientCAs)
 		if err != nil {
 			return fmt.Errorf("error reading client CAs file: %s", err)
 		}
 		clientCAs := x509.NewCertPool()
-		clientCAs.AppendCertsFromPEM(bytes)
+		clientCAs.AppendCertsFromPEM(caBytes)
 		tlscfg.ClientCAs = clientCAs
+	}
+
+	if len(cfg.PinnedClientCert) > 0 {
+		tlscfg.VerifyPeerCertificate, err = GetPeerCertificatePinVerifier(cfg.PinnedClientCert)
+		if err != nil {
+			return err
+		}
 	}
 
 	switch {
@@ -76,11 +89,12 @@ func (cfg tlsServerCfg) Prepare() error {
 
 // tlsClientConfig stores the configuration options for a TLS client.
 type tlsClientConfig struct {
-	Name               string `required:"true" description:"Name of this TLS client configuration"`
-	Cert               string `required:"false" description:"Client certificate filename"`
-	Key                string `required:"false" description:"Client private key filename"`
-	RootCAs            string `required:"false" description:"Root CA bundle to use instead of system trust"`
-	InsecureSkipVerify bool   `required:"false" description:"Accept any server cert" default:"false"`
+	Name               string   `required:"true" description:"Name of this TLS client configuration"`
+	Cert               string   `required:"false" description:"Client certificate filename"`
+	Key                string   `required:"false" description:"Client private key filename"`
+	RootCAs            string   `required:"false" description:"Root CA bundle to use instead of system trust"`
+	InsecureSkipVerify bool     `required:"false" description:"Accept any server cert" default:"false"`
+	PinnedServerCert   []string `required:"false" description:"Pinned fingerprint of required server certificate"`
 }
 
 // Prepare creates the tls.config and stores it in the global map.
@@ -94,15 +108,15 @@ func (cfg tlsClientConfig) Prepare() error {
 		if cfg.Cert == "" || cfg.Key == "" {
 			return fmt.Errorf("cert and key must both be supplied or neither")
 		}
-		certbytes, err := ioutil.ReadFile(cfg.Cert)
+		certBytes, err := ioutil.ReadFile(cfg.Cert)
 		if err != nil {
 			return err
 		}
-		keybytes, err := ioutil.ReadFile(cfg.Key)
+		keyBytes, err := ioutil.ReadFile(cfg.Key)
 		if err != nil {
 			return err
 		}
-		cert, err := tls.X509KeyPair(certbytes, keybytes)
+		cert, err := tls.X509KeyPair(certBytes, keyBytes)
 		if err != nil {
 			return err
 		}
@@ -110,19 +124,76 @@ func (cfg tlsClientConfig) Prepare() error {
 	}
 
 	if cfg.RootCAs != "" {
-		bytes, err := ioutil.ReadFile(cfg.RootCAs)
+		caBytes, err := ioutil.ReadFile(cfg.RootCAs)
 		if err != nil {
 			return fmt.Errorf("error reading root CAs file: %s", err)
 		}
 
 		rootCAs := x509.NewCertPool()
-		rootCAs.AppendCertsFromPEM(bytes)
+		rootCAs.AppendCertsFromPEM(caBytes)
 		tlscfg.RootCAs = rootCAs
+	}
+
+	if len(cfg.PinnedServerCert) > 0 {
+		var err error
+		tlscfg.VerifyPeerCertificate, err = GetPeerCertificatePinVerifier(cfg.PinnedServerCert)
+		if err != nil {
+			return err
+		}
 	}
 
 	tlscfg.InsecureSkipVerify = cfg.InsecureSkipVerify
 
 	return MainInstance.SetClientTLSConfig(cfg.Name, tlscfg)
+}
+
+func GetPeerCertificatePinVerifier(pinnedFingerprints []string) (func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error, error) {
+	fingerprintBytes := make([][]byte, 0, len(pinnedFingerprints))
+	for _, fingStr := range pinnedFingerprints {
+		fingBytes, err := hex.DecodeString(strings.ReplaceAll(fingStr, ":", ""))
+		if err != nil {
+			return nil, fmt.Errorf("error decoding fingerprint")
+		}
+		if len(fingBytes) != 32 && len(fingBytes) != 64 {
+			return nil, fmt.Errorf("fingerprints must be 32 or 64 bytes for sha256 or sha512")
+		}
+		fingerprintBytes = append(fingerprintBytes, fingBytes)
+	}
+	verifier := func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+		if len(rawCerts) == 0 {
+			return fmt.Errorf("peer certificate missing")
+		}
+		cert, err := x509.ParseCertificate(rawCerts[0])
+		if err != nil {
+			return fmt.Errorf("error parsing certificate: %w", err)
+		}
+		var sha256sum []byte
+		var sha512sum []byte
+		for _, fing := range fingerprintBytes {
+			switch len(fing) {
+			case 32:
+				if sha256sum == nil {
+					sum := sha256.Sum256(cert.Raw)
+					sha256sum = sum[:]
+				}
+				if bytes.Equal(fing, sha256sum) {
+					return nil
+				}
+			case 64:
+				if sha512sum == nil {
+					sum := sha512.Sum512(cert.Raw)
+					sha512sum = sum[:]
+				}
+				if bytes.Equal(fing, sha256sum) {
+					return nil
+				}
+			}
+		}
+		
+		return fmt.Errorf("peer certificate did not match any pinned fingerprint")
+	}
+
+	return verifier, nil
 }
 
 func init() {


### PR DESCRIPTION
Receptor currently allows a user to specify a CA, or list of CAs, that must sign a certificate in order to trust it for a connection.  However, there are situations where you want to be able to identify a single certificate, or one of a list of certificates, that should be allowed to connect, and it's not sufficient to just say "any certificate signed by such-and-so CA."  The solution to this is certificate pinning, where you list specific certificate fingerprints that should be the only ones to be trusted.

Here are example configuration files exercising this feature:

```
---
- node:
    id: foo

- log-level: debug

- tls-server:
    name: foo_tls
    cert: certs/testcert-foo.crt
    key: certs/testcert-foo.key
    requireclientcert: true
    clientcas: certs/ca.crt
    pinnedclientcert: E6:9B:98:A7:A5:DB:17:D6:E4:2C:DE:76:45:42:A8:79:A3:0A:C5:6D:10:42:7A:6A:C4:54:57:83:F1:0F:E
2:95

- tcp-listener:
    port: 2222
    tls: foo_tls

- control-service:
    service: control
    filename: receptor.sock
```

```
---
- node:
    id: bar

- log-level: debug

- tls-client:
    name: bar_tls
    cert: certs/testcert-bar.crt
    key: certs/testcert-bar.key
    rootcas: certs/ca.crt
    pinnedservercert: 91:4B:90:C4:D2:33:94:62:37:2F:0C:83:7A:20:C1:E3:61:FB:0D:EE:9F:6B:E7:1C:2B:76:A2:97:63:21:4
E:F4

- control-service:
    service: control
    filename: bar.sock

- tcp-peer:
    address: localhost:2222
    redial: true
    tls: bar_tls

```

You can find the fingerprint of a given certificate using `openssl x509 -in certs/testcert-foo.crt -noout -fingerprint -sha256`.  This PR supports sha256 and sha512, but not sha1, because sha1 is now considered insecure.  If sha1 support is desired it can easily be added.
