### PR TITLE
fix: avoid error for missing image if pod is provided

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -1418,7 +1418,7 @@ func (cfg KubeWorkerCfg) Prepare() error {
 	if cfg.Pod != "" && (cfg.Image != "" || cfg.Command != "" || cfg.Params != "") {
 		return fmt.Errorf("can only provide Pod when Image, Command, and Params are empty")
 	}
-	if cfg.Image == "" && !cfg.AllowRuntimeCommand && !cfg.AllowRuntimePod {
+	if cfg.Pod == "" && cfg.Image == "" && !cfg.AllowRuntimeCommand && !cfg.AllowRuntimePod {
 		return fmt.Errorf("must specify a container image to run")
 	}
 	method := strings.ToLower(cfg.StreamMethod)


### PR DESCRIPTION
Closes #712

Tested this PR in various patterns:

```bash
# Fixed: Case that previously resulted in an error as #712
$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true pod=/tmp/pod.yml
INFO 2022/12/24 09:03:25 Initialization complete
```

```bash
# Invalid configuration; resulted expected error
$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true
Error: must specify a container image to run

$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true pod=/tmp/pod.yml image=busybox
Error: can only provide Pod when Image, Command, and Params are empty

$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true pod=/tmp/pod.yml command=sleep
Error: can only provide Pod when Image, Command, and Params are empty

$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true pod=/tmp/pod.yml params=10
Error: can only provide Pod when Image, Command, and Params are empty
```

```bash
# Valid configuration
$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true allowruntimecommand=true
INFO 2022/12/24 09:04:00 Initialization complete

$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true allowruntimepod=true
INFO 2022/12/24 09:04:02 Initialization complete

$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true image=busybox
INFO 2022/12/24 09:04:06 Initialization complete

$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true image=busybox allowruntimecommand=true
INFO 2022/12/24 09:04:08 Initialization complete

$ ./receptor --local-only --work-kubernetes worktype=demo allowruntimeauth=true image=busybox allowruntimepod=true
INFO 2022/12/24 09:04:10 Initialization complete
```