### PR TITLE
Fix several race conditions and sources of test flake

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -3,7 +3,6 @@ name: CI
 
 on:
   pull_request:
-  push:
 
 jobs:
   lint-receptor:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -36,6 +36,7 @@ jobs:
     name: receptor (Go ${{ matrix.go-version }})
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.16, 1.17]
     steps:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -77,6 +77,10 @@ jobs:
       - name: get k8s logs
         if: ${{ failure() }}
         run: .github/workflows/artifact-k8s-logs.sh
+      
+      - name: remove sockets before archiving logs
+        if: ${{ failure() }}
+        run: find /tmp/receptor-testing -name controlsock -delete
 
       - name: Artifact receptor data
         uses: actions/upload-artifact@v2

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -42,8 +42,6 @@ func dialerSession(ctx context.Context, wg *sync.WaitGroup, redial bool, redialD
 				case <-closeChan:
 					// continue
 				case <-ctx.Done():
-					_ = sess.Close()
-
 					return
 				}
 			}

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -140,13 +140,13 @@ func (b *WebsocketListener) Start(ctx context.Context, wg *sync.WaitGroup) (chan
 		return nil, err
 	}
 	wg.Add(1)
+	b.server = &http.Server{
+		Addr:    b.address,
+		Handler: mux,
+	}
 	go func() {
 		defer wg.Done()
 		var err error
-		b.server = &http.Server{
-			Addr:    b.address,
-			Handler: mux,
-		}
 		if b.tlscfg == nil {
 			err = b.server.Serve(b.li)
 		} else {

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -72,7 +72,7 @@ func (b *WebsocketDialer) Start(ctx context.Context, wg *sync.WaitGroup) (chan n
 			if resp.Body.Close(); err != nil {
 				return nil, err
 			}
-			ns := newWebsocketSession(conn, closeChan)
+			ns := newWebsocketSession(ctx, conn, closeChan)
 
 			return ns, nil
 		})
@@ -132,7 +132,7 @@ func (b *WebsocketListener) Start(ctx context.Context, wg *sync.WaitGroup) (chan
 
 			return
 		}
-		ws := newWebsocketSession(conn, nil)
+		ws := newWebsocketSession(ctx, conn, nil)
 		sessChan <- ws
 	})
 	b.li, err = net.Listen("tcp", b.address)
@@ -169,6 +169,7 @@ func (b *WebsocketListener) Start(ctx context.Context, wg *sync.WaitGroup) (chan
 // WebsocketSession implements BackendSession for WebsocketDialer and WebsocketListener.
 type WebsocketSession struct {
 	conn            *websocket.Conn
+	context         context.Context
 	recvChan        chan *recvResult
 	closeChan       chan struct{}
 	closeChanCloser sync.Once
@@ -179,9 +180,10 @@ type recvResult struct {
 	err  error
 }
 
-func newWebsocketSession(conn *websocket.Conn, closeChan chan struct{}) *WebsocketSession {
+func newWebsocketSession(ctx context.Context, conn *websocket.Conn, closeChan chan struct{}) *WebsocketSession {
 	ws := &WebsocketSession{
 		conn:            conn,
+		context:         ctx,
 		recvChan:        make(chan *recvResult),
 		closeChan:       closeChan,
 		closeChanCloser: sync.Once{},
@@ -195,9 +197,13 @@ func newWebsocketSession(conn *websocket.Conn, closeChan chan struct{}) *Websock
 func (ns *WebsocketSession) recvChannelizer() {
 	for {
 		_, data, err := ns.conn.ReadMessage()
-		ns.recvChan <- &recvResult{
+		select {
+		case <-ns.context.Done():
+			return
+		case ns.recvChan <- &recvResult{
 			data: data,
 			err:  err,
+		}:
 		}
 		if err != nil {
 			return

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -356,15 +356,11 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 						return
 					}
 					if err != nil {
-						if strings.HasSuffix(err.Error(), "normal close") {
-							continue
+						if !strings.HasSuffix(err.Error(), "normal close") {
+							logger.Error("Error accepting connection: %s\n", err)
 						}
-					}
-					if err != nil {
-						logger.Error("Error accepting connection: %s. Closing listener.\n", err)
-						_ = listener.Close()
 
-						return
+						continue
 					}
 					go func() {
 						defer conn.Close()

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -53,7 +53,6 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		service = s.getEphemeralService()
 	}
 	s.listenerLock.Lock()
-	defer s.listenerLock.Unlock()
 	_, isReserved := s.reservedServices[service]
 	_, isListening := s.listenerRegistry[service]
 	if isReserved || isListening {
@@ -88,6 +87,7 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 	}
 	pc.startUnreachable()
 	s.listenerRegistry[service] = pc
+	s.listenerLock.Unlock()
 	cfg := &quic.Config{
 		MaxIdleTimeout: MaxIdleTimeoutForQuicConnections,
 	}
@@ -292,8 +292,8 @@ func (s *Netceptor) DialContext(ctx context.Context, node string, service string
 	rAddr := s.NewAddr(node, service)
 	cfg := &quic.Config{
 		HandshakeIdleTimeout: 15 * time.Second,
-		MaxIdleTimeout:   MaxIdleTimeoutForQuicConnections,
-		KeepAlive:        KeepAliveForQuicConnections,
+		MaxIdleTimeout:       MaxIdleTimeoutForQuicConnections,
+		KeepAlive:            KeepAliveForQuicConnections,
 	}
 	if tlscfg == nil {
 		tlscfg = generateClientTLSConfig()

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -446,7 +446,7 @@ func TestDuplicateNodeDetection(t *testing.T) {
 		}()
 		select {
 		case <-backendCloseChan:
-		case <-time.After(60 * time.Second):
+		case <-time.After(120 * time.Second):
 			t.Fatal("timed out waiting for duplicate node to terminate")
 		}
 

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -137,7 +137,10 @@ func TestHopCountLimit(t *testing.T) {
 		if !ok {
 			t.Fatal("node2 disappeared from node1's connections")
 		}
-		if time.Since(c.lastReceivedData) > 250*time.Millisecond {
+		c.lastReceivedLock.RLock()
+		lastReceivedData := c.lastReceivedData
+		c.lastReceivedLock.RUnlock()
+		if time.Since(lastReceivedData) > 250*time.Millisecond {
 			break
 		}
 		select {

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -339,7 +339,9 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 	var stdin *stdinReader
 	if !skipStdin {
 		stdin, err = newStdinReader(kw.UnitDir())
-		if err != nil {
+		if err == errFileSizeZero {
+			skipStdin = true
+		} else if err != nil {
 			errMsg := fmt.Sprintf("Error opening stdin file: %s", err)
 			logger.Error(errMsg)
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
@@ -381,6 +383,8 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 				}
 			}
 		}()
+	} else {
+		kw.UpdateBasicStatus(WorkStateRunning, "Pod Running", stdout.Size())
 	}
 
 	// Actually run the streams.  This blocks until the pod finishes.

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -68,9 +68,19 @@ type stdinReader struct {
 	doneOnce sync.Once
 }
 
+var errFileSizeZero error
+
 // newStdinReader allocates a new stdinReader, which reads from a stdin file and provides a Done function.
 func newStdinReader(unitdir string) (*stdinReader, error) {
-	reader, err := os.Open(path.Join(unitdir, "stdin"))
+	stdinpath := path.Join(unitdir, "stdin")
+	stat, err := os.Stat(stdinpath)
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size() == 0 {
+		return nil, errFileSizeZero
+	}
+	reader, err := os.Open(stdinpath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -3,6 +3,7 @@
 package workceptor
 
 import (
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -68,7 +69,7 @@ type stdinReader struct {
 	doneOnce sync.Once
 }
 
-var errFileSizeZero error
+var errFileSizeZero = errors.New("file is empty")
 
 // newStdinReader allocates a new stdinReader, which reads from a stdin file and provides a Done function.
 func newStdinReader(unitdir string) (*stdinReader, error) {

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -148,7 +148,7 @@ func TestNegativeCost(t *testing.T) {
 			time.Sleep(100 * time.Millisecond)
 
 			cmd.Process.Kill()
-			cmd.Process.Wait()
+			cmd.Wait()
 			if receptorStdOut.String() != "Error: connection cost must be positive\n" {
 				t.Fatalf("Expected stdout: Error: connection cost must be positive, actual stdout: %s", receptorStdOut.String())
 			}


### PR DESCRIPTION
Fixed up a few places in the code where we do blocking send and receive calls, but don't select on the overall context being finished.

This should help mitigate some race conditions we've discovered in testing when starting up and shutting down nodes.