### PR TITLE
Improve ExternalBackend context handling

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.16, 1.17]
+        go-version: [1.16, 1.17, 1.18]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
The current implementation of ExternalBackend does not allow a library user to know when a connection has ended.  This PR adds a context at the ExternalSession level, which an external caller can monitor to detect when the connection is finished.

While looking into this, I found that when an ExternalSession is closed, it calls the cancel function of the whole ExternalBackend, which implies there can only ever be one session per backend.  However, the created context is not saved correctly, so the cancel function doesn't actually have any effect on anything.  This PR creates a new context object at the ExternalSession level, which can track and be cancelled by a session, without cancelling its parent backend.