### PR TITLE
k8s skip stdin if stdin file is 0 bytes

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -383,6 +383,8 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 				}
 			}
 		}()
+	} else {
+		kw.UpdateBasicStatus(WorkStateRunning, "Pod Running", stdout.Size())
 	}
 
 	// Actually run the streams.  This blocks until the pod finishes.

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -339,7 +339,9 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 	var stdin *stdinReader
 	if !skipStdin {
 		stdin, err = newStdinReader(kw.UnitDir())
-		if err != nil {
+		if err == errFileSizeZero {
+			skipStdin = true
+		} else if err != nil {
 			errMsg := fmt.Sprintf("Error opening stdin file: %s", err)
 			logger.Error(errMsg)
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -73,16 +73,16 @@ var errFileSizeZero error
 // newStdinReader allocates a new stdinReader, which reads from a stdin file and provides a Done function.
 func newStdinReader(unitdir string) (*stdinReader, error) {
 	stdinpath := path.Join(unitdir, "stdin")
-	reader, err := os.Open(stdinpath)
-	if err != nil {
-		return nil, err
-	}
 	stat, err := os.Stat(stdinpath)
 	if err != nil {
 		return nil, err
 	}
 	if stat.Size() == 0 {
 		return nil, errFileSizeZero
+	}
+	reader, err := os.Open(stdinpath)
+	if err != nil {
+		return nil, err
 	}
 
 	return &stdinReader{

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -68,11 +68,21 @@ type stdinReader struct {
 	doneOnce sync.Once
 }
 
+var errFileSizeZero error
+
 // newStdinReader allocates a new stdinReader, which reads from a stdin file and provides a Done function.
 func newStdinReader(unitdir string) (*stdinReader, error) {
-	reader, err := os.Open(path.Join(unitdir, "stdin"))
+	stdinpath := path.Join(unitdir, "stdin")
+	reader, err := os.Open(stdinpath)
 	if err != nil {
 		return nil, err
+	}
+	stat, err := os.Stat(stdinpath)
+	if err != nil {
+		return nil, err
+	}
+	if stat.Size() == 0 {
+		return nil, errFileSizeZero
 	}
 
 	return &stdinReader{


### PR DESCRIPTION
related https://github.com/ansible/receptor/issues/489

Check if stdin file is 0 bytes. If empty, do not attempt to attach stdin stream to container. If the container already exited, this can lead to an unintended error.