### PR TITLE
Better implementation of pinned certificates

### DIFF
--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -296,7 +296,7 @@ func (cfg tcpDialerCfg) Run() error {
 	if err != nil {
 		return err
 	}
-	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, host, "dns")
+	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, host, netceptor.ExpectedHostnameTypeDNS)
 	if err != nil {
 		return err
 	}

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -333,7 +333,7 @@ func (cfg websocketDialerCfg) Run() error {
 	if u.Scheme == "wss" && tlsCfgName == "" {
 		tlsCfgName = "default"
 	}
-	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(tlsCfgName, u.Hostname(), "dns")
+	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(tlsCfgName, u.Hostname(), netceptor.ExpectedHostnameTypeDNS)
 	if err != nil {
 		return err
 	}

--- a/pkg/controlsvc/connect.go
+++ b/pkg/controlsvc/connect.go
@@ -75,7 +75,7 @@ func (t *connectCommandType) InitFromJSON(config map[string]interface{}) (Contro
 }
 
 func (c *connectCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
-	tlscfg, err := nc.GetClientTLSConfig(c.tlsConfigName, c.targetNode, "receptor")
+	tlscfg, err := nc.GetClientTLSConfig(c.tlsConfigName, c.targetNode, netceptor.ExpectedHostnameTypeReceptor)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -71,7 +71,7 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 			tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
 				clientTLSCfg := tlscfg.Clone()
 				remoteNode := strings.Split(hi.Conn.RemoteAddr().String(), ":")[0]
-				clientTLSCfg.VerifyPeerCertificate = s.receptorVerifyFunc(tlscfg, remoteNode, VerifyClient)
+				clientTLSCfg.VerifyPeerCertificate = ReceptorVerifyFunc(tlscfg, [][]byte{}, remoteNode, ExpectedHostnameTypeReceptor, VerifyClient)
 
 				return clientTLSCfg, nil
 			}

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -69,10 +69,11 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		tlscfg.NextProtos = []string{"netceptor"}
 		if tlscfg.ClientAuth == tls.RequireAndVerifyClientCert {
 			tlscfg.GetConfigForClient = func(hi *tls.ClientHelloInfo) (*tls.Config, error) {
+				clientTLSCfg := tlscfg.Clone()
 				remoteNode := strings.Split(hi.Conn.RemoteAddr().String(), ":")[0]
-				tlscfg.VerifyPeerCertificate = s.receptorVerifyFunc(tlscfg, remoteNode, VerifyClient)
+				clientTLSCfg.VerifyPeerCertificate = s.receptorVerifyFunc(tlscfg, remoteNode, VerifyClient)
 
-				return tlscfg, nil
+				return clientTLSCfg, nil
 			}
 		}
 	}

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -95,7 +95,7 @@ type tcpProxyInboundCfg struct {
 // Run runs the action.
 func (cfg tcpProxyInboundCfg) Run() error {
 	logger.Debug("Running TCP inbound proxy service %v\n", cfg)
-	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, cfg.RemoteNode, "receptor")
+	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, cfg.RemoteNode, netceptor.ExpectedHostnameTypeReceptor)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (cfg tcpProxyOutboundCfg) Run() error {
 	if err != nil {
 		return err
 	}
-	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, host, "dns")
+	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, host, netceptor.ExpectedHostnameTypeDNS)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -89,7 +89,7 @@ type unixProxyInboundCfg struct {
 // Run runs the action.
 func (cfg unixProxyInboundCfg) Run() error {
 	logger.Debug("Running Unix socket inbound proxy service %v\n", cfg)
-	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, cfg.RemoteNode, "receptor")
+	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, cfg.RemoteNode, netceptor.ExpectedHostnameTypeReceptor)
 	if err != nil {
 		return err
 	}

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/ansible/receptor/pkg/netceptor"
 	"io"
 	"net"
 	"os"
@@ -49,7 +50,7 @@ func (rw *remoteUnit) connectToRemote(ctx context.Context) (net.Conn, *bufio.Rea
 	if !ok {
 		return nil, nil, fmt.Errorf("remote ExtraData missing")
 	}
-	tlsConfig, err := rw.w.nc.GetClientTLSConfig(red.TLSClient, red.RemoteNode, "receptor")
+	tlsConfig, err := rw.w.nc.GetClientTLSConfig(red.TLSClient, red.RemoteNode, netceptor.ExpectedHostnameTypeReceptor)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -241,7 +241,7 @@ func (w *Workceptor) AllocateUnit(workTypeName string, params map[string]string)
 // AllocateRemoteUnit creates a new remote work unit and generates a local identifier for it.
 func (w *Workceptor) AllocateRemoteUnit(remoteNode, remoteWorkType, tlsClient, ttl string, signWork bool, params map[string]string) (WorkUnit, error) {
 	if tlsClient != "" {
-		_, err := w.nc.GetClientTLSConfig(tlsClient, "testhost", "receptor")
+		_, err := w.nc.GetClientTLSConfig(tlsClient, "testhost", netceptor.ExpectedHostnameTypeReceptor)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This is a better-integrated implementation of pinned certificates, with a single verifier function instead of two different ones at different parts of the code.  To accomplish this, it is necessary to store the client pinned fingerprints alongside `clientTLSConfigs`, because we need access to them to generate client-specific `tls.Config`s at connection time.  We do not need this with server configs.

I have also changed ReceptorVerifyFunc to be standalone, since it does not access the Netceptor data structure at all, and public, because this functionality is needed for Go library users of Netceptor, who can't (and probably don't want to) construct a `tlsClientConfig` or `tlsServerConfig`.

This PR includes the change in https://github.com/ansible/receptor/pull/552.