### PR TITLE
Add dummy setup.py

### DIFF
--- a/receptorctl/setup.py
+++ b/receptorctl/setup.py
@@ -1,0 +1,7 @@
+# This file is only used by our downstream RPM builds.
+# Remove this once that tooling has been updated to work with setup.cfg.
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
Backport of https://github.com/ansible/receptor/pull/589

Our downstream tooling doesnt yet support installing from a setup.py-less project.

Borrowed from https://stackoverflow.com/questions/66857302/how-does-one-install-a-setup-cfg-pyproject-toml-python-project-in-editable-mod