### PR TITLE
Fix goroutine leak in utils.BridgeConns

### DIFF
--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -16,6 +16,7 @@ func BridgeConns(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2
 	go bridgeHalf(c1, c1Name, c2, c2Name, doneChan)
 	go bridgeHalf(c2, c2Name, c1, c1Name, doneChan)
 	<-doneChan
+	<-doneChan
 }
 
 // BridgeHalf bridges the read side of c1 to the write side of c2.


### PR DESCRIPTION
one of the two `done <- true` (in bridgeHalf) blocks forever as "receive" from unbuffered done channel is executed only once