### PR TITLE
feat: build and publish binaries on release by using make and action-gh-release

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   promote:
     runs-on: ubuntu-latest
@@ -67,3 +70,30 @@ jobs:
         with:
           src: ghcr.io/${{ github.repository }}:${{env.TAG}}
           dst: quay.io/${{ github.repository }}:${{env.FLOATING_TAG}}
+
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{github.event.release.tag_name}}
+    steps:
+      - name: Checkout Receptor
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+
+      - name: Build packages
+        run: |
+          make build-package GOOS=linux GOARCH=amd64 BINNAME=receptor
+          make build-package GOOS=linux GOARCH=arm64 BINNAME=receptor
+          make build-package GOOS=darwin GOARCH=amd64 BINNAME=receptor
+          make build-package GOOS=darwin GOARCH=arm64 BINNAME=receptor
+          make build-package GOOS=windows GOARCH=amd64 BINNAME=receptor.exe
+          make build-package GOOS=windows GOARCH=arm64 BINNAME=receptor.exe
+
+      - name: Publish packages
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |-
+            dist/checksums.txt
+            dist/*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ kubectl
 /receptorctl/venv/
 .vagrant/
 /docs/build
+/dist

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,14 @@ build-all:
 	go build -o receptor --tags no_controlsvc,no_backends,no_services,no_tls_config,no_workceptor,no_cert_auth ./cmd/receptor-cl && \
 	go build -o receptor ./cmd/receptor-cl
 
+DIST := receptor_$(shell echo '$(VERSION)' | sed 's/^v//')_$(GOOS)_$(GOARCH)
+build-package:
+	@echo "Building and packaging binary for $(GOOS)/$(GOARCH) as dist/$(DIST).tar.gz" && \
+	mkdir -p dist/$(DIST) && \
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -o dist/$(DIST)/$(BINNAME) $(DEBUGFLAGS) -ldflags "-X 'github.com/ansible/receptor/internal/version.Version=$(VERSION)'" $(TAGPARAM) ./cmd/receptor-cl && \
+	tar -C dist/$(DIST) -zcf dist/$(DIST).tar.gz $(BINNAME) && \
+	cd dist/ && sha256sum $(DIST).tar.gz >> checksums.txt
+
 RUNTEST ?=
 ifeq ($(RUNTEST),)
 TESTCMD =
@@ -156,6 +164,7 @@ clean:
 	@rm -fv receptor-python-worker/dist/*
 	@rm -fv packaging/container/receptor
 	@rm -fv packaging/container/*.whl
+	@rm -rfv dist/
 	@rm -fv .container-flag*
 	@rm -fv .VERSION
 	@rm -rfv receptorctl-test-venv/

--- a/docs/source/release_process.rst
+++ b/docs/source/release_process.rst
@@ -10,5 +10,9 @@ After the draft release has been created, edit it and populate the description. 
 
 After the release is published, the `Promote Release <https://github.com/ansible/receptor/actions/workflows/promote.yml>`_ workflow will run automatically. This workflow will:
 
-- Publish receptorctl to PyPi.
-- Pull the container image from ghcr.io, re-tag, and push to quay.io.
+- Publish receptorctl to `PyPI <https://pypi.org/project/receptorctl/>`_.
+- Pull the container image from ghcr.io, re-tag, and push to `Quay.io <https://quay.io/repository/ansible/receptor>`_.
+- Build binaries for various OSes/platforms, and attach them to the `release <https://github.com/ansible/receptor/releases>`_.
+
+.. note::
+  To customize packaging and allow for tags that do not strictly satisfy the semantic versioning given to development releases, the current workflow uses simple ``make`` to build and archive binaries, instead of specific tools for build and release.


### PR DESCRIPTION
Closes #719 

@TheRealHaoLiu 
I saw that you were already assigned to the issue, so feel free to ignore this PR, but I've created this as a working demo 😃 

### Design

In this PR, I use `make` and `action-gh-release` to build and publish binaries.

- **`make` and `action-gh-release`**
  - **Pros:**
    - Fully customizable
    - Any tags are allowed even if the tag does not satisfy semver
  - **Cons:**
    - Building rpms and debs can be a bit more complicated

- **GoReleaser**
  - **Pros:**
    - Supports building rpms and debs in addition to building binaries
  - **Cons:**
    - Less customizable especially for rpms and debs
    - The tags for the release MUST satisfy semver (current `v1.3.0.dev1` is not allowed)

The pros for GoReleaser is that it also supports building RPMs in addition to just binaries, but compiling SELinux policies and generating Bash Completion are required before GoReleaer, so it ends up being a bit more complicated.

Also, since non-semver tags are not allowed, the workflow will fail if we pass the tags like `v1.3.0.dev1` when releasing manually. 

So, first, I've created a PR to publish binaries using `make` in a straightforward and simple manner.

For demo purpose, GoReleaser version is here: https://github.com/ansible/receptor/pull/725

### Test

Demo release is available on my forked repository: <https://github.com/kurokobo/receptor/releases/tag/v1.3.1-demo1a>

1. Create release by hand
   ![image](https://user-images.githubusercontent.com/2920259/216241064-830587ac-9124-445c-a2f9-9429be247712.png)
2. Wait for the the job `publish` in `promote.yml` to be completed.
   - <https://github.com/kurokobo/receptor/actions/runs/4071606857/jobs/7013552996>
3. Ensure the release has been updated and binaries are published.
   ![image](https://user-images.githubusercontent.com/2920259/216241992-1d8e7788-fab3-442a-8452-ec99d775e0ae.png)
4. Download binaries and ensure works well.
   ```bash
   $ curl -LO https://github.com/kurokobo/receptor/releases/download/v1.3.1-demo1a/receptor_1.3.1-demo1a_linux_amd64.tar.gz
     % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                    Dload  Upload   Total   Spent    Left  Speed
     0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
   100 20.8M  100 20.8M    0     0   9.8M      0  0:00:02  0:00:02 --:--:-- 18.4M
   
   $ tar zxvf receptor_1.3.1-demo1a_linux_amd64.tar.gz 
   receptor
   
   $ ./receptor --version
   v1.3.1-demo1a
   ```
   ```powershell
   PS C:\Temp> Invoke-WebRequest https://github.com/kurokobo/receptor/releases/download/v1.3.1-demo1a/receptor_1.3.1-demo1a_windows_amd64.tar.gz -OutFile receptor_1.3.1-demo1a_windows_amd64.tar.gz
   
   PS C:\Temp> tar zxvf .\receptor_1.3.1-demo1a_windows_amd64.tar.gz
   x receptor.exe
   
   PS C:\Temp> .\receptor.exe --version
   v1.3.1-demo1a
   ```
