### PR TITLE
Add retry mechanism to handle intermittent connection issues with Kubernetes logging stream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 
 test: receptor
 	PATH=${PWD}:${PATH} \
-	go test ./... -p 1 -parallel=16 $(TESTCMD) -count=1 -race
+	go test ./... -p 1 -parallel=16 $(TESTCMD) -count=1 -race -v
 
 receptorctl-test: receptorctl/.VERSION
 	@cd receptorctl && tox -e py3

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -24,7 +24,7 @@ func saveStdoutSize(unitdir string, stdoutSize int64) error {
 // stdoutWriter writes to a stdout file while also updating the status file.
 type stdoutWriter struct {
 	unitdir      string
-	writer       io.Writer
+	writer       io.WriteCloser
 	bytesWritten int64
 }
 
@@ -64,7 +64,7 @@ func (sw *stdoutWriter) Size() int64 {
 
 // stdinReader reads from a stdin file and provides a Done function.
 type stdinReader struct {
-	reader   io.Reader
+	reader   io.ReadCloser
 	lasterr  error
 	doneChan chan struct{}
 	doneOnce sync.Once

--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -90,6 +90,30 @@ func (bwu *BaseWorkUnit) Init(w *Workceptor, unitID string, workType string) {
 	bwu.ctx, bwu.cancel = context.WithCancel(w.ctx)
 }
 
+// Error logs message with unitID prepended.
+func (bwu *BaseWorkUnit) Error(format string, v ...interface{}) {
+	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	logger.Error(format, v...)
+}
+
+// Warning logs message with unitID prepended.
+func (bwu *BaseWorkUnit) Warning(format string, v ...interface{}) {
+	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	logger.Warning(format, v...)
+}
+
+// Info logs message with unitID prepended.
+func (bwu *BaseWorkUnit) Info(format string, v ...interface{}) {
+	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	logger.Info(format, v...)
+}
+
+// Debug logs message with unitID prepended.
+func (bwu *BaseWorkUnit) Debug(format string, v ...interface{}) {
+	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	logger.Debug(format, v...)
+}
+
 // SetFromParams sets the in-memory state from parameters.
 func (bwu *BaseWorkUnit) SetFromParams(params map[string]string) error {
 	return nil


### PR DESCRIPTION
Due to a issue in Kubernetes, AWX can't currently run jobs longer than 4 hours when deployed on Kubernetes. More context on that in https://github.com/ansible/awx/issues/11805.

This PR adds logic that will pick back up from the last line we saw, using Kubernetes log timestamp 

require fix in Kubernetes for [Pod logs: long lines are corrupted when using timestamps=true](https://github.com/kubernetes/kubernetes/issues/77603)
fixed in https://github.com/kubernetes/kubernetes/pull/113481

Fixe backported into Kubernetes release branches in the following PRs:
[release-1.23](https://github.com/kubernetes/kubernetes/pull/113517) (1.23.14)
[release-1.24](https://github.com/kubernetes/kubernetes/pull/113516) (1.24.8)
[release-1.25](https://github.com/kubernetes/kubernetes/pull/113515) (1.25.4)

Fixes ported to OpenShift in the following PRs
[release-4.9](https://github.com/openshift/kubernetes/pull/1417) (4.9.x) (not yet merged)
[release-4.10](https://github.com/openshift/kubernetes/pull/1415) (4.10.42)
[release-4.11](https://github.com/openshift/kubernetes/pull/1408) (4.11.16)
[release-4.12](https://github.com/openshift/kubernetes/pull/1407) (4.12.0)

the fix in this PR should detect the Kubernetes version and use `--timestamp` according however due to the "wild wild west" nature of Kubernetes world we added `RECEPTOR_KUBE_SUPPORT_RECONNECT` environment variable to force enable/disable the fix.

`RECEPTOR_KUBE_SUPPORT_RECONNECT`  have following options:
- “enabled”: this option will use timestamp with the log and enable our new code path
- “disabled”: this option will not use timestamp and use the original code path
- “auto”: auto detect if it's appropriate to enable timestamp base on kube version

this flag can be set via awx custom resource 
```
apiVersion: awx.ansible.com/v1beta1
kind: AWX
metadata:
  name: awx
  namespace: awx
spec:
  …
  ee_extra_env: |
    - name: RECEPTOR_KUBE_SUPPORT_RECONNECT
      value: enabled
```

NOTE: `RECEPTOR_KUBE_SUPPORT_RECONNECT` will bypass check for ALL container group when set to "enabled/disabled". If a specific container group is not contain have the right Kubernetes version and `RECEPTOR_KUBE_SUPPORT_RECONNECT` is set to enabled job execution with that container group will fail due to corrupted log stream 

NOTE: it is also possible for kublet version to be different from kube-apiserver detecting the presence of the fix using kube-apiserver version is not the safest option, but its the only option we have here.
