### PR TITLE
Services logger

### DIFF
--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -8,7 +8,6 @@ import (
 	"net"
 	"os/exec"
 
-	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/creack/pty"
@@ -37,21 +36,21 @@ func CommandService(s *netceptor.Netceptor, service string, tlscfg *tls.Config, 
 		"type": "Command Service",
 	})
 	if err != nil {
-		logger.Error("Error listening on Receptor network: %s\n", err)
+		s.Logger.Error("Error listening on Receptor network: %s\n", err)
 
 		return
 	}
 	for {
 		qc, err := qli.Accept()
 		if err != nil {
-			logger.Error("Error accepting connection on Receptor network: %s\n", err)
+			s.Logger.Error("Error accepting connection on Receptor network: %s\n", err)
 
 			return
 		}
 		go func() {
 			err := runCommand(qc, command)
 			if err != nil {
-				logger.Error("Error running command: %s\n", err)
+				s.Logger.Error("Error running command: %s\n", err)
 			}
 			_ = qc.Close()
 		}()
@@ -67,7 +66,7 @@ type commandSvcCfg struct {
 
 // Run runs the action.
 func (cfg commandSvcCfg) Run() error {
-	logger.Info("Running command service %s\n", cfg)
+	netceptor.MainInstance.Logger.Info("Running command service %s\n", cfg)
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {
 		return err

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"strconv"
 
-	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
@@ -30,13 +29,13 @@ func TCPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, tlsSe
 		for {
 			tc, err := tli.Accept()
 			if err != nil {
-				logger.Error("Error accepting TCP connection: %s\n", err)
+				s.Logger.Error("Error accepting TCP connection: %s\n", err)
 
 				return
 			}
 			qc, err := s.Dial(node, rservice, tlsClient)
 			if err != nil {
-				logger.Error("Error connecting on Receptor network: %s\n", err)
+				s.Logger.Error("Error connecting on Receptor network: %s\n", err)
 
 				continue
 			}
@@ -62,7 +61,7 @@ func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *
 		for {
 			qc, err := qli.Accept()
 			if err != nil {
-				logger.Error("Error accepting connection on Receptor network: %s\n", err)
+				s.Logger.Error("Error accepting connection on Receptor network: %s\n", err)
 
 				return
 			}
@@ -73,7 +72,7 @@ func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *
 				tc, err = tls.Dial("tcp", address, tlsClient)
 			}
 			if err != nil {
-				logger.Error("Error connecting via TCP: %s\n", err)
+				s.Logger.Error("Error connecting via TCP: %s\n", err)
 
 				continue
 			}
@@ -96,7 +95,7 @@ type tcpProxyInboundCfg struct {
 
 // Run runs the action.
 func (cfg tcpProxyInboundCfg) Run() error {
-	logger.Debug("Running TCP inbound proxy service %v\n", cfg)
+	netceptor.MainInstance.Logger.Debug("Running TCP inbound proxy service %v\n", cfg)
 	tlsClientCfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLSClient, cfg.RemoteNode, netceptor.ExpectedHostnameTypeReceptor)
 	if err != nil {
 		return err
@@ -120,7 +119,7 @@ type tcpProxyOutboundCfg struct {
 
 // Run runs the action.
 func (cfg tcpProxyOutboundCfg) Run() error {
-	logger.Debug("Running TCP inbound proxy service %s\n", cfg)
+	netceptor.MainInstance.Logger.Debug("Running TCP inbound proxy service %s\n", cfg)
 	tlsServerCfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLSServer)
 	if err != nil {
 		return err

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
@@ -29,14 +28,14 @@ func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permission
 		for {
 			uc, err := uli.Accept()
 			if err != nil {
-				logger.Error("Error accepting Unix socket connection: %s", err)
+				s.Logger.Error("Error accepting Unix socket connection: %s", err)
 
 				return
 			}
 			go func() {
 				qc, err := s.Dial(node, rservice, tlscfg)
 				if err != nil {
-					logger.Error("Error connecting on Receptor network: %s", err)
+					s.Logger.Error("Error connecting on Receptor network: %s", err)
 
 					return
 				}
@@ -61,13 +60,13 @@ func UnixProxyServiceOutbound(s *netceptor.Netceptor, service string, tlscfg *tl
 		for {
 			qc, err := qli.Accept()
 			if err != nil {
-				logger.Error("Error accepting connection on Receptor network: %s\n", err)
+				s.Logger.Error("Error accepting connection on Receptor network: %s\n", err)
 
 				return
 			}
 			uc, err := net.Dial("unix", filename)
 			if err != nil {
-				logger.Error("Error connecting via Unix socket: %s\n", err)
+				s.Logger.Error("Error connecting via Unix socket: %s\n", err)
 
 				continue
 			}
@@ -89,7 +88,7 @@ type unixProxyInboundCfg struct {
 
 // Run runs the action.
 func (cfg unixProxyInboundCfg) Run() error {
-	logger.Debug("Running Unix socket inbound proxy service %v\n", cfg)
+	netceptor.MainInstance.Logger.Debug("Running Unix socket inbound proxy service %v\n", cfg)
 	tlscfg, err := netceptor.MainInstance.GetClientTLSConfig(cfg.TLS, cfg.RemoteNode, netceptor.ExpectedHostnameTypeReceptor)
 	if err != nil {
 		return err
@@ -108,7 +107,7 @@ type unixProxyOutboundCfg struct {
 
 // Run runs the action.
 func (cfg unixProxyOutboundCfg) Run() error {
-	logger.Debug("Running Unix socket inbound proxy service %s\n", cfg)
+	netceptor.MainInstance.Logger.Debug("Running Unix socket inbound proxy service %s\n", cfg)
 	tlscfg, err := netceptor.MainInstance.GetServerTLSConfig(cfg.TLS)
 	if err != nil {
 		return err


### PR DESCRIPTION
Building on PR https://github.com/ansible/receptor/pull/723 , this PR follows the same logging methodology and extends it to the services package.

Based off of Shanes PR here: https://github.com/ansible/receptor/pull/718
and the blog here: https://gogoapps.io/blog/passing-loggers-in-go-golang-logging-best-practices/#global-state

Once PR https://github.com/ansible/receptor/pull/723 is merged, I will rebase this PR and take it out of draft.