### PR TITLE
Install python dependencies from pypi in container (and add a test)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -124,3 +124,43 @@ jobs:
 
       - name: Run receptorctl tests
         run: make receptorctl-test
+
+  container:
+    name: container
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build container
+        run: make container
+
+      - name: Write out basic config
+        run: |
+          cat << EOF > test.cfg
+          ---
+          - local-only:
+
+          - control-service:
+              service: control
+              filename: /tmp/receptor.sock
+
+          - work-command:
+              worktype: cat
+              command: cat
+          EOF
+
+      - name: Run receptor (and wait a few seconds for it to boot)
+        run: |
+          podman run --name receptor -d -v $PWD/test.cfg:/etc/receptor/receptor.conf:Z localhost/receptor
+          sleep 3
+          podman logs receptor
+
+      - name: Submit work and assert the output we expect
+        run: |
+          output=$(podman exec -i receptor receptorctl work submit cat -l 'hello world' -f)
+          echo $output
+          if [[ "$output" != "hello world" ]]; then
+            echo "Output did not contain expected value"
+            exit 1  
+          fi

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -16,7 +16,7 @@ LABEL version="${VERSION}"
 
 RUN dnf -y update && \
     dnf -y install epel-release && \
-    dnf -y install tini python3-click python3-pyyaml python3-dateutil python3-pip python3-wheel && \
+    dnf -y install tini python3-pip python3-wheel && \
     dnf clean all
 
 COPY receptorctl-${VERSION}-py3-none-any.whl /tmp

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream8 as builder
 
-RUN dnf -y update && dnf install -y golang make python3 python3-pip python3-wheel
+RUN dnf -y update && dnf install -y golang make python3 python3-pip python3-wheel git
 
 ADD source.tar.gz /source
 WORKDIR /source


### PR DESCRIPTION
CentOS 8 Stream has an old version of Click 6.x and we were seeing this error:

```
Traceback (most recent call last):
  File "/usr/local/bin/receptorctl", line 7, in <module>
    from receptorctl import run
  File "/usr/local/lib/python3.6/site-packages/receptorctl/__init__.py", line 1, in <module>
    from .cli import run
  File "/usr/local/lib/python3.6/site-packages/receptorctl/cli.py", line 85, in <module>
    show_default=True,
  File "/usr/lib/python3.6/site-packages/click/decorators.py", line 170, in decorator
    _param_memo(f, OptionClass(param_decls, **attrs))
  File "/usr/lib/python3.6/site-packages/click/core.py", line 1459, in __init__
    Parameter.__init__(self, param_decls, type=type, **attrs)
TypeError: __init__() got an unexpected keyword argument 'show_envvar'
```