### PR TITLE
Removed typecheck from the linting suite

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,7 +56,7 @@ linters:
     #- testpackage # TODO: Put tests in their dedicated test packages.
     #- thelper # TODO: Requires test refactoring.
     - tparallel
-    - typecheck
+    #- typecheck # Has become flakey and is no better than the compiler
     - unconvert
     #- unparam # TODO: This breaks something, look at it!
     - unused


### PR DESCRIPTION
"`typecheck` is not a real linter, it's just a way to parse compiling errors (produced by the types.Checker) and some linter errors." 
As it is becoming flakey we will relay on the compiler.