### PR TITLE
receptorctl: Remove setuptools runtime dependency

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -107,7 +107,7 @@ jobs:
     strategy:
       matrix:
         os-version: ["ubuntu-22.04"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: "${{ matrix.os-version }}"
     steps:
       - name: Checkout

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -9,7 +9,7 @@ import click
 import json
 from functools import partial
 import dateutil.parser
-import pkg_resources
+import importlib.metadata
 from .socket_interface import ReceptorControl
 
 
@@ -87,7 +87,7 @@ def print_error(message, nl=True):
 def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
     ctx.obj = {
         "rc": None,
-        "receptorctlVersion": pkg_resources.get_distribution("receptorctl").version,
+        "receptorctlVersion": importlib.metadata.version("receptorctl"),
         "receptorVersion": "Unknown",
     }
     # If we got a socket parameter we can make a ReceptorControl object


### PR DESCRIPTION
Due to the `pkg_resources` import then setuptools is a runtime dependency.
The `pkg_resources` module is deprecated and we should use `importlib.metadata` instead which is a python builtin (since 3.8)

https://setuptools.pypa.io/en/latest/pkg_resources.html
https://docs.python.org/3.9/library/importlib.metadata.html