### PR TITLE
Refactored logging in the utils package to no longer use a global log…

### DIFF
--- a/pkg/controlsvc/connect.go
+++ b/pkg/controlsvc/connect.go
@@ -83,7 +83,7 @@ func (c *connectCommand) ControlFunc(ctx context.Context, nc *netceptor.Netcepto
 	if err != nil {
 		return nil, err
 	}
-	err = cfo.BridgeConn("Connecting\n", rc, "connected service")
+	err = cfo.BridgeConn("Connecting\n", rc, "connected service", nc.Logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/ghjm/cmdline"
@@ -31,14 +32,14 @@ func (s *sockControl) RemoteAddr() net.Addr {
 }
 
 // BridgeConn bridges the socket to another socket.
-func (s *sockControl) BridgeConn(message string, bc io.ReadWriteCloser, bcName string) error {
+func (s *sockControl) BridgeConn(message string, bc io.ReadWriteCloser, bcName string, logger *logger.ReceptorLogger) error {
 	if message != "" {
 		_, err := s.conn.Write([]byte(message))
 		if err != nil {
 			return err
 		}
 	}
-	utils.BridgeConns(s.conn, "control service", bc, bcName)
+	utils.BridgeConns(s.conn, "control service", bc, bcName, logger)
 
 	return nil
 }

--- a/pkg/controlsvc/interfaces.go
+++ b/pkg/controlsvc/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 
+	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 )
 
@@ -21,7 +22,7 @@ type ControlCommand interface {
 
 // ControlFuncOperations provides callbacks for control services to take actions.
 type ControlFuncOperations interface {
-	BridgeConn(message string, bc io.ReadWriteCloser, bcName string) error
+	BridgeConn(message string, bc io.ReadWriteCloser, bcName string, logger *logger.ReceptorLogger) error
 	ReadFromConn(message string, out io.Writer) error
 	WriteToConn(message string, in chan []byte) error
 	Close() error

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -1101,7 +1101,7 @@ func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expecte
 		}
 
 		if expectedHostnameType == ExpectedHostnameTypeReceptor {
-			found, receptorNames, err := utils.ParseReceptorNamesFromCert(certs[0], expectedHostname)
+			found, receptorNames, err := utils.ParseReceptorNamesFromCert(certs[0], expectedHostname, logger)
 			if err != nil {
 				return err
 			}

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -53,7 +53,7 @@ func checkCertificatesMatchNodeID(certbytes []byte, n *Netceptor, certName strin
 		return err
 	}
 
-	found, receptorNames, err := utils.ParseReceptorNamesFromCert(parsedCert, n.nodeID)
+	found, receptorNames, err := utils.ParseReceptorNamesFromCert(parsedCert, n.nodeID, n.Logger)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/command.go
+++ b/pkg/services/command.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os/exec"
 
+	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/utils"
 	"github.com/creack/pty"
@@ -15,7 +16,7 @@ import (
 	"github.com/google/shlex"
 )
 
-func runCommand(qc net.Conn, command string) error {
+func runCommand(qc net.Conn, command string, logger *logger.ReceptorLogger) error {
 	args, err := shlex.Split(command)
 	if err != nil {
 		return err
@@ -25,7 +26,7 @@ func runCommand(qc net.Conn, command string) error {
 	if err != nil {
 		return err
 	}
-	utils.BridgeConns(tty, "external command", qc, "command service")
+	utils.BridgeConns(tty, "external command", qc, "command service", logger)
 
 	return nil
 }
@@ -48,7 +49,7 @@ func CommandService(s *netceptor.Netceptor, service string, tlscfg *tls.Config, 
 			return
 		}
 		go func() {
-			err := runCommand(qc, command)
+			err := runCommand(qc, command, s.Logger)
 			if err != nil {
 				s.Logger.Error("Error running command: %s\n", err)
 			}

--- a/pkg/services/tcp_proxy.go
+++ b/pkg/services/tcp_proxy.go
@@ -39,7 +39,7 @@ func TCPProxyServiceInbound(s *netceptor.Netceptor, host string, port int, tlsSe
 
 				continue
 			}
-			go utils.BridgeConns(tc, "tcp service", qc, "receptor connection")
+			go utils.BridgeConns(tc, "tcp service", qc, "receptor connection", s.Logger)
 		}
 	}()
 
@@ -76,7 +76,7 @@ func TCPProxyServiceOutbound(s *netceptor.Netceptor, service string, tlsServer *
 
 				continue
 			}
-			go utils.BridgeConns(qc, "receptor service", tc, "tcp connection")
+			go utils.BridgeConns(qc, "receptor service", tc, "tcp connection", s.Logger)
 		}
 	}()
 

--- a/pkg/services/unix_proxy.go
+++ b/pkg/services/unix_proxy.go
@@ -39,7 +39,7 @@ func UnixProxyServiceInbound(s *netceptor.Netceptor, filename string, permission
 
 					return
 				}
-				utils.BridgeConns(uc, "unix socket service", qc, "receptor connection")
+				utils.BridgeConns(uc, "unix socket service", qc, "receptor connection", s.Logger)
 			}()
 		}
 	}()
@@ -70,7 +70,7 @@ func UnixProxyServiceOutbound(s *netceptor.Netceptor, service string, tlscfg *tl
 
 				continue
 			}
-			go utils.BridgeConns(qc, "receptor service", uc, "unix socket connection")
+			go utils.BridgeConns(qc, "receptor service", uc, "unix socket connection", s.Logger)
 		}
 	}()
 

--- a/pkg/utils/bridge.go
+++ b/pkg/utils/bridge.go
@@ -11,16 +11,16 @@ import (
 const NormalBufferSize = 65536
 
 // BridgeConns bridges two connections, like netcat.
-func BridgeConns(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2Name string) {
+func BridgeConns(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2Name string, logger *logger.ReceptorLogger) {
 	doneChan := make(chan bool)
-	go bridgeHalf(c1, c1Name, c2, c2Name, doneChan)
-	go bridgeHalf(c2, c2Name, c1, c1Name, doneChan)
+	go bridgeHalf(c1, c1Name, c2, c2Name, doneChan, logger)
+	go bridgeHalf(c2, c2Name, c1, c1Name, doneChan, logger)
 	<-doneChan
 	<-doneChan
 }
 
 // BridgeHalf bridges the read side of c1 to the write side of c2.
-func bridgeHalf(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2Name string, done chan bool) {
+func bridgeHalf(c1 io.ReadWriteCloser, c1Name string, c2 io.ReadWriteCloser, c2Name string, done chan bool, logger *logger.ReceptorLogger) {
 	logger.Trace("    Bridging %s to %s\n", c1Name, c2Name)
 	defer func() {
 		done <- true

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ansible/receptor/pkg/logger"
 )
 
-func ParseReceptorNamesFromCert(cert *x509.Certificate, expectedHostname string) (bool, []string, error) {
+func ParseReceptorNamesFromCert(cert *x509.Certificate, expectedHostname string, logger *logger.ReceptorLogger) (bool, []string, error) {
 	var receptorNames []string
 	receptorNames, err := ReceptorNames(cert.Extensions)
 	if err != nil {


### PR DESCRIPTION
…ger.

Building on PR https://github.com/ansible/receptor/pull/723 , this PR follows the same logging methodology and extends it to the utils package.

Based off of Shanes PR here: https://github.com/ansible/receptor/pull/718
and the blog here: https://gogoapps.io/blog/passing-loggers-in-go-golang-logging-best-practices/#global-state
