### PR TITLE
Fix deadlock in handleMessageData

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -53,6 +53,7 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		service = s.getEphemeralService()
 	}
 	s.listenerLock.Lock()
+	defer s.listenerLock.Unlock()
 	_, isReserved := s.reservedServices[service]
 	_, isListening := s.listenerRegistry[service]
 	if isReserved || isListening {
@@ -88,7 +89,6 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 	}
 	pc.startUnreachable()
 	s.listenerRegistry[service] = pc
-	s.listenerLock.Unlock()
 	cfg := &quic.Config{
 		MaxIdleTimeout: MaxIdleTimeoutForQuicConnections,
 	}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -1628,8 +1628,12 @@ func (s *Netceptor) handleMessageData(md *MessageData) error {
 
 			return nil
 		}
-		pc.recvChan <- md
 		s.listenerLock.RUnlock()
+		select {
+		case <-pc.context.Done():
+			return nil
+		case pc.recvChan <- md:
+		}
 
 		return nil
 	}


### PR DESCRIPTION
This must have been introduced by our recent changes that added some contexts in places we were doing blocking reads or writes. Our integration tests started blowing up because Receptor started hanging. After attaching to the process and looking at [the goroutines](https://gist.githubusercontent.com/shanemcd/a474f8e10f5f23ff7675096ab1a0242c/raw/8a0927480a100d92a1013ea11a6b6c575df62303/gistfile1.txt) with delve, I noticed we had 2 Goroutines stuck in `handleMessageData`.

The first one was stuck here:

https://github.com/ansible/receptor/blob/015bad6282f1fb2408c4c25e5940e25a01edace1/pkg/netceptor/netceptor.go#L1631

```
  Goroutine 200 - User: /builddir/build/BUILD/receptor-3ecf65571e141244f04e89f1fc9199eb8f6680f9/pkg/netceptor/netceptor.go:1631 github.com/ansible/receptor/pkg/netceptor.(*Netceptor).handleMessageData (0x8cbcdc) [chan send 457314h58m45.572259763s]
	0  0x000000000043f725 in runtime.gopark
	    at /usr/lib/golang/src/runtime/proc.go:337
	1  0x000000000040be5a in runtime.chansend
	    at /usr/lib/golang/src/runtime/chan.go:257
	2  0x000000000040bbb5 in runtime.chansend1
	    at /usr/lib/golang/src/runtime/chan.go:143
	3  0x00000000008cbcdc in github.com/ansible/receptor/pkg/netceptor.(*Netceptor).handleMessageData
	    at /builddir/build/BUILD/receptor-3ecf65571e141244f04e89f1fc9199eb8f6680f9/pkg/netceptor/netceptor.go:1631
	4  0x00000000008ceb31 in github.com/ansible/receptor/pkg/netceptor.(*Netceptor).runProtocol
	    at /builddir/build/BUILD/receptor-3ecf65571e141244f04e89f1fc9199eb8f6680f9/pkg/netceptor/netceptor.go:1859
	5  0x00000000008d431b in github.com/ansible/receptor/pkg/netceptor.(*Netceptor).AddBackend.func1.2
	    at /builddir/build/BUILD/receptor-3ecf65571e141244f04e89f1fc9199eb8f6680f9/pkg/netceptor/netceptor.go:513
	6  0x0000000000472de1 in runtime.goexit
	    at /usr/lib/golang/src/runtime/asm_amd64.s:1371
```

And the second one was stuck here:

https://github.com/ansible/receptor/blob/015bad6282f1fb2408c4c25e5940e25a01edace1/pkg/netceptor/netceptor.go#L1614

```
  Goroutine 322 - User: /usr/lib/golang/src/runtime/sema.go:71 sync.runtime_SemacquireMutex (0x46f287) [semacquire 457314h58m45.223415189s]
	0  0x000000000043f725 in runtime.gopark
	    at /usr/lib/golang/src/runtime/proc.go:337
	1  0x00000000004508a5 in runtime.goparkunlock
	    at /usr/lib/golang/src/runtime/proc.go:342
	2  0x00000000004508a5 in runtime.semacquire1
	    at /usr/lib/golang/src/runtime/sema.go:144
	3  0x000000000046f287 in sync.runtime_SemacquireMutex
	    at /usr/lib/golang/src/runtime/sema.go:71
	4  0x00000000008cbd65 in sync.(*RWMutex).RLock
	    at /usr/lib/golang/src/sync/rwmutex.go:63
	5  0x00000000008cbd65 in github.com/ansible/receptor/pkg/netceptor.(*Netceptor).handleMessageData
	    at /builddir/build/BUILD/receptor-3ecf65571e141244f04e89f1fc9199eb8f6680f9/pkg/netceptor/netceptor.go:1614
	6  0x00000000008ceb31 in github.com/ansible/receptor/pkg/netceptor.(*Netceptor).runProtocol
	    at /builddir/build/BUILD/receptor-3ecf65571e141244f04e89f1fc9199eb8f6680f9/pkg/netceptor/netceptor.go:1859
	7  0x00000000008d431b in github.com/ansible/receptor/pkg/netceptor.(*Netceptor).AddBackend.func1.2
	    at /builddir/build/BUILD/receptor-3ecf65571e141244f04e89f1fc9199eb8f6680f9/pkg/netceptor/netceptor.go:513
	8  0x0000000000472de1 in runtime.goexit
	    at /usr/lib/golang/src/runtime/asm_amd64.s:1371
```

My attempt at articulating the problem: The first goroutine was not releasing its read lock because it was stuck on a channel send. Once this happened, something else tried to grab a full lock, which is sitting waiting for the read lock to get released. This also prevented the second goroutine from being able to grab a readlock, resulting in a deadlock.
