### PR TITLE
fix error message to show what node id was expected vs found in cert

### DIFF
--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -990,7 +990,7 @@ func (s *Netceptor) receptorVerifyFunc(tlscfg *tls.Config, expectedNodeID string
 			}
 		}
 		if !found {
-			logger.Error("RVF ReceptorNameError: %s", err)
+			logger.Error("RVF ReceptorNameError: expected %s but found %s", expectedNodeID, strings.Join(receptorNames, ", "))
 
 			return ReceptorCertNameError{ValidNodes: receptorNames, ExpectedNode: expectedNodeID}
 		}


### PR DESCRIPTION
Node IDs are embedded in the TLS certificate. If a client attempts to connect with a cert with an invalid name (the node ID in the cert doesn't match the node ID of the connection), then the server properly emits an error.

Currently the error message is bugged, so this commit fixes that

before

`ERROR 2022/02/01 12:47:10 RVF ReceptorNameError: **%!s(<nil>)`

after

`ERROR 2022/02/01 12:54:15 RVF ReceptorNameError: expected foo but found baz`