### PR TITLE
Fix hanging channel writes

### DIFF
--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -1706,12 +1706,12 @@ func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, bi *ba
 			if !done {
 				select {
 				case s.updateRoutingTableChan <- 0:
-				case <-s.context.Done():
+				default:
 				}
 
 				select {
 				case s.sendRouteFloodChan <- 0:
-				case <-s.context.Done():
+				default:
 				}
 			}
 		}


### PR DESCRIPTION
Tests were sometimes getting stuck waiting for backends to shutdown and I noticed that this goroutine was stuck trying to write to these channels.

Not sure if this is the correct way to fix this, but `make testloop` seems happy.