### PR TITLE
fixing linting issues introduced by golangci-lint 1.46.0

### DIFF
--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -63,11 +63,11 @@ func TestStatusFileLock(t *testing.T) {
 				}
 				fileHasExisted = true
 				if err != nil {
-					t.Fatal(fmt.Sprintf("Error loading status file: %s", err))
+					t.Fatalf(fmt.Sprintf("Error loading status file: %s", err))
 				}
 				detailIter, err := strconv.Atoi(sfd.Detail)
 				if err != nil {
-					t.Fatal(fmt.Sprintf("Error converting status detail to int: %s", err))
+					t.Fatalf(fmt.Sprintf("Error converting status detail to int: %s", err))
 				}
 				if detailIter >= 0 {
 					if int64(sfd.State) != sfd.StdoutSize || sfd.State != detailIter {

--- a/pkg/workceptor/lock_test.go
+++ b/pkg/workceptor/lock_test.go
@@ -63,11 +63,11 @@ func TestStatusFileLock(t *testing.T) {
 				}
 				fileHasExisted = true
 				if err != nil {
-					t.Fatalf(fmt.Sprintf("Error loading status file: %s", err))
+					t.Fatalf("Error loading status file: %s", err)
 				}
 				detailIter, err := strconv.Atoi(sfd.Detail)
 				if err != nil {
-					t.Fatalf(fmt.Sprintf("Error converting status detail to int: %s", err))
+					t.Fatalf("Error converting status detail to int: %s", err)
 				}
 				if detailIter >= 0 {
 					if int64(sfd.State) != sfd.StdoutSize || sfd.State != detailIter {

--- a/tests/functional/mesh/conn_test.go
+++ b/tests/functional/mesh/conn_test.go
@@ -2,7 +2,6 @@ package mesh
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net"
 	"strings"
@@ -26,33 +25,33 @@ func TestQuicConnectTimeout(t *testing.T) {
 	// Start a TCP listener on the first node
 	b1, err := backends.NewTCPListener("localhost:3333", nil)
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error listening on TCP: %s\n", err))
+		t.Fatalf("Error listening on TCP: %s\n", err)
 	}
 	err = n1.AddBackend(b1)
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error starting backend: %s\n", err))
+		t.Fatalf("Error starting backend: %s\n", err)
 	}
 
 	// Start a TCP dialer on the second node - this will connect to the listener we just started
 	b2, err := backends.NewTCPDialer("localhost:3333", false, nil)
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error dialing on TCP: %s\n", err))
+		t.Fatalf("Error dialing on TCP: %s\n", err)
 	}
 	err = n2.AddBackend(b2)
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error starting backend: %s\n", err))
+		t.Fatalf("Error starting backend: %s\n", err)
 	}
 
 	// Start an echo server on node 1
 	l1, err := n1.Listen("echo", nil)
 	if err != nil {
-		t.Fatalf(fmt.Sprintf("Error listening on Receptor network: %s\n", err))
+		t.Fatalf("Error listening on Receptor network: %s\n", err)
 	}
 	go func() {
 		// Accept an incoming connection - note that conn is just a regular net.Conn
 		conn, err := l1.Accept()
 		if err != nil {
-			t.Fatalf(fmt.Sprintf("Error accepting connection: %s\n", err))
+			t.Fatalf("Error accepting connection: %s\n", err)
 
 			return
 		}
@@ -69,7 +68,7 @@ func TestQuicConnectTimeout(t *testing.T) {
 					if strings.Contains(err.Error(), "no recent network activity") {
 						t.Log("Successfully got the desired timeout error")
 					} else {
-						t.Fatalf(fmt.Sprintf("Read error in Receptor listener: %s\n", err))
+						t.Fatalf("Read error in Receptor listener: %s\n", err)
 					}
 
 					return
@@ -77,7 +76,7 @@ func TestQuicConnectTimeout(t *testing.T) {
 				if n > 0 {
 					_, err := conn.Write(buf[:n])
 					if err != nil {
-						t.Fatalf(fmt.Sprintf("Write error in Receptor listener: %s\n", err))
+						t.Fatalf("Write error in Receptor listener: %s\n", err)
 
 						return
 					}

--- a/tests/functional/mesh/conn_test.go
+++ b/tests/functional/mesh/conn_test.go
@@ -26,33 +26,33 @@ func TestQuicConnectTimeout(t *testing.T) {
 	// Start a TCP listener on the first node
 	b1, err := backends.NewTCPListener("localhost:3333", nil)
 	if err != nil {
-		t.Fatal(fmt.Sprintf("Error listening on TCP: %s\n", err))
+		t.Fatalf(fmt.Sprintf("Error listening on TCP: %s\n", err))
 	}
 	err = n1.AddBackend(b1)
 	if err != nil {
-		t.Fatal(fmt.Sprintf("Error starting backend: %s\n", err))
+		t.Fatalf(fmt.Sprintf("Error starting backend: %s\n", err))
 	}
 
 	// Start a TCP dialer on the second node - this will connect to the listener we just started
 	b2, err := backends.NewTCPDialer("localhost:3333", false, nil)
 	if err != nil {
-		t.Fatal(fmt.Sprintf("Error dialing on TCP: %s\n", err))
+		t.Fatalf(fmt.Sprintf("Error dialing on TCP: %s\n", err))
 	}
 	err = n2.AddBackend(b2)
 	if err != nil {
-		t.Fatal(fmt.Sprintf("Error starting backend: %s\n", err))
+		t.Fatalf(fmt.Sprintf("Error starting backend: %s\n", err))
 	}
 
 	// Start an echo server on node 1
 	l1, err := n1.Listen("echo", nil)
 	if err != nil {
-		t.Fatal(fmt.Sprintf("Error listening on Receptor network: %s\n", err))
+		t.Fatalf(fmt.Sprintf("Error listening on Receptor network: %s\n", err))
 	}
 	go func() {
 		// Accept an incoming connection - note that conn is just a regular net.Conn
 		conn, err := l1.Accept()
 		if err != nil {
-			t.Fatal(fmt.Sprintf("Error accepting connection: %s\n", err))
+			t.Fatalf(fmt.Sprintf("Error accepting connection: %s\n", err))
 
 			return
 		}
@@ -69,7 +69,7 @@ func TestQuicConnectTimeout(t *testing.T) {
 					if strings.Contains(err.Error(), "no recent network activity") {
 						t.Log("Successfully got the desired timeout error")
 					} else {
-						t.Fatal(fmt.Sprintf("Read error in Receptor listener: %s\n", err))
+						t.Fatalf(fmt.Sprintf("Read error in Receptor listener: %s\n", err))
 					}
 
 					return
@@ -77,7 +77,7 @@ func TestQuicConnectTimeout(t *testing.T) {
 				if n > 0 {
 					_, err := conn.Write(buf[:n])
 					if err != nil {
-						t.Fatal(fmt.Sprintf("Write error in Receptor listener: %s\n", err))
+						t.Fatalf(fmt.Sprintf("Write error in Receptor listener: %s\n", err))
 
 						return
 					}

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -3,7 +3,6 @@ package mesh
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -189,7 +188,7 @@ func TestTraceroute(t *testing.T) {
 				}
 				_, ok = valMap["Error"]
 				if ok {
-					t.Fatalf(fmt.Sprintf("traceroute returned error: %s", valMap["Error"]))
+					t.Fatalf("traceroute returned error: %s", valMap["Error"])
 				}
 			}
 			expectedHops := []struct {
@@ -219,10 +218,10 @@ func TestTraceroute(t *testing.T) {
 					}
 				}
 				if !ok {
-					t.Fatalf(fmt.Sprintf("hop %s not in result data or not in expected format", eh.key))
+					t.Fatalf("hop %s not in result data or not in expected format", eh.key)
 				}
 				if fromStr != eh.from {
-					t.Fatalf(fmt.Sprintf("hop %s should be %s but is actually %s", eh.key, eh.from, fromStr))
+					t.Fatalf("hop %s should be %s but is actually %s", eh.key, eh.from, fromStr)
 				}
 			}
 

--- a/tests/functional/mesh/mesh_test.go
+++ b/tests/functional/mesh/mesh_test.go
@@ -189,7 +189,7 @@ func TestTraceroute(t *testing.T) {
 				}
 				_, ok = valMap["Error"]
 				if ok {
-					t.Fatal(fmt.Sprintf("traceroute returned error: %s", valMap["Error"]))
+					t.Fatalf(fmt.Sprintf("traceroute returned error: %s", valMap["Error"]))
 				}
 			}
 			expectedHops := []struct {
@@ -219,10 +219,10 @@ func TestTraceroute(t *testing.T) {
 					}
 				}
 				if !ok {
-					t.Fatal(fmt.Sprintf("hop %s not in result data or not in expected format", eh.key))
+					t.Fatalf(fmt.Sprintf("hop %s not in result data or not in expected format", eh.key))
 				}
 				if fromStr != eh.from {
-					t.Fatal(fmt.Sprintf("hop %s should be %s but is actually %s", eh.key, eh.from, fromStr))
+					t.Fatalf(fmt.Sprintf("hop %s should be %s but is actually %s", eh.key, eh.from, fromStr))
 				}
 			}
 


### PR DESCRIPTION
thought about pinning golangci-lint version to something like `1.45.0` but this new update exposes changes that should be made.