### PR TITLE
add podman-remote to image

### DIFF
--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -22,7 +22,9 @@ COPY receptor.conf /etc/receptor/receptor.conf
 
 RUN dnf -y update && \
     dnf -y install python3-pip && \
+    dnf -y install podman-remote && \
     dnf clean all && \
+    ln -s /usr/bin/podman-remote /usr/bin/podman && \
     pip install --no-cache-dir wheel dumb-init && \
     pip install --no-cache-dir /tmp/*.whl && \
     rm /tmp/*.whl


### PR DESCRIPTION
This PR modifies the Dockerfile to add `podman-remote` to the container and symlink `podman-remote` as `podman`

The goal is to have containerized receptor be able to create container on the host machine

Symlink `podman-remote` to `podman` avoids the AWX having to know the differences between receptor running in container and receptor running directly on VM.