### PR TITLE
Clone TLS config before changing it

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -69,10 +69,11 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		tlscfg.NextProtos = []string{"netceptor"}
 		if tlscfg.ClientAuth == tls.RequireAndVerifyClientCert {
 			tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
+				clientTLSCfg := tlscfg.Clone()
 				remoteNode := strings.Split(hi.Conn.RemoteAddr().String(), ":")[0]
-				tlscfg.VerifyPeerCertificate = s.receptorVerifyFunc(tlscfg, remoteNode, VerifyClient)
+				clientTLSCfg.VerifyPeerCertificate = s.receptorVerifyFunc(tlscfg, remoteNode, VerifyClient)
 
-				return tlscfg, nil
+				return clientTLSCfg, nil
 			}
 		}
 	}


### PR DESCRIPTION
`GetConfigForClient` returns a new `tls.Config` customized for the client currently connecting.  The function is a closure on `tlscfg` from the outer scope, so when we assign to `tlscfg.VerifyPeerCertificate`, our change affects future connections that reuse this configuration.  The immediate solution is to make a local clone inside `GetConfigForClient` so our change doesn't propagate to the outer scope.