### PR TITLE
advertise backends on control service ad

### DIFF
--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -42,6 +42,10 @@ func (cfg *nullBackendCfg) GetTLS() *tls.Config {
 	return nil
 }
 
+func (cfg *nullBackendCfg) GetType() string {
+	return ""
+}
+
 func (cfg nullBackendCfg) Reload() error {
 	return cfg.Run()
 }

--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -47,6 +47,10 @@ func (b *TCPDialer) GetTLS() *tls.Config {
 	return b.tls
 }
 
+func (b *TCPDialer) GetType() string {
+	return "tcp-peer"
+}
+
 // Start runs the given session function over this backend service.
 func (b *TCPDialer) Start(ctx context.Context, wg *sync.WaitGroup) (chan netceptor.BackendSession, error) {
 	return dialerSession(ctx, wg, b.redial, 5*time.Second, b.logger,
@@ -91,6 +95,9 @@ func NewTCPListener(address string, tls *tls.Config, logger *logger.ReceptorLogg
 
 // Addr returns the network address the listener is listening on.
 func (b *TCPListener) GetAddr() string {
+	if b.li == nil {
+		return b.address
+	}
 	return b.li.Addr().String()
 }
 
@@ -100,6 +107,10 @@ func (b *TCPListener) GetCost() string {
 
 func (b *TCPListener) GetTLS() *tls.Config {
 	return b.TLS
+}
+
+func (b *TCPListener) GetType() string {
+	return "tcp-listener"
 }
 
 // Start runs the given session function over the TCPListener backend.

--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -35,6 +35,10 @@ func (b *UDPDialer) GetTLS() *tls.Config {
 	return nil
 }
 
+func (b *UDPDialer) GetType() string {
+	return "udp-peer"
+}
+
 // NewUDPDialer instantiates a new UDPDialer backend.
 func NewUDPDialer(address string, redial bool, logger *logger.ReceptorLogger) (*UDPDialer, error) {
 	_, err := net.ResolveUDPAddr("udp", address)
@@ -142,6 +146,10 @@ func (b *UDPListener) GetAddr() string {
 
 func (b *UDPListener) GetTLS() *tls.Config {
 	return &tls.Config{}
+}
+
+func (b *UDPListener) GetType() string {
+	return "udp-listener"
 }
 
 // NewUDPListener instantiates a new UDPListener backend.

--- a/pkg/backends/websockets.go
+++ b/pkg/backends/websockets.go
@@ -38,6 +38,10 @@ func (b *WebsocketDialer) GetTLS() *tls.Config {
 	return b.tlscfg
 }
 
+func (b *WebsocketDialer) GetType() string {
+	return "ws-peer"
+}
+
 // NewWebsocketDialer instantiates a new WebsocketDialer backend.
 func NewWebsocketDialer(address string, tlscfg *tls.Config, extraHeader string, redial bool, logger *logger.ReceptorLogger) (*WebsocketDialer, error) {
 	addrURL, err := url.Parse(address)
@@ -98,11 +102,18 @@ type WebsocketListener struct {
 }
 
 func (b *WebsocketListener) GetAddr() string {
-	return b.Addr().String()
+	if b.li == nil {
+		return b.address
+	}
+	return b.li.Addr().String()
 }
 
 func (b *WebsocketListener) GetTLS() *tls.Config {
 	return b.tlscfg
+}
+
+func (b *WebsocketListener) GetType() string {
+	return "ws-listener"
 }
 
 // NewWebsocketListener instantiates a new WebsocketListener backend.

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -158,6 +158,14 @@ func (b *ExternalBackend) Start(ctx context.Context, _ *sync.WaitGroup) (chan Ba
 	return b.sessChan, nil
 }
 
+func (b *ExternalBackend) GetAddr() string {
+	return ""
+}
+
+func (b *ExternalBackend) GetType() string {
+	return "external"
+}
+
 // ExternalSession implements BackendSession for external backends.
 type ExternalSession struct {
 	eb          *ExternalBackend


### PR DESCRIPTION
adds `Backends` section, see below

piggy backs off of the control service ad, similar to how we advertise work commands

for example,

```json
{
    "Advertisements": [
        {
            "Backends": [
                {
                    "Address": "localhost:2222",
                    "Type": "tcp-peer"
                },
                {
                    "Address": "0.0.0.0:6666",
                    "Type": "tcp-listener"
                }
            ],
            "ConnType": 1,
            "NodeID": "node1",
            "Service": "control",
            "Tags": {
                "type": "Control Service"
            },
            "Time": "2023-05-01T16:47:08.551973781-04:00",
            "WorkCommands": null
        }
    ],
    "Connections": [],
    "KnownConnectionCosts": {},
    "NodeID": "node1",
    "RoutingTable": {},
    "SystemCPUCount": 8,
    "SystemMemoryMiB": 31787,
    "Version": "v1.3.1+g6053953"
}

```

In AWX, we can use this info to introspect a node's active backends and infer if the receptor configuration is stale/out of date.