### PR TITLE
Avoid dropping buffered results data

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -466,7 +466,7 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 					return
 				}
 			}()
-			_, err = io.Copy(stdout, conn)
+			_, err = io.Copy(stdout, reader)
 			close(doneChan)
 			if err != nil {
 				var errmsg string


### PR DESCRIPTION
Currently, Workceptor's remote_work module does the following:

* Connects to the remote node using a `netceptor.Conn`
* Creates a `bufio.Reader` wrapper around the `Conn` object
* Reads the `Streaming results` message using the reader
* Calls `io.Copy` _on the `Conn`_ to retrieve the work results

However, it is not guaranteed that the `bufio.Reader` will stop reading at the `\n` delineating the end of the `Streaming results` message.  The whole point of `bufio.Reader` _is that it is buffered_.  This means that some of the work results may have already been read in to the `bufio.Reader` by the time `io.Copy` is called, and the work results will be missing a chunk from the beginning.

The solution is simple: have the `io.Copy` continue read from the `bufio.Reader` instead of the `Conn`.  This allows buffered data to be written out as expected, rather than being lost.