### PR TITLE
test image before pushing to quay

### DIFF
--- a/.github/workflows/devel_image.yml
+++ b/.github/workflows/devel_image.yml
@@ -16,6 +16,9 @@ jobs:
         run: |
           TAG=receptor:devel make container
 
+      - name: Test Image
+        run: podman run --rm receptor:devel receptor --version
+
       - name: Push To Quay
         uses: redhat-actions/push-to-registry@v2.1.1
         with:


### PR DESCRIPTION
related https://github.com/ansible/receptor/issues/539

if receptor builds okay, but doesn't run okay, this small command should find that and exit.

e.g. if the build would have failed for the recent 1.16 issue

```
[2/2] STEP 14/18: RUN receptor --version
panic: qtls.ClientHelloInfo doesn't match

goroutine 1 [running]:
github.com/marten-seemann/qtls-go1-15.init.0()
	/root/go/pkg/mod/github.com/marten-seemann/qtls-go1-15@v0.1.0/unsafe.go:20 +0x132
Error: error building at STEP "RUN receptor --version": error while running runtime: exit status 2
make: *** [Makefile:134: .container-flag-0.9.8.dev272] Error 125
```