### PR TITLE
feat: build and publish binaries on release by using goreleaser

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write
+
 jobs:
   promote:
     runs-on: ubuntu-latest
@@ -67,3 +70,21 @@ jobs:
         with:
           src: ghcr.io/${{ github.repository }}:${{env.TAG}}
           dst: quay.io/${{ github.repository }}:${{env.FLOATING_TAG}}
+
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{github.event.release.tag_name}}
+    steps:
+      - name: Checkout Receptor
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          args: release --rm-dist -f packaging/goreleaser/goreleaser.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -82,6 +82,19 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
 
+      - name: Compile SELinux policy
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y selinux-policy-dev
+          cd packaging/rpm/usr/share/selinux/packages/
+          make -f /usr/share/selinux/devel/Makefile receptor.pp
+
+      - name: Generate bash-completion
+        run: |
+          make receptor
+          mkdir -p packaging/rpm/usr/share/bash-completion/completions/
+          ./receptor --bash-completion > packaging/rpm/usr/share/bash-completion/completions/receptor
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:

--- a/packaging/goreleaser/goreleaser.yml
+++ b/packaging/goreleaser/goreleaser.yml
@@ -20,6 +20,65 @@ archives:
   - files:
       - none*
 
+nfpms:
+  - vendor: Ansible
+    homepage: https://github.com/ansible/receptor
+    description: >-
+      Project Receptor is a flexible multi-service relayer with remote execution and
+      orchestration capabilities linking controllers with executors across a mesh of
+      nodes.
+    license: ASL 2.0
+    formats:
+      - rpm
+    contents:
+      - dst: /var/lib/receptor
+        type: dir
+        file_info:
+          mode: 0700
+      - dst: /var/log/receptor
+        type: dir
+        file_info:
+          mode: 0755
+      - dst: /var/run/receptor
+        type: dir
+        file_info:
+          mode: 2775
+      - dst: /etc/receptor
+        type: dir
+        file_info:
+          mode: 0755
+      - src: packaging/rpm/etc/receptor/receptor.conf
+        dst: /etc/receptor/receptor.conf
+        type: config|noreplace
+      - src: packaging/rpm/etc/receptor/receptor.conf.example
+        dst: /etc/receptor/receptor.conf.example
+      - src: packaging/rpm/etc/logrotate.d/receptor
+        dst: /etc/logrotate.d/receptor
+      - src: packaging/rpm/usr/lib/systemd/system/receptor.service
+        dst: /usr/lib/systemd/system/receptor.service
+      - src: packaging/rpm/usr/lib/systemd/system/receptor@.service
+        dst: /usr/lib/systemd/system/receptor@.service
+      - src: packaging/rpm/usr/share/sosreport/sos/plugins/receptor.py
+        dst: /usr/share/sosreport/sos/plugins/receptor.py
+      - src: packaging/rpm/usr/share/selinux/packages/receptor.pp
+        dst: /usr/share/selinux/packages/receptor.pp
+        file_info:
+          mode: 0600
+      - src: packaging/rpm/usr/share/bash-completion/completions/receptor
+        dst: /usr/share/bash-completion/completions/receptor
+    scripts:
+      preinstall: packaging/rpm/preinstall.sh
+      postinstall: packaging/rpm/postinstall.sh
+      postremove: packaging/rpm/postremove.sh
+    dependencies:
+      - logrotate
+      - sos
+      - systemd
+      - libselinux-utils
+      - policycoreutils
+    rpm:
+      group: Unspecified
+
 release:
   mode: keep-existing
 

--- a/packaging/goreleaser/goreleaser.yml
+++ b/packaging/goreleaser/goreleaser.yml
@@ -1,0 +1,27 @@
+---
+project_name: receptor
+
+builds:
+  - main: ./cmd/receptor-cl
+    binary: receptor
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -X "github.com/ansible/receptor/internal/version.Version={{.Env.VERSION}}"
+
+archives:
+  - files:
+      - none*
+
+release:
+  mode: keep-existing
+
+changelog:
+  skip: true

--- a/packaging/rpm/.gitignore
+++ b/packaging/rpm/.gitignore
@@ -1,0 +1,4 @@
+!receptor
+usr/share/selinux/packages/*
+!usr/share/selinux/packages/receptor.te
+usr/share/bash-completion/completions

--- a/packaging/rpm/etc/logrotate.d/receptor
+++ b/packaging/rpm/etc/logrotate.d/receptor
@@ -1,0 +1,7 @@
+/var/log/receptor/*.log {
+    rotate 7
+    daily
+    compress
+    copytruncate
+    missingok
+}

--- a/packaging/rpm/etc/receptor/receptor.conf
+++ b/packaging/rpm/etc/receptor/receptor.conf
@@ -1,0 +1,11 @@
+---
+- node: 
+    id: receptor
+
+- log-level: info
+
+- control-service:
+    service: control
+    filename: /var/run/receptor/receptor.sock
+
+- local-only:

--- a/packaging/rpm/etc/receptor/receptor.conf.example
+++ b/packaging/rpm/etc/receptor/receptor.conf.example
@@ -1,0 +1,35 @@
+#
+# receptor.conf
+#
+# This is a YAML-formatted file in which each block represents a Receptor
+# configuration directive.  For a list of possible directives, see
+# "receptor --help".  Below is a basic example of a single node.
+
+
+# To create and launch a new systemd-managed Receptor node:
+#
+# 1. Copy this file to /etc/receptor/receptor.conf
+# 2. chmod 0600 if the new file will contain any passwords or sensitive data
+# 3. Edit the new config file as needed
+# 4. systemctl enable receptor --now
+
+
+# Basic properties of the node.  The node ID must be unique.
+- node:
+    id: receptor
+
+# The control service allows receptorctl to talk to the running service,
+# and is also used for functions like remote work submission.
+- control-service:
+    service: control
+    filename: /var/run/receptor.sock
+
+# A listener allows other Receptor nodes to connect to this one.
+- tcp-listener:
+    port: 2345
+
+# A work-command defines a type of worker that jobs can be submitted to.
+- work-command:
+    worktype: hello
+    command: /bin/echo
+    params: "Hello, world!"

--- a/packaging/rpm/postinstall.sh
+++ b/packaging/rpm/postinstall.sh
@@ -1,0 +1,7 @@
+distro_python_sitelib=$(/usr/libexec/platform-python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+semodule -n -i /usr/share/selinux/packages/receptor.pp
+if /usr/sbin/selinuxenabled ; then
+    /usr/sbin/load_policy
+fi;
+ln -s /usr/share/sosreport/sos/plugins/receptor.py ${distro_python_sitelib}/sos/report/plugins/receptor.py || :
+exit 0

--- a/packaging/rpm/postremove.sh
+++ b/packaging/rpm/postremove.sh
@@ -1,0 +1,9 @@
+distro_python_sitelib=$(/usr/libexec/platform-python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
+if [ $1 -eq 0 ]; then
+    semodule -n -r receptor
+    if /usr/sbin/selinuxenabled ; then
+       /usr/sbin/load_policy
+    fi;
+    rm -f ${distro_python_sitelib}/sos/report/plugins/receptor.py || :
+fi;
+exit 0

--- a/packaging/rpm/preinstall.sh
+++ b/packaging/rpm/preinstall.sh
@@ -1,0 +1,3 @@
+getent group receptor >/dev/null || groupadd -r receptor
+getent passwd receptor >/dev/null || \
+    useradd -r -g receptor -d /var/lib/receptor -s /bin/bash receptor

--- a/packaging/rpm/usr/lib/systemd/system/receptor.service
+++ b/packaging/rpm/usr/lib/systemd/system/receptor.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Receptor
+
+[Service]
+ExecStart=/usr/bin/receptor -c /etc/receptor/receptor.conf
+User=receptor
+Group=receptor
+StandardOutput=append:/var/log/receptor/receptor.log
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/rpm/usr/lib/systemd/system/receptor@.service
+++ b/packaging/rpm/usr/lib/systemd/system/receptor@.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Receptor
+
+[Service]
+ExecStart=/usr/bin/receptor -c /etc/receptor/%i.conf
+User=receptor
+Group=receptor
+StandardOutput=append:/var/log/receptor/%i.log
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/rpm/usr/share/selinux/packages/receptor.te
+++ b/packaging/rpm/usr/share/selinux/packages/receptor.te
@@ -1,0 +1,9 @@
+module receptor 1.0;
+
+require {
+	type init_t;
+	type var_log_t;
+	class file create;
+}
+
+allow init_t var_log_t:file create;

--- a/packaging/rpm/usr/share/sosreport/sos/plugins/receptor.py
+++ b/packaging/rpm/usr/share/sosreport/sos/plugins/receptor.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 Ansible, Inc.
+# All Rights Reserved.
+
+import glob
+
+try:
+    from sos.plugins import Plugin, RedHatPlugin
+except ImportError:
+    from sos.report.plugins import Plugin, RedHatPlugin
+
+SOSREPORT_COMMANDS = [
+    "ls -ll /etc/receptor",
+    "ls -ll /var/run/receptor",
+    "ls -ll /var/run/awx-receptor"
+]
+
+SOSREPORT_DIRS = [
+    "/etc/receptor",
+    "/var/lib/receptor"
+]
+
+SOSREPORT_FORBIDDEN_PATHS = [
+    "/etc/receptor/tls"
+]
+
+
+class Receptor(Plugin, RedHatPlugin):
+    '''Collect Receptor information'''
+
+    short_desc = "Receptor information"
+    plugin_name = "receptor"
+    packages = ('receptor', 'receptorctl',)
+    services = ('receptor',)
+
+    def setup(self):
+
+        for s in glob.glob('/var/run/*receptor/*.sock'):
+            SOSREPORT_COMMANDS.append(f"receptorctl --socket {s} status")
+        self.add_cmd_output(SOSREPORT_COMMANDS)
+
+        if self.get_option("all_logs"):
+            SOSREPORT_DIRS.append("/var/log/receptor")
+        else:
+            SOSREPORT_DIRS.append("/var/log/receptor/*.log")
+        self.add_copy_spec(SOSREPORT_DIRS)
+
+        self.add_forbidden_path(SOSREPORT_FORBIDDEN_PATHS)


### PR DESCRIPTION
A GoReleaser version of https://github.com/ansible/receptor/pull/724 including building RPMs.

In my opinion, #724 is preferable at this time, so I am marking this PR as draft.
If this is more desirable than #724, please let me know and I will remove the draft.

### Demos

- **Only binaries**:
  - demo release: https://github.com/kurokobo/receptor/releases/tag/v1.3.1-demo2
  - commit: https://github.com/ansible/receptor/commit/4f1380964c6cc468ba5f8e70531dbc1884840ecf
  - gh-action log: https://github.com/kurokobo/receptor/actions/runs/3988580337/jobs/6839928094
- **Binaries and RPMs**:
  - demo release: https://github.com/kurokobo/receptor/releases/tag/v1.3.1-demo3
  - commit: https://github.com/ansible/receptor/commit/118f65ed52e58559a99f27c523a0173427a9a9a3
  - gh-action log: https://github.com/kurokobo/receptor/actions/runs/3988651041/jobs/6840090013

### Notes

- These RPMs are not signed.
- These RPMs are built by GoReleaser's [nFPM](https://goreleaser.com/customization/nfpm/), not `rpmbuild`. Therefore, there is no `spec` file.
- The contents of RPMs are based on the RPM and SRPM on Copr (but not fully test since this is just a demo purpose).

### Tests

```bash
$ curl -LO https://github.com/kurokobo/receptor/releases/download/v1.3.1-demo3/receptor_1.3.1-demo3_linux_amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 21.0M  100 21.0M    0     0  5331k      0  0:00:04  0:00:04 --:--:-- 8377k

$ tar zxvf receptor_1.3.1-demo3_linux_amd64.tar.gz 
receptor

$ ./receptor --version
v1.3.1-demo3
```

```bash
$ curl -LO https://github.com/kurokobo/receptor/releases/download/v1.3.1-demo3/receptor_1.3.1-demo3_linux_amd64.rpm
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 21.7M  100 21.7M    0     0  11.0M      0  0:00:01  0:00:01 --:--:-- 18.3M

$ rpm -qi receptor_1.3.1-demo3_linux_amd64.rpm 
Name        : receptor
Epoch       : 0
Version     : 1.3.1~demo3
Release     : 1
Architecture: x86_64
Install Date: (not installed)
Group       : Unspecified
Size        : 50782662
License     : ASL 2.0
Signature   : (none)
Source RPM  : receptor-1.3.1~demo3-1.src.rpm
Build Date  : Tue 24 Jan 2023 02:02:16 AM JST
Build Host  : fv-az646-862
Relocations : (not relocatable)
Packager    : 
Vendor      : Ansible
URL         : https://github.com/ansible/receptor
Summary     : Project Receptor is a flexible multi-service relayer with remote execution and orchestration capabilities linking controllers with executors across a mesh of nodes.
Description :
Project Receptor is a flexible multi-service relayer with remote execution and orchestration capabilities linking controllers with executors across a mesh of nodes.

$ rpm -ql receptor_1.3.1-demo3_linux_amd64.rpm 
/etc/logrotate.d/receptor
/etc/receptor
/etc/receptor/receptor.conf
/etc/receptor/receptor.conf.example
/usr/bin/receptor
/usr/lib/systemd/system/receptor.service
/usr/lib/systemd/system/receptor@.service
/usr/share/bash-completion/completions/receptor
/usr/share/selinux/packages/receptor.pp
/usr/share/sosreport/sos/plugins/receptor.py
/var/lib/receptor
/var/log/receptor
/var/run/receptor

$ rpm -qp --scripts receptor_1.3.1-demo3_linux_amd64.rpm 
preinstall scriptlet (using /bin/sh):
getent group receptor >/dev/null || groupadd -r receptor
getent passwd receptor >/dev/null || \
    useradd -r -g receptor -d /var/lib/receptor -s /bin/bash receptor

postinstall scriptlet (using /bin/sh):
distro_python_sitelib=$(/usr/libexec/platform-python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
semodule -n -i /usr/share/selinux/packages/receptor.pp
if /usr/sbin/selinuxenabled ; then
    /usr/sbin/load_policy
fi;
ln -s /usr/share/sosreport/sos/plugins/receptor.py ${distro_python_sitelib}/sos/report/plugins/receptor.py || :
exit 0

postuninstall scriptlet (using /bin/sh):
distro_python_sitelib=$(/usr/libexec/platform-python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
if [ $1 -eq 0 ]; then
    semodule -n -r receptor
    if /usr/sbin/selinuxenabled ; then
       /usr/sbin/load_policy
    fi;
    rm -f ${distro_python_sitelib}/sos/report/plugins/receptor.py || :
fi;
exit 0
```
