### PR TITLE
Add openssl dependency to the test doc

### DIFF
--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -18,7 +18,8 @@ The following are needed to run the integration tests:
  * In order to run the receptorctl tests you must have python3, virtualenv, and
    pip installed. The `receptorctl-tests` make target will setup a virtualenv
    for the tests.
- * `openssl` must be installed on the system in order for the cli tests to pass
+ * `openssl` must be installed on the system in order for the cli tests to run 
+   properly.
 
 ## CLI Tests
 

--- a/tests/functional/README.md
+++ b/tests/functional/README.md
@@ -18,6 +18,7 @@ The following are needed to run the integration tests:
  * In order to run the receptorctl tests you must have python3, virtualenv, and
    pip installed. The `receptorctl-tests` make target will setup a virtualenv
    for the tests.
+ * `openssl` must be installed on the system in order for the cli tests to pass
 
 ## CLI Tests
 


### PR DESCRIPTION
Add openssl dependency to the test doc since openssl is required of cli tests and for Receptor in general. Fedora doesn't ship with openssl installed so a new Fedora machine will fail the cli tests.