### PR TITLE
Lay groundwork for benchmark tests and reporting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,11 @@ testloop: receptor
 	  make test; do \
 	  i=$$((i+1)); done
 
+benchmark:
+	PATH="${PWD}:${PATH}" \
+	go test -bench=. -run=^# ./...
+
+
 kubectl:
 	curl -LO "https://storage.googleapis.com/kubernetes-release/release/$$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl"
 	chmod a+x kubectl


### PR DESCRIPTION
Create github workflows to both run and report the results of the benchmarks
Create a new Makefile target to traverse the project and run any benchmark while ignoring normal tests
Refactor some of the util test functions to support `testing.B` and `testing.T` types