### PR TITLE
 Adding support for ppc64le platform using Multi-arch GitHub Actions flow

### DIFF
--- a/.github/workflows/devel_image.yml
+++ b/.github/workflows/devel_image.yml
@@ -14,23 +14,39 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      
+      # setup qemu and buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
       - name: Install build dependencies
         run: |
           pip install build
 
+       # we will first build the image for x86 and load it on the host for testing
       - name: Build Image
         run: |
-          make container REPO=receptor TAG=devel
+          export CONTAINERCMD="docker buildx"
+          export EXTRA_OPTS="--platform linux/amd64 --load"
+          make container REPO=quay.io/ansible/receptor TAG=devel
 
       - name: Test Image
-        run: podman run --rm receptor:devel receptor --version
+        run: docker run --rm quay.io/ansible/receptor:devel receptor --version
 
-      - name: Push To Quay
-        uses: redhat-actions/push-to-registry@v2.1.1
+      - name: Login To Quay
+        uses: docker/login-action@v2
         with:
-          image: receptor
-          tags: devel
-          registry: quay.io/ansible/
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}
+          registry: quay.io/ansible/receptor
+
+      # Since x86 image is built in previous step
+      # buildx will use cached image, hence overall time will not be affected
+      - name: Build Multiarch Image & Push To Quay
+        run: |
+          export  CONTAINERCMD="docker buildx"
+          export EXTRA_OPTS="--platform linux/amd64,linux/ppc64le --push"
+          make container REPO=quay.io/ansible/receptor TAG=devel    

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -43,11 +43,12 @@ jobs:
         run: |
           echo ${{ secrets.QUAY_TOKEN }} | docker login quay.io -u ${{ secrets.QUAY_USER }} --password-stdin
 
-      - name: Re-tag and promote awx image
-        run: |
-          docker pull ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-          docker tag ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-          docker tag ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }} quay.io/${{ github.repository }}:latest
-          docker push quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
-          docker push quay.io/${{ github.repository }}:latest
+      - name: Copy Image to Quay
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+          dst: |
+            quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+            quay.io/${{ github.repository }}:latest
+
 

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install build
+      
+      # setup qemu and buildx
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2  
 
       - name: Log in to registry
         run: |
@@ -56,7 +63,7 @@ jobs:
 
       - name: Build container image
         run: |
-          make container CONTAINERCMD=docker REPO=ghcr.io/${{ github.repository_owner }}/receptor VERSION=v${{ github.event.inputs.version }} LATEST=yes
+          make container CONTAINERCMD="docker buildx" EXTRA_OPTS="--platform linux/amd64,linux/ppc64le --push" REPO=ghcr.io/${{ github.repository_owner }}/receptor VERSION=v${{ github.event.inputs.version }} LATEST=yes
 
       - name: Stage container image
         run: |

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ $(RECEPTOR_PYTHON_WORKER_WHEEL): receptor-python-worker/README.md receptor-pytho
 	@cd receptor-python-worker && python3 -m build --wheel
 
 # Container command can be docker or podman
-CONTAINERCMD := podman
+CONTAINERCMD ?= podman
 
 # Repo without tag
 REPO := quay.io/ansible/receptor
@@ -133,12 +133,14 @@ TAG := $(subst +,-,$(VERSION))
 # Set this to tag image as :latest in addition to :$(VERSION)
 LATEST :=
 
+EXTRA_OPTS ?=
+
 container: .container-flag-$(VERSION)
 .container-flag-$(VERSION): $(RECEPTORCTL_WHEEL) $(RECEPTOR_PYTHON_WORKER_WHEEL)
 	@tar --exclude-vcs-ignores -czf packaging/container/source.tar.gz .
 	@cp $(RECEPTORCTL_WHEEL) packaging/container
 	@cp $(RECEPTOR_PYTHON_WORKER_WHEEL) packaging/container
-	$(CONTAINERCMD) build packaging/container --build-arg VERSION=$(VERSION:v%=%) -t $(REPO):$(TAG) $(if $(LATEST),-t $(REPO):latest,)
+	$(CONTAINERCMD) build $(EXTRA_OPTS) packaging/container --build-arg VERSION=$(VERSION:v%=%) -t $(REPO):$(TAG) $(if $(LATEST),-t $(REPO):latest,)
 	@touch .container-flag-$(VERSION)
 
 tc-image: container


### PR DESCRIPTION
This PR is in reference to #613 to provide `quay.io/ansible/receptor:devel` image for **Power** (ppc64le) platform.
I have modified the GitHub Action workflows  to use `docker buildx` tool to cross compile docker images for ppc64le and produce **multiarch image**. I have tested the workflows in my fork repository and mentioned below are the links for the same.

1. `devel_image.yml` workflow:
 - Link for GitHub Actions: https://github.com/Sunidhi-Gaonkar1/receptor/actions/runs/2590090642
 - Link for the image : https://quay.io/repository/siddhesh_ghadi/ansible_receptor?tab=tags&tag=devel

2. `stage.yml` workflow:
- Link for GitHub Actions: https://github.com/Sunidhi-Gaonkar1/receptor/actions/runs/2594580131
- Link for the image: https://github.com/Sunidhi-Gaonkar1/receptor/pkgs/container/receptor

3. `promote.yml` workflow:
- Link for GitHub Actions: https://github.com/Sunidhi-Gaonkar1/receptor/actions/runs/2594823333
- Link for the image: https://quay.io/repository/siddhesh_ghadi/ansible_receptor?tab=tags&tag=latest

This PR modifies 3 workflows (devel_image.yml , stage.yml and promote.yml) and can be extended for PR workflow as well.(if required)