### PR TITLE
Fix promote action 

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -81,6 +81,8 @@ jobs:
 
       - name: Set up Go
         uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
 
       - name: Build packages
         run: |


### PR DESCRIPTION
As shared on Elementor from @kurokobo, we need to pin go version on promote github action due to quic-go incompatibility with go 1.20.

Error reported was: `The version of quic-go you're using can't be built on Go 1.20 yet`

