### PR TITLE
ignore pre-release in version comparison

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -697,6 +697,9 @@ func shouldUseReconnect(kw *kubeUnit) bool {
 		return false
 	}
 
+	// ignore pre-release in version comparison
+	semver = semver.WithPreRelease("")
+
 	// The patch was backported to minor version 23, 24 and 25. We must check z stream
 	// based on the minor version
 	// if minor version == 24, compare with v1.24.8


### PR DESCRIPTION
related to https://github.com/ansible/receptor/issues/708

GCP does not use proper semvar, example:
```
1.24.8-gke.401
```

AKS does the same thing 
```
v1.21.14-eks-fb459a0
```

instead of using + for build metadata they use - which indicate pre-release

this PR will ignore `-<prerelease tag>` when doing version comparison

currently we have no clue if this mess with other "variants" of Kubernetes 