### PR TITLE
Fix promote workflow

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -48,9 +48,9 @@ jobs:
       - name: Copy Image to Quay
         uses: akhilerm/tag-push-action@v2.0.0
         with:
-          src: ghcr.io/${{ github.repository }}:$TAG
+          src: ghcr.io/${{ github.repository }}:${{env.TAG}}
           dst: |
-            quay.io/${{ github.repository }}:$TAG
+            quay.io/${{ github.repository }}:${{env.TAG}}
             quay.io/${{ github.repository }}:latest
 
       - name: Check if floating tag is needed


### PR DESCRIPTION
Tested this on my fork and ran into a problem: https://github.com/shanemcd/receptor/actions/runs/3606108434/jobs/6077133319

```
crane [copy ghcr.io/shanemcd/receptor:$TAG quay.io/shanemcd/receptor:$TAG]
[29](https://github.com/shanemcd/receptor/actions/runs/3606108434/jobs/6077133319#step:10:30)
Error: parsing reference "ghcr.io/shanemcd/receptor:$TAG": could not parse reference: ghcr.io/shanemcd/receptor:$TAG
[30](https://github.com/shanemcd/receptor/actions/runs/3606108434/jobs/6077133319#step:10:31)
panic: exit status 1
```