### PR TITLE
Remove deprecated golangci linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - asciicheck
     - bodyclose
     #- cyclop # TODO: Reduce code complexity.
-    - deadcode
     - depguard
     - dogsled
     #- dupl # TODO: Remove duplicates.
@@ -36,7 +35,6 @@ linters:
     - gosec
     - gosimple
     - govet
-    - ifshort
     - importas
     - ineffassign
     - makezero
@@ -54,7 +52,6 @@ linters:
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
-    - structcheck
     - stylecheck
     #- testpackage # TODO: Put tests in their dedicated test packages.
     #- thelper # TODO: Requires test refactoring.
@@ -63,7 +60,6 @@ linters:
     - unconvert
     #- unparam # TODO: This breaks something, look at it!
     - unused
-    - varcheck
     - wastedassign
     - whitespace
     # - wrapcheck # TODO: Errors passed upwards should be wrapped.


### PR DESCRIPTION
these warnings are popping up
```
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'ifshort' is deprecated (since v1.48.0) due to: The repository of the linter has been deprecated by the owner.  
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
```

so removing them.