### PR TITLE
Add a noxfile to receptorctl

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install tox
-        run: pip install tox
+      - name: Setup nox
+        uses: wntrblm/nox@2024.03.02
 
       - name: Run receptorctl linters
         run: make receptorctl-lint
@@ -135,8 +135,8 @@ jobs:
       - name: Upgrade pip
         run: pip install --upgrade pip
 
-      - name: Install tox
-        run: pip install tox
+      - name: Setup nox
+        uses: wntrblm/nox@2024.03.02
 
       - name: Run receptorctl tests
         run: make receptorctl-test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,11 +30,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup up python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
       - name: Setup nox
         uses: wntrblm/nox@2024.03.02
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -100,13 +100,9 @@ jobs:
           name: receptor
           path: /usr/local/bin/receptor
   receptorctl:
-    name: receptorctl (Python ${{ matrix.python-version }})
+    name: receptorctl
     needs: receptor
-    strategy:
-      matrix:
-        os-version: ["ubuntu-22.04"]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
-    runs-on: "${{ matrix.os-version }}"
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,14 +117,6 @@ jobs:
 
       - name: Fix permissions on receptor binary
         run: sudo chmod a+x /usr/local/bin/receptor
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "${{ matrix.python-version }}"
-
-      - name: Upgrade pip
-        run: pip install --upgrade pip
 
       - name: Setup nox
         uses: wntrblm/nox@2024.03.02

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ kubectl
 /dist
 /test-configs
 coverage.txt
+venv

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ lint:
 	@golint cmd/... pkg/... example/...
 
 receptorctl-lint: receptorctl/.VERSION
-	@cd receptorctl && tox -e lint
+	@cd receptorctl && nox -s lint
 
 format:
 	@find cmd/ pkg/ -type f -name '*.go' -exec $(GO) fmt {} \;
@@ -140,7 +140,7 @@ test: receptor
 	$(GO) test ./... $(TESTCMD) -count=1 -race -timeout 5m
 
 receptorctl-test: receptorctl/.VERSION
-	@cd receptorctl && tox -e py3
+	@cd receptorctl && nox -s tests
 
 testloop: receptor
 	@i=1; while echo "------ $$i" && \

--- a/receptorctl/README.md
+++ b/receptorctl/README.md
@@ -1,1 +1,59 @@
 Receptorctl is a front-end CLI and importable Python library that interacts with Receptor over its control socket interface.
+
+# Setting up nox
+
+This project includes a `nox` configuration to automate tests, checks, and other functions in a reproducible way using isolated environments.
+Before you submit a PR, you should install `nox` and verify your changes.
+
+> To run `make receptorctl-lint` and `receptorctl-test` from the repository root, you must first install `nox`.
+
+1. Install `nox` using `python3 -m pip install nox` or your distribution's package manager.
+2. Run `nox --list` from the `receptorctl` directory to view available sessions.
+
+You can run `nox` with no arguments to execute all checks and tests.
+Alternatively, you can run only certain tasks as outlined in the following sections.
+
+# Checking changes to Receptorctl
+
+Run the following `nox` sessions to check for code style and formatting issues:
+
+* Run all checks.
+
+  ``` bash
+  nox -s lint
+  ```
+
+* Check code style.
+
+  ``` bash
+  nox -s check_style
+  ```
+
+* Check formatting.
+
+  ``` bash
+  nox -s check_format
+  ```
+
+* Format code if the check fails.
+
+  ``` bash
+  nox -s format
+  ```
+
+# Running Receptorctl tests
+
+Run the following `nox` sessions to test Receptorctl changes:
+
+* Run tests against the complete matrix of Python versions.
+
+  ``` bash
+  nox -s tests
+  ```
+
+* Run tests against a specific Python version.
+
+  ``` bash
+  # For example, this command tests Receptorctl against Python 3.11.
+  nox -s tests-3.11
+  ```

--- a/receptorctl/noxfile.py
+++ b/receptorctl/noxfile.py
@@ -1,0 +1,56 @@
+from glob import iglob
+
+import nox
+
+python_versions = ["3.8", "3.9", "3.10", "3.11"]
+
+LINT_FILES: tuple[str, ...] = (
+    *iglob("receptorctl/*.py"),
+    "setup.py",
+)
+
+
+@nox.session(python=python_versions)
+def tests(session: nox.Session):
+    """
+    Run receptorctl tests
+    """
+    session.install("pytest")
+    session.install("-e", ".")
+    session.run("pytest", "-v", "tests", *session.posargs)
+
+
+@nox.session
+def check_style(session: nox.Session):
+    """
+    Check receptorctl Python code style
+    """
+    session.install("flake8")
+    session.run("flake8", *session.posargs, *LINT_FILES)
+
+
+@nox.session
+def check_format(session: nox.Session):
+    """
+    Check receptorctl Python file formatting without making changes
+    """
+    session.install("black")
+    session.run("black", "--check", *session.posargs, *LINT_FILES)
+
+
+@nox.session
+def format(session: nox.Session):
+    """
+    Format receptorctl Python files
+    """
+    session.install("black")
+    session.run("black", *session.posargs, *LINT_FILES)
+
+
+@nox.session
+def lint(session: nox.Session):
+    """
+    Check receptorctl for code style and formatting
+    """
+    session.notify("check_style")
+    session.notify("check_format")


### PR DESCRIPTION
This PR converts the receptorctl tox file to use a noxfile instead as discussed with @thom-at-redhat The purpose of converting to a noxfile is to eventually add sessions for receptorctl documentation. Many other projects are using noxfiles for their docs so it seems good to be consistent.

Some notes:

- I left the tox file in place. If this PR is merged I can submit a follow up to remove it.
- Also did not update the workflows that call the tox file. I would also like to do that in a follow up PR.
- Rather than using `envlist = py3` from the tox file I included a matrix of versions taken from https://github.com/ansible/receptor/blob/8ab33508ae38cfb9f537063c6451f712059426d0/.github/workflows/pull_request.yml#L113
  I think we'll be able to use the nox session in the workflow and condense several of the steps. This pretty much means moving that matrix from the workflow to the noxfile. Again, I'd like to do that as a follow on. Just wanted to point it out here.