### PR TITLE
Make node ID verifier factory public

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -71,7 +71,7 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		if tlscfg.ClientAuth == tls.RequireAndVerifyClientCert {
 			tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
 				remoteNode := strings.Split(hi.Conn.RemoteAddr().String(), ":")[0]
-				tlscfg.VerifyPeerCertificate = s.receptorVerifyFunc(tlscfg, remoteNode, VerifyClient)
+				tlscfg.VerifyPeerCertificate = s.GetNodeVerifyFunc(tlscfg, remoteNode, VerifyClient)
 
 				return tlscfg, nil
 			}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -925,8 +925,8 @@ const (
 	VerifyClient = 2
 )
 
-// receptorVerifyFunc generates a function that verifies a Receptor node ID.
-func (s *Netceptor) receptorVerifyFunc(tlscfg *tls.Config, expectedNodeID string,
+// GetNodeVerifyFunc generates a function that verifies a Receptor node ID.
+func (s *Netceptor) GetNodeVerifyFunc(tlscfg *tls.Config, expectedNodeID string,
 	verifyType int) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		certs := make([]*x509.Certificate, len(rawCerts))
@@ -1010,7 +1010,7 @@ func (s *Netceptor) GetClientTLSConfig(name string, expectedHostName string, exp
 		// noop
 	case expectedHostNameType == "receptor":
 		tlscfg.InsecureSkipVerify = true
-		tlscfg.VerifyPeerCertificate = s.receptorVerifyFunc(tlscfg, expectedHostName, VerifyServer)
+		tlscfg.VerifyPeerCertificate = s.GetNodeVerifyFunc(tlscfg, expectedHostName, VerifyServer)
 	default:
 		tlscfg.ServerName = expectedHostName
 	}


### PR DESCRIPTION
Someone writing Go code importing Netceptor may want to establish an above-the-mesh mutual TLS connection.  To do this, they need to build a tls.Config that verifies node IDs.  Because `receptorVerifyFunc` is currently private, the user will have to write their own verifier that understands the Receptor otherName OID - or more likely, just copy-and-paste this code.  Making it public allows a library user to easily create verifier functions as needed.