### PR TITLE
Add check if receptorctl pypi already at latest

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -31,7 +31,11 @@ jobs:
         run: echo pypi_repo=testpypi >> $GITHUB_ENV
         if: ${{ github.repository_owner != 'ansible' }}
 
+      - name: Set receptor pypi version
+        run: echo RECEPTORCTL_PYPI_VERSION_CALL=$(curl -s -o /dev/null -w "%{http_code}" 'https://pypi.org/pypi/receptorctl/${{ env.TAG }}/json') >> $GITHUB_ENV
+
       - name: Build receptorctl and upload to pypi
+        if: ${{ env.RECEPTORCTL_PYPI_VERSION_CALL == '404' }}
         run: |
           make receptorctl_wheel receptorctl_sdist VERSION=$TAG
           twine upload \

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -32,10 +32,10 @@ jobs:
         if: ${{ github.repository_owner != 'ansible' }}
 
       - name: Set receptor pypi version
-        run: echo RECEPTORCTL_PYPI_VERSION_CALL=$(curl -s -o /dev/null -w "%{http_code}" 'https://pypi.org/pypi/receptorctl/${{ env.TAG }}/json') >> $GITHUB_ENV
+        run: echo RECEPTORCTL_PYPI_VERSION=$(curl --silent https://pypi.org/pypi/receptorctl/json | jq --raw-output '.info.version') >> $GITHUB_ENV
 
       - name: Build receptorctl and upload to pypi
-        if: ${{ env.RECEPTORCTL_PYPI_VERSION_CALL == '404' }}
+        if: ${{ env.RECEPTORCTL_PYPI_VERSION != env.TAG }}
         run: |
           make receptorctl_wheel receptorctl_sdist VERSION=$TAG
           twine upload \


### PR DESCRIPTION
Add a check if receptorctl is already at the promote version on pypi.

This is helpful when a promote job fails after receptorctl has already been uploaded to pypi and need to be ran again.