### PR TITLE
Bump Receptorctl dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,14 @@ updates:
     directory: /
     schedule:
       interval: daily
+  - package-ecosystem: "pip"
+    directory: "/receptorctl"
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "pip"
+      - "dependencies"


### PR DESCRIPTION
This PR updates the dependabot config to bump Python dependencies for Receptorctl.