### PR TITLE
Pass startpos for work results

### DIFF
--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -245,9 +245,11 @@ class ReceptorControl:
         result = json.loads(text)
         return result
 
-    def get_work_results(self, unit_id, return_socket=False, return_sockfile=True):
+    def get_work_results(
+        self, unit_id, startpos=0, return_socket=False, return_sockfile=True
+    ):
         self.connect()
-        self.writestr(f"work results {unit_id}\n")
+        self.writestr(f"work results {unit_id} {startpos}\n")
         text = self.readstr()
         m = re.compile("Streaming results for work unit (.+)").fullmatch(text)
         if not m:


### PR DESCRIPTION
Allows receptorctl to get partial results of a work unit by supplying the startpos

e.g. `receptor_ctl.get_work_results(.unit_id, startpos=100)` to start getting stdout at byte position 100