### PR TITLE
Controlsvc logger

### DIFF
--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -16,7 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
@@ -129,20 +128,20 @@ func errorNormal(err error) bool {
 
 // RunControlSession runs the server protocol on the given connection.
 func (s *Server) RunControlSession(conn net.Conn) {
-	logger.Debug("Client connected to control service %s\n", conn.RemoteAddr().String())
+	s.nc.Logger.Debug("Client connected to control service %s\n", conn.RemoteAddr().String())
 	defer func() {
-		logger.Debug("Client disconnected from control service %s\n", conn.RemoteAddr().String())
+		s.nc.Logger.Debug("Client disconnected from control service %s\n", conn.RemoteAddr().String())
 		if conn != nil {
 			err := conn.Close()
 			if err != nil {
-				logger.Warning("Could not close connection: %s\n", err)
+				s.nc.Logger.Warning("Could not close connection: %s\n", err)
 			}
 		}
 	}()
 	_, err := conn.Write([]byte(fmt.Sprintf("Receptor Control, node %s\n", s.nc.NodeID())))
 	if err != nil {
 		if !errorNormal(err) {
-			logger.Error("Could not write in control service: %s\n", err)
+			s.nc.Logger.Error("Could not write in control service: %s\n", err)
 		}
 
 		return
@@ -156,13 +155,13 @@ func (s *Server) RunControlSession(conn net.Conn) {
 		for {
 			n, err := conn.Read(buf)
 			if err == io.EOF {
-				logger.Debug("Control service closed\n")
+				s.nc.Logger.Debug("Control service closed\n")
 				done = true
 
 				break
 			} else if err != nil {
 				if !errorNormal(err) {
-					logger.Warning("Could not read in control service: %s\n", err)
+					s.nc.Logger.Warning("Could not read in control service: %s\n", err)
 				}
 
 				return
@@ -199,7 +198,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 				_, err = conn.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
 				if err != nil {
 					if !errorNormal(err) {
-						logger.Error("Write error in control service: %s\n", err)
+						s.nc.Logger.Error("Write error in control service: %s\n", err)
 					}
 
 					return
@@ -242,12 +241,12 @@ func (s *Server) RunControlSession(conn net.Conn) {
 			}
 			if err != nil {
 				if !errorNormal(err) {
-					logger.Error(err.Error())
+					s.nc.Logger.Error(err.Error())
 				}
 				_, err = conn.Write([]byte(fmt.Sprintf("ERROR: %s\n", err)))
 				if err != nil {
 					if !errorNormal(err) {
-						logger.Error("Write error in control service: %s\n", err)
+						s.nc.Logger.Error("Write error in control service: %s\n", err)
 					}
 
 					return
@@ -258,7 +257,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 					_, err = conn.Write([]byte(fmt.Sprintf("ERROR: could not convert response to JSON: %s\n", err)))
 					if err != nil {
 						if !errorNormal(err) {
-							logger.Error("Write error in control service: %s\n", err)
+							s.nc.Logger.Error("Write error in control service: %s\n", err)
 						}
 
 						return
@@ -268,7 +267,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 				_, err = conn.Write(rbytes)
 				if err != nil {
 					if !errorNormal(err) {
-						logger.Error("Write error in control service: %s\n", err)
+						s.nc.Logger.Error("Write error in control service: %s\n", err)
 					}
 
 					return
@@ -278,7 +277,7 @@ func (s *Server) RunControlSession(conn net.Conn) {
 			_, err = conn.Write([]byte("ERROR: Unknown command\n"))
 			if err != nil {
 				if !errorNormal(err) {
-					logger.Error("Write error in control service: %s\n", err)
+					s.nc.Logger.Error("Write error in control service: %s\n", err)
 				}
 
 				return
@@ -334,7 +333,7 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 	if uli == nil && li == nil {
 		return fmt.Errorf("no listeners specified")
 	}
-	logger.Info("Running control service %s\n", service)
+	s.nc.Logger.Info("Running control service %s\n", service)
 	go func() {
 		<-ctx.Done()
 		if uli != nil {
@@ -358,7 +357,7 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 					}
 					if err != nil {
 						if !strings.HasSuffix(err.Error(), "normal close") {
-							logger.Error("Error accepting connection: %s\n", err)
+							s.nc.Logger.Error("Error accepting connection: %s\n", err)
 						}
 
 						continue
@@ -370,19 +369,19 @@ func (s *Server) RunControlSvc(ctx context.Context, service string, tlscfg *tls.
 							// Explicitly run server TLS handshake so we can deal with timeout and errors here
 							err = conn.SetDeadline(time.Now().Add(10 * time.Second))
 							if err != nil {
-								logger.Error("Error setting timeout: %s. Closing socket.\n", err)
+								s.nc.Logger.Error("Error setting timeout: %s. Closing socket.\n", err)
 
 								return
 							}
 							err = tlsConn.Handshake()
 							if err != nil {
-								logger.Error("TLS handshake error: %s. Closing socket.\n", err)
+								s.nc.Logger.Error("TLS handshake error: %s. Closing socket.\n", err)
 
 								return
 							}
 							err = conn.SetDeadline(time.Time{})
 							if err != nil {
-								logger.Error("Error clearing timeout: %s. Closing socket.\n", err)
+								s.nc.Logger.Error("Error clearing timeout: %s. Closing socket.\n", err)
 
 								return
 							}
@@ -422,7 +421,7 @@ type cmdlineConfigUnix struct {
 // Run runs the action.
 func (cfg cmdlineConfigUnix) Run() error {
 	if cfg.TLS != "" && cfg.TCPListen != "" && cfg.TCPTLS == "" {
-		logger.Warning("Control service %s has TLS configured on the Receptor listener but not the TCP listener.", cfg.Service)
+		netceptor.MainInstance.Logger.Warning("Control service %s has TLS configured on the Receptor listener but not the TCP listener.", cfg.Service)
 	}
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {

--- a/pkg/controlsvc/reload.go
+++ b/pkg/controlsvc/reload.go
@@ -149,7 +149,7 @@ func (t *reloadCommandType) InitFromJSON(config map[string]interface{}) (Control
 	return c, nil
 }
 
-func handleError(err error, errorcode int) (map[string]interface{}, error) {
+func handleError(err error, errorcode int, logger *logger.ReceptorLogger) (map[string]interface{}, error) {
 	cfr := make(map[string]interface{})
 	cfr["Success"] = false
 	cfr["Error"] = fmt.Sprintf("%s ERRORCODE %d", err.Error(), errorcode)
@@ -161,31 +161,31 @@ func handleError(err error, errorcode int) (map[string]interface{}, error) {
 func (c *reloadCommand) ControlFunc(ctx context.Context, nc *netceptor.Netceptor, cfo ControlFuncOperations) (map[string]interface{}, error) {
 	// Reload command stops all backends, and re-runs the ParseAndRun() on the
 	// initial config file
-	logger.Debug("Reloading")
+	nc.Logger.Debug("Reloading")
 
 	// Do a quick check to catch any yaml errors before canceling backends
 	err := reloadParseAndRun([]string{"PreReload"})
 	if err != nil {
-		return handleError(err, 4)
+		return handleError(err, 4, nc.Logger)
 	}
 
 	// check if non-reloadable items have been added or modified
 	err = checkReload()
 	if err != nil {
-		return handleError(err, 3)
+		return handleError(err, 3, nc.Logger)
 	}
 
 	// check if non-reloadable items have been removed
 	err = cfgAbsent()
 	if err != nil {
-		return handleError(err, 3)
+		return handleError(err, 3, nc.Logger)
 	}
 
 	nc.CancelBackends()
 	// reloadParseAndRun is a ParseAndRun closure, set in receptor.go/main()
 	err = reloadParseAndRun([]string{"PreReload", "Reload"})
 	if err != nil {
-		return handleError(err, 4)
+		return handleError(err, 4, nc.Logger)
 	}
 
 	cfr := make(map[string]interface{})


### PR DESCRIPTION
Building on PR https://github.com/ansible/receptor/pull/723 , this PR follows the same logging methodology and extends it to the controlsvc package.

Based off of Shanes PR here: https://github.com/ansible/receptor/pull/718
and the blog here: https://gogoapps.io/blog/passing-loggers-in-go-golang-logging-best-practices/#global-state

Once PR https://github.com/ansible/receptor/pull/723 is merged, I will rebase this PR and take it out of draft.