### PR TITLE
Fix receptorctl status output

### DIFF
--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -149,7 +149,9 @@ def status(ctx, printjson):
         print_message(f"{'Known Node':<{longest_node}} Known Connections")
         for node in costs:
             print_message(f"{node:<{longest_node}} ", nl=False)
-            print_json(costs[node])
+            for peer, cost in costs[node].items():
+                print_message(f"{peer}: {cost} ", nl=False)
+            print_message()
 
     routes = status.pop("RoutingTable", None)
     if routes:
@@ -199,7 +201,7 @@ def status(ctx, printjson):
             workTypes = ", ".join(workTypes)
             if printOnce:
                 print_message()
-                print_message(f"{'Node':<{longest_node}}  {header}")
+                print_message(f"{'Node':<{longest_node}} {header}")
                 printOnce = False
             print_message(f"{ad['NodeID']:<{longest_node}} ", nl=False)
             print_message(workTypes)


### PR DESCRIPTION
before

```
Known Node   Known Connections
bar          {
                "fish": 1,
                "foo": 1
}
fish         {
                "bar": 1
}
foo          {
                "bar": 1
}
```

after

```
Known Node   Known Connections
bar          fish: 1 foo: 1 
fish         bar: 1 
foo          bar: 1 
```