### PR TITLE
Don't error if log reconnection fails due to context canceled

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -225,7 +225,6 @@ func (kw *kubeUnit) kubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 			errMsg := fmt.Sprintf("Error getting pod %s/%s. Error: %s", podNamespace, podName, err)
 			kw.Error(errMsg)
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
-
 			break
 		}
 
@@ -239,6 +238,13 @@ func (kw *kubeUnit) kubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 		for *stdinErr == nil { // check between every line read to see if we need to stop reading
 			line, err := streamReader.ReadString('\n')
 			if err != nil {
+				if kw.ctx.Err() == context.Canceled {
+					kw.Info(
+						"Context was canceled while reading logs for pod %s/%s. Assuming pod has finished",
+						podNamespace,
+						podName)
+					return
+				}
 				kw.Info(
 					"Detected Error: %s for pod %s/%s. Will retry %d more times.",
 					err,

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -225,6 +225,7 @@ func (kw *kubeUnit) kubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 			errMsg := fmt.Sprintf("Error getting pod %s/%s. Error: %s", podNamespace, podName, err)
 			kw.Error(errMsg)
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
+			
 			break
 		}
 
@@ -243,6 +244,7 @@ func (kw *kubeUnit) kubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 						"Context was canceled while reading logs for pod %s/%s. Assuming pod has finished",
 						podNamespace,
 						podName)
+					
 					return
 				}
 				kw.Info(

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -225,7 +225,7 @@ func (kw *kubeUnit) kubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 			errMsg := fmt.Sprintf("Error getting pod %s/%s. Error: %s", podNamespace, podName, err)
 			kw.Error(errMsg)
 			kw.UpdateBasicStatus(WorkStateFailed, errMsg, 0)
-			
+
 			break
 		}
 
@@ -244,7 +244,7 @@ func (kw *kubeUnit) kubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 						"Context was canceled while reading logs for pod %s/%s. Assuming pod has finished",
 						podNamespace,
 						podName)
-					
+
 					return
 				}
 				kw.Info(


### PR DESCRIPTION
Don't retry either as the context won't become uncanceled