### PR TITLE
Handle PKCS8PrivateKey

### DIFF
--- a/pkg/certificates/ca.go
+++ b/pkg/certificates/ca.go
@@ -71,6 +71,12 @@ func LoadFromPEMFile(filename string) ([]interface{}, error) {
 				return nil, err
 			}
 			results = append(results, key)
+		case "PRIVATE KEY":
+			key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, key)
 		case "PUBLIC KEY":
 			key, err := x509.ParsePKIXPublicKey(block.Bytes)
 			if err != nil {


### PR DESCRIPTION
certificate generated by newer openssl generate PKCS8Private key by default causing `receptor --cert-makereq` and `receptor --cert-signreq` to fail