### PR TITLE
Backends logger

### DIFF
--- a/example/net.go
+++ b/example/net.go
@@ -26,7 +26,7 @@ func main() {
 	n2 := netceptor.New(context.Background(), "node2")
 
 	// Start a TCP listener on the first node
-	b1, err := backends.NewTCPListener("localhost:3333", nil)
+	b1, err := backends.NewTCPListener("localhost:3333", nil, n1.Logger)
 	if err != nil {
 		fmt.Printf("Error listening on TCP: %s\n", err)
 		os.Exit(1)
@@ -38,7 +38,7 @@ func main() {
 	}
 
 	// Start a TCP dialer on the second node - this will connect to the listener we just started
-	b2, err := backends.NewTCPDialer("localhost:3333", false, nil)
+	b2, err := backends.NewTCPDialer("localhost:3333", false, nil, n2.Logger)
 	if err != nil {
 		fmt.Printf("Error dialing on TCP: %s\n", err)
 		os.Exit(1)

--- a/pkg/backends/utils.go
+++ b/pkg/backends/utils.go
@@ -17,7 +17,7 @@ const (
 type dialerFunc func(chan struct{}) (netceptor.BackendSession, error)
 
 // dialerSession is a convenience function for backends that use dial/retry logic.
-func dialerSession(ctx context.Context, wg *sync.WaitGroup, redial bool, redialDelay time.Duration,
+func dialerSession(ctx context.Context, wg *sync.WaitGroup, redial bool, redialDelay time.Duration, logger *logger.ReceptorLogger,
 	df dialerFunc,
 ) (chan netceptor.BackendSession, error) {
 	sessChan := make(chan netceptor.BackendSession)
@@ -80,7 +80,7 @@ type (
 )
 
 // listenerSession is a convenience function for backends that use listen/accept logic.
-func listenerSession(ctx context.Context, wg *sync.WaitGroup, lf listenFunc, af acceptFunc, lcf listenerCancelFunc) (chan netceptor.BackendSession, error) {
+func listenerSession(ctx context.Context, wg *sync.WaitGroup, logger *logger.ReceptorLogger, lf listenFunc, af acceptFunc, lcf listenerCancelFunc) (chan netceptor.BackendSession, error) {
 	if err := lf(); err != nil {
 		return nil, err
 	}

--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -104,7 +104,7 @@ func TestWebsocketExternalInterop(t *testing.T) {
 		MinVersion:       tls.VersionTLS12,
 		CurvePreferences: []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},
 	}
-	b2, err := NewWebsocketDialer("wss://"+li.Addr().String(), tls2, "X-Extra-Data: SomeData", true)
+	b2, err := NewWebsocketDialer("wss://"+li.Addr().String(), tls2, "X-Extra-Data: SomeData", true, n1.Logger)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tests/functional/lib/mesh/libmesh.go
+++ b/tests/functional/lib/mesh/libmesh.go
@@ -102,7 +102,7 @@ func (m *LibMesh) Nodes() map[string]Node {
 // TCPListen helper function to create and start a TCPListener
 // This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]float64, tlsCfg *tls.Config) error {
-	b1, err := backends.NewTCPListener(address, tlsCfg)
+	b1, err := backends.NewTCPListener(address, tlsCfg, n.NetceptorInstance.Logger)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func (n *LibNode) TCPListen(address string, cost float64, nodeCost map[string]fl
 // TCPDial helper function to create and start a TCPDialer
 // This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) error {
-	b1, err := backends.NewTCPDialer(address, true, tlsCfg)
+	b1, err := backends.NewTCPDialer(address, true, tlsCfg, n.NetceptorInstance.Logger)
 	if err != nil {
 		return err
 	}
@@ -127,7 +127,7 @@ func (n *LibNode) TCPDial(address string, cost float64, tlsCfg *tls.Config) erro
 // UDPListen helper function to create and start a UDPListener
 // This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]float64) error {
-	b1, err := backends.NewUDPListener(address)
+	b1, err := backends.NewUDPListener(address, n.NetceptorInstance.Logger)
 	if err != nil {
 		return err
 	}
@@ -140,7 +140,7 @@ func (n *LibNode) UDPListen(address string, cost float64, nodeCost map[string]fl
 // UDPDial helper function to create and start a UDPDialer
 // This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) UDPDial(address string, cost float64) error {
-	b1, err := backends.NewUDPDialer(address, true)
+	b1, err := backends.NewUDPDialer(address, true, n.NetceptorInstance.Logger)
 	if err != nil {
 		return err
 	}
@@ -153,7 +153,7 @@ func (n *LibNode) UDPDial(address string, cost float64) error {
 // This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[string]float64, tlsCfg *tls.Config) error {
 	// TODO: Add support for TLS
-	b1, err := backends.NewWebsocketListener(address, tlsCfg)
+	b1, err := backends.NewWebsocketListener(address, tlsCfg, n.NetceptorInstance.Logger)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func (n *LibNode) WebsocketListen(address string, cost float64, nodeCost map[str
 // This might be an unnecessary abstraction and maybe should be deleted.
 func (n *LibNode) WebsocketDial(address string, cost float64, tlsCfg *tls.Config) error {
 	// TODO: Add support for TLS and extra headers
-	b1, err := backends.NewWebsocketDialer(address, nil, "", true)
+	b1, err := backends.NewWebsocketDialer(address, nil, "", true, n.NetceptorInstance.Logger)
 	if err != nil {
 		return err
 	}

--- a/tests/functional/mesh/conn_test.go
+++ b/tests/functional/mesh/conn_test.go
@@ -23,7 +23,7 @@ func TestQuicConnectTimeout(t *testing.T) {
 	n2 := netceptor.New(context.Background(), "node2")
 
 	// Start a TCP listener on the first node
-	b1, err := backends.NewTCPListener("localhost:3333", nil)
+	b1, err := backends.NewTCPListener("localhost:3333", nil, n1.Logger)
 	if err != nil {
 		t.Fatalf("Error listening on TCP: %s\n", err)
 	}
@@ -33,7 +33,7 @@ func TestQuicConnectTimeout(t *testing.T) {
 	}
 
 	// Start a TCP dialer on the second node - this will connect to the listener we just started
-	b2, err := backends.NewTCPDialer("localhost:3333", false, nil)
+	b2, err := backends.NewTCPDialer("localhost:3333", false, nil, n2.Logger)
 	if err != nil {
 		t.Fatalf("Error dialing on TCP: %s\n", err)
 	}


### PR DESCRIPTION
Building on PR #723 , this PR follows the same logging methodology and extends it to the backends package.

Based off of Shanes PR here: https://github.com/ansible/receptor/pull/718
and the blog here: https://gogoapps.io/blog/passing-loggers-in-go-golang-logging-best-practices/#global-state


Once PR #723 is merged, I will rebase this PR and take it out of draft.