### PR TITLE
Respect ctx cancel

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -321,6 +321,15 @@ func (kw *kubeUnit) runWorkUsingLogger() {
 		// resuming from a previously created pod
 		var err error
 		for retries := 5; retries > 0; retries-- {
+			// check if the kw.ctx is already cancel
+			select {
+			case <-kw.ctx.Done():
+				errMsg := fmt.Sprintf("Context Done while getting pod %s/%s. Error: %s", podNamespace, podName, kw.ctx.Err())
+				kw.Warning(errMsg)
+				return
+			default:
+			}
+
 			kw.pod, err = kw.clientset.CoreV1().Pods(podNamespace).Get(kw.ctx, podName, metav1.GetOptions{})
 			if err == nil {
 				break


### PR DESCRIPTION
I think there's a race condition between controller and receptor

controller see the job finished and try to cancel workunit

receptor does not respect the cancel and continue to do GET to kube apiserver with a dead ctx which cause a very misleading error message
```
client rate limiter Wait returned an error: context canceled
```