### PR TITLE
allow setting minimum TLS to 1.3

### DIFF
--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -278,6 +278,10 @@ func (cfg websocketListenerCfg) Run() error {
 	if err != nil {
 		return err
 	}
+	// websockets requires at least the following cipher at the top of the list
+	if tlscfg != nil && len(tlscfg.CipherSuites) > 0 {
+		tlscfg.CipherSuites = append([]uint16{tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256}, tlscfg.CipherSuites...)
+	}
 	b, err := NewWebsocketListener(address, tlscfg)
 	if err != nil {
 		logger.Error("Error creating listener %s: %s\n", address, err)


### PR DESCRIPTION
e.g.

```yaml
- tls-server:
    name: server2
    cert: /home/sbf/sockceptor/certs/foo.crt
    key: /home/sbf/sockceptor/certs/foo.key
    requireclientcert: true
    clientcas: /home/sbf/sockceptor/certs/ca.crt
    minTLS13: true
```

cipher scan

**With `minTLS13: true`**
```
PORT     STATE SERVICE
2222/tcp open  EtherNetIP-1
| ssl-enum-ciphers: 
|   TLSv1.3: 
|     ciphers: 
|       TLS_AKE_WITH_AES_128_GCM_SHA256 (ecdh_x25519) - A
|       TLS_AKE_WITH_AES_256_GCM_SHA384 (ecdh_x25519) - A
|       TLS_AKE_WITH_CHACHA20_POLY1305_SHA256 (ecdh_x25519) - A
|     cipher preference: client
|_  least strength: A
```
