### PR TITLE
fix lint - ran `gofumpt -w` on all go files in receptor

### DIFF
--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -18,7 +18,8 @@ type dialerFunc func(chan struct{}) (netceptor.BackendSession, error)
 
 // dialerSession is a convenience function for backends that use dial/retry logic.
 func dialerSession(ctx context.Context, wg *sync.WaitGroup, redial bool, redialDelay time.Duration,
-	df dialerFunc) (chan netceptor.BackendSession, error) {
+	df dialerFunc,
+) (chan netceptor.BackendSession, error) {
 	sessChan := make(chan netceptor.BackendSession)
 	wg.Add(1)
 	go func() {

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -289,7 +289,8 @@ func (s *Server) RunControlSession(conn net.Conn) {
 
 // RunControlSvc runs the main accept loop of the control service.
 func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.Config,
-	unixSocket string, unixSocketPermissions os.FileMode, tcpListen string, tcptls *tls.Config) error {
+	unixSocket string, unixSocketPermissions os.FileMode, tcpListen string, tcptls *tls.Config,
+) error {
 	var uli net.Listener
 	var lock *utils.FLock
 	var err error

--- a/pkg/controlsvc/controlsvc_stub.go
+++ b/pkg/controlsvc/controlsvc_stub.go
@@ -40,6 +40,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 
 // RunControlSvc runs the main accept loop of the control service
 func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.Config,
-	unixSocket string, unixSocketPermissions os.FileMode, tcpListen string, tcptls *tls.Config) error {
+	unixSocket string, unixSocketPermissions os.FileMode, tcpListen string, tcptls *tls.Config,
+) error {
 	return ErrNotImplemented
 }

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -298,7 +298,8 @@ func makeNetworkName(nodeID string) string {
 // NewWithConsts constructs a new Receptor network protocol instance, specifying operational constants.
 func NewWithConsts(ctx context.Context, nodeID string,
 	mtu int, routeUpdateTime time.Duration, serviceAdTime time.Duration, seenUpdateExpireTime time.Duration,
-	maxForwardingHops byte, maxConnectionIdleTime time.Duration) *Netceptor {
+	maxForwardingHops byte, maxConnectionIdleTime time.Duration,
+) *Netceptor {
 	s := Netceptor{
 		nodeID:                   nodeID,
 		mtu:                      mtu,
@@ -963,7 +964,8 @@ const (
 
 // ReceptorVerifyFunc generates a function that verifies a Receptor node ID.
 func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expectedHostname string,
-	expectedHostnameType ExpectedHostnameType, verifyType VerifyType) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
+	expectedHostnameType ExpectedHostnameType, verifyType VerifyType,
+) func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, verifiedChains [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
 			logger.Error("RVF failed: peer certificate missing")

--- a/pkg/services/ip_router.go
+++ b/pkg/services/ip_router.go
@@ -47,7 +47,8 @@ type IPRouterService struct {
 
 // NewIPRouter creates a new IP router service.
 func NewIPRouter(nc *netceptor.Netceptor, networkName string, tunInterface string,
-	localNet string, routes string) (*IPRouterService, error) {
+	localNet string, routes string,
+) (*IPRouterService, error) {
 	ipr := &IPRouterService{
 		nc:              nc,
 		networkName:     networkName,

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -17,7 +17,8 @@ import (
 
 // TCPProxyServiceInbound listens on a TCP port and forwards the connection over the Receptor network.
 func TCPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, tlsServer *tls.Config,
-	node string, rservice string, tlsClient *tls.Config) error {
+	node string, rservice string, tlsClient *tls.Config,
+) error {
 	tli, err := net.Listen("tcp", net.JoinHostPort(host, strconv.Itoa(port)))
 	if tlsServer != nil {
 		tli = tls.NewListener(tli, tlsServer)
@@ -48,7 +49,8 @@ func TCPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, tlsSe
 
 // TCPProxyServiceOutbound listens on the Receptor network and forwards the connection via TCP.
 func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *tls.Config,
-	address string, tlsClient *tls.Config) error {
+	address string, tlsClient *tls.Config,
+) error {
 	qli, err := s.ListenAndAdvertise(service, tlsServer, map[string]string{
 		"type":    "TCP Proxy",
 		"address": address,

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -18,7 +18,8 @@ import (
 
 // UnixProxyServiceInbound listens on a Unix socket and forwards connections over the Receptor network.
 func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permissions os.FileMode,
-	node string, rservice string, tlscfg *tls.Config) error {
+	node string, rservice string, tlscfg *tls.Config,
+) error {
 	uli, lock, err := utils.UnixSocketListen(filename, permissions)
 	if err != nil {
 		return fmt.Errorf("error opening Unix socket: %s", err)

--- a/pkg/utils/flock_windows.go
+++ b/pkg/utils/flock_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package utils

--- a/pkg/utils/unixsock_windows.go
+++ b/pkg/utils/unixsock_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package utils

--- a/pkg/workceptor/command_detach_windows.go
+++ b/pkg/workceptor/command_detach_windows.go
@@ -1,3 +1,4 @@
+//go:build windows && !no_workceptor
 // +build windows,!no_workceptor
 
 package workceptor

--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -218,7 +218,8 @@ func (rw *remoteUnit) startRemoteUnit(ctx context.Context, conn net.Conn, reader
 
 // cancelOrReleaseRemoteUnit makes a single attempt to cancel or release a remote unit.
 func (rw *remoteUnit) cancelOrReleaseRemoteUnit(ctx context.Context, conn net.Conn, reader *bufio.Reader,
-	release bool, force bool) error {
+	release bool, force bool,
+) error {
 	defer conn.(interface{ CloseConnection() error }).CloseConnection()
 	red := rw.Status().ExtraData.(*remoteExtraData)
 	var workCmd string


### PR DESCRIPTION
the receptor-lint github action is throwing linting issues on files not associated with changes in a particular PR. i ran the `gofumpt -w` formatter on every go file in the project to get the files up to linting compliance with `golangci-lint` - so that the check passes in github actions