### PR TITLE
Move ping and traceroute to Netceptor package

### DIFF
--- a/pkg/controlsvc/ping.go
+++ b/pkg/controlsvc/ping.go
@@ -3,8 +3,6 @@ package controlsvc
 import (
 	"context"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/ansible/receptor/pkg/netceptor"
 )
@@ -43,75 +41,8 @@ func (t *pingCommandType) InitFromJSON(config map[string]interface{}) (ControlCo
 	return c, nil
 }
 
-// ping is the internal implementation of sending a single ping packet and waiting for a reply or error.
-func ping(nc *netceptor.Netceptor, target string, hopsToLive byte) (time.Duration, string, error) {
-	pc, err := nc.ListenPacket("")
-	if err != nil {
-		return 0, "", err
-	}
-	ctx, ctxCancel := context.WithCancel(nc.Context())
-	defer func() {
-		ctxCancel()
-		_ = pc.Close()
-	}()
-	pc.SetHopsToLive(hopsToLive)
-	doneChan := make(chan struct{})
-	unrCh := pc.SubscribeUnreachable(doneChan)
-	defer close(doneChan)
-	type errorResult struct {
-		err      error
-		fromNode string
-	}
-	errorChan := make(chan errorResult)
-	go func() {
-		for msg := range unrCh {
-			errorChan <- errorResult{
-				err:      fmt.Errorf(msg.Problem),
-				fromNode: msg.ReceivedFromNode,
-			}
-		}
-	}()
-	startTime := time.Now()
-	replyChan := make(chan string)
-	go func() {
-		buf := make([]byte, 8)
-		_, addr, err := pc.ReadFrom(buf)
-		fromNode := ""
-		if addr != nil {
-			fromNode = addr.String()
-			fromNode = strings.TrimSuffix(fromNode, ":ping")
-		}
-		if err == nil {
-			select {
-			case replyChan <- fromNode:
-			case <-ctx.Done():
-			}
-		} else {
-			select {
-			case errorChan <- errorResult{
-				err:      err,
-				fromNode: fromNode,
-			}:
-			case <-ctx.Done():
-			}
-		}
-	}()
-	_, err = pc.WriteTo([]byte{}, nc.NewAddr(target, "ping"))
-	if err != nil {
-		return time.Since(startTime), nc.NodeID(), err
-	}
-	select {
-	case errRes := <-errorChan:
-		return time.Since(startTime), errRes.fromNode, errRes.err
-	case remote := <-replyChan:
-		return time.Since(startTime), remote, nil
-	case <-time.After(10 * time.Second):
-		return time.Since(startTime), "", fmt.Errorf("timeout")
-	}
-}
-
 func (c *pingCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
-	pingTime, pingRemote, err := ping(nc, c.target, nc.MaxForwardingHops())
+	pingTime, pingRemote, err := nc.Ping(ctx, c.target, nc.MaxForwardingHops())
 	cfr := make(map[string]interface{})
 	if err == nil {
 		cfr["Success"] = true

--- a/pkg/netceptor/ping.go
+++ b/pkg/netceptor/ping.go
@@ -1,0 +1,118 @@
+package netceptor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Ping sends a single test packet and waits for a reply or error.
+func (s *Netceptor) Ping(ctx context.Context, target string, hopsToLive byte) (time.Duration, string, error) {
+	pc, err := s.ListenPacket("")
+	if err != nil {
+		return 0, "", err
+	}
+	ctxPing, ctxCancel := context.WithCancel(ctx)
+	defer func() {
+		ctxCancel()
+		_ = pc.Close()
+	}()
+	pc.SetHopsToLive(hopsToLive)
+	doneChan := make(chan struct{})
+	unrCh := pc.SubscribeUnreachable(doneChan)
+	defer close(doneChan)
+	type errorResult struct {
+		err      error
+		fromNode string
+	}
+	errorChan := make(chan errorResult)
+	go func() {
+		for msg := range unrCh {
+			errorChan <- errorResult{
+				err:      fmt.Errorf(msg.Problem),
+				fromNode: msg.ReceivedFromNode,
+			}
+		}
+	}()
+	startTime := time.Now()
+	replyChan := make(chan string)
+	go func() {
+		buf := make([]byte, 8)
+		_, addr, err := pc.ReadFrom(buf)
+		fromNode := ""
+		if addr != nil {
+			fromNode = addr.String()
+			fromNode = strings.TrimSuffix(fromNode, ":ping")
+		}
+		if err == nil {
+			select {
+			case replyChan <- fromNode:
+			case <-ctxPing.Done():
+			case <-s.context.Done():
+			}
+		} else {
+			select {
+			case errorChan <- errorResult{
+				err:      err,
+				fromNode: fromNode,
+			}:
+			case <-ctx.Done():
+			case <-s.context.Done():
+			}
+		}
+	}()
+	_, err = pc.WriteTo([]byte{}, s.NewAddr(target, "ping"))
+	if err != nil {
+		return time.Since(startTime), s.NodeID(), err
+	}
+	select {
+	case errRes := <-errorChan:
+		return time.Since(startTime), errRes.fromNode, errRes.err
+	case remote := <-replyChan:
+		return time.Since(startTime), remote, nil
+	case <-time.After(10 * time.Second):
+		return time.Since(startTime), "", fmt.Errorf("timeout")
+	case <-ctxPing.Done():
+		return time.Since(startTime), "", fmt.Errorf("user cancelled")
+	case <-s.context.Done():
+		return time.Since(startTime), "", fmt.Errorf("netceptor shutdown")
+	}
+}
+
+// TracerouteResult is the result of one hop of a traceroute.
+type TracerouteResult struct {
+	From string
+	Time time.Duration
+	Err  error
+}
+
+// Traceroute returns a channel which will receive a series of hops between this node and the target.
+func (s *Netceptor) Traceroute(ctx context.Context, target string) <-chan *TracerouteResult {
+	results := make(chan *TracerouteResult)
+	go func() {
+		defer close(results)
+		for i := 0; i <= int(s.MaxForwardingHops()); i++ {
+			pingTime, pingRemote, err := s.Ping(ctx, target, byte(i))
+			res := &TracerouteResult{
+				From: pingRemote,
+				Time: pingTime,
+			}
+			if err != nil && err.Error() != ProblemExpiredInTransit {
+				res.Err = err
+			}
+			select {
+			case results <- res:
+			case <-ctx.Done():
+				return
+			case <-s.context.Done():
+				return
+			}
+			if res.Err != nil || err == nil {
+				return
+			}
+		}
+	}()
+	
+	return results
+}


### PR DESCRIPTION
Currently, the ping and traceroute functionality is locked inside the control service implementation.  This PR moves the functionality to the Netceptor module, with the control service handlers calling it.  The motivation is to allow the use of ping and traceroute from Go code that imports Netceptor.