### PR TITLE
Remove verifySignature requirement for remote work type

### DIFF
--- a/pkg/workceptor/workceptor.go
+++ b/pkg/workceptor/workceptor.go
@@ -62,7 +62,7 @@ func New(ctx context.Context, nc *netceptor.Netceptor, dataDir string) (*Workcep
 		signingExpiration: 5 * time.Minute,
 		verifyingKey:      "",
 	}
-	err := w.RegisterWorker("remote", newRemoteWorker, true)
+	err := w.RegisterWorker("remote", newRemoteWorker, false)
 	if err != nil {
 		return nil, fmt.Errorf("could not register remote worker function: %s", err)
 	}
@@ -171,7 +171,12 @@ func (w *Workceptor) createSignature(nodeID string) (string, error) {
 	return tokenString, nil
 }
 
-func (w *Workceptor) ShouldVerifySignature(workType string) bool {
+func (w *Workceptor) ShouldVerifySignature(workType string, signWork bool) bool {
+	// if work unit is remote, just get the signWork boolean from the
+	// remote extra data field
+	if workType == "remote" {
+		return signWork
+	}
 	w.workTypesLock.RLock()
 	wt, ok := w.workTypes[workType]
 	w.workTypesLock.RUnlock()


### PR DESCRIPTION
Currently the built-in "remote" work type is hard-coded to require a signature, which is odd and leads to unexpected errors. Notably, when clients connect to a control service, operations (like results, cancel, release) on a remote-type work unit requires signed commands even though no target work types are expecting signed requests.

When interacting with a work unit that is of type "remote", we need to determine whether we expect signed work or not. That value should be derived from the signWork field that was filled in when we first launched the work unit.

If signWork is off, we don't need to verify a signature (note if signWork is `false` on control node, and the target execution node expects it, then we'll get an error)