### PR TITLE
Handle .dev releases

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    env:
+      TAG: ${{github.event.release.tag_name}}
     steps:
       - name: Checkout Receptor
         uses: actions/checkout@v2
@@ -28,7 +30,7 @@ jobs:
 
       - name: Build receptorctl and upload to pypi
         run: |
-          make receptorctl_wheel receptorctl_sdist VERSION=${{ github.event.release.tag_name }}
+          make receptorctl_wheel receptorctl_sdist VERSION=$TAG
           twine upload \
             -r ${{ env.pypi_repo }} \
             -u ${{ secrets.PYPI_USERNAME }} \
@@ -46,9 +48,22 @@ jobs:
       - name: Copy Image to Quay
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+          src: ghcr.io/${{ github.repository }}:$TAG
           dst: |
-            quay.io/${{ github.repository }}:${{ github.event.release.tag_name }}
+            quay.io/${{ github.repository }}:$TAG
             quay.io/${{ github.repository }}:latest
 
+      - name: Check if floating tag is needed
+        run: |
+          if [[ $TAG == *"dev"* ]];
+          then
+           echo "FLOATING_TAG=$(echo $TAG | sed 's/[0-9]\+$//')" >> $GITHUB_ENV
+          else
+           echo "FLOATING_TAG=$TAG" >> $GITHUB_ENV
+          fi
 
+      - name: Push floating tag to Quay
+        uses: akhilerm/tag-push-action@v2.0.0
+        with:
+          src: ghcr.io/${{ github.repository }}:${{env.TAG}}
+          dst: quay.io/${{ github.repository }}:${{env.FLOATING_TAG}}


### PR DESCRIPTION
We want to create a floating tag on quay

if .dev is in the release tag, e.g. v1.3.0.dev3, we want to chop off the 3 and push to 
`quay.io/ansible/awx:v1.3.0.dev`

That way awx-ee can copy receptor binary from this floating tag image to get the latest v1.3.0.dev* releases.