### PR TITLE
CloseConnection considered harmful

### DIFF
--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -86,7 +86,6 @@ func TestWebsocketExternalInterop(t *testing.T) {
 			MinVersion:               tls.VersionTLS12,
 			PreferServerCipherSuites: true,
 		},
-		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {
 		err := server.ServeTLS(li, "", "")

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -86,6 +86,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 			MinVersion:               tls.VersionTLS12,
 			PreferServerCipherSuites: true,
 		},
+		ReadHeaderTimeout: 10 * time.Second,
 	}
 	go func() {
 		err := server.ServeTLS(li, "", "")

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -406,6 +406,7 @@ func (c *Conn) Read(b []byte) (int, error) {
 	if ok && aerr.ErrorMessage == "normal close" {
 		err = io.EOF
 	}
+
 	return n, err
 }
 
@@ -421,6 +422,7 @@ func (c *Conn) Write(b []byte) (int, error) {
 	if ok && aerr.ErrorMessage == "normal close" {
 		err = net.ErrClosed
 	}
+
 	return n, err
 }
 

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -411,8 +411,8 @@ func (c *Conn) Write(b []byte) (n int, err error) {
 	return c.qs.Write(b)
 }
 
-// Close closes the writer side of the connection.
-func (c *Conn) Close() error {
+// CloseWrite closes the writer side of the connection.
+func (c *Conn) CloseWrite() error {
 	c.doneOnce.Do(func() {
 		close(c.doneChan)
 	})
@@ -420,7 +420,7 @@ func (c *Conn) Close() error {
 	return c.qs.Close()
 }
 
-func (c *Conn) CloseConnection() error {
+func (c *Conn) Close() error {
 	c.pc.cancel()
 	c.doneOnce.Do(func() {
 		close(c.doneChan)

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -31,7 +31,7 @@ func bridgeHalf(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2N
 		n, err := c1.Read(buf)
 		if err != nil {
 			if err.Error() != "EOF" && !strings.Contains(err.Error(), "use of closed network connection") &&
-				!strings.Contains(err.Error(), "normal close") {
+				!strings.Contains(err.Error(), "normal close") && !strings.Contains(err.Error(), "context closed") {
 				logger.Error("Connection read error: %s\n", err)
 			}
 			shouldClose = true

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -30,7 +30,8 @@ func bridgeHalf(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2N
 	for {
 		n, err := c1.Read(buf)
 		if err != nil {
-			if err.Error() != "EOF" && !strings.Contains(err.Error(), "use of closed network connection") {
+			if err.Error() != "EOF" && !strings.Contains(err.Error(), "use of closed network connection") &&
+				!strings.Contains(err.Error(), "normal close") {
 				logger.Error("Connection read error: %s\n", err)
 			}
 			shouldClose = true


### PR DESCRIPTION
What's wrong with this code?  (Other than the lack of error checking.)

```
n := netceptor.New(...)
conn, _ := n.Dial("node2", "mysvc", nil)
fmt.Fprintf(conn, "Hello, world!\n")
conn.Close()
```

Answer: It doesn't close the connection.  A PacketConn and QUIC connection, with the associated dozen-or-so goroutines, are still running, and will remain running for the life of your program.

Somehow (and I'm well aware that this is code that I probably wrote), in Receptor-land it turns out that `Close()` has the meaning we would normally associate with `CloseWrite()` - it shuts down the write side of the connection and indicates an EOF to the other side, but leaves the connection open and ready to continue receiving data from the other side.  If you want to _actually close_ the Receptor connection, you have to call `CloseConnection()`, which has the effect we would normally associate with `Close()`.

If you don't know about this and just call `Close()`, expecting Receptor to behave like any other networking library, you'll wind up leaking goroutines and memory like crazy.  And given that `CloseConnection()` only appears in the Receptor code in a few places in Workceptor, I'm imagining that long-running Receptor instances probably _do_ leak goroutines and memory like crazy.

This PR renames the functions to the sensible names, and updates Workceptor to call the right functions.  If other parts of the code are relying on `Close()` not really closing the connection, then this will break them, but arguably they were already broken since they were leaking connections.  Also, this is a breaking change for API users, so should be in a new minor release.