### PR TITLE
Add log of kube pod status on error

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -816,6 +816,7 @@ func (kw *KubeUnit) runWorkUsingLogger() {
 					// this is probably not possible...
 					errMsg := fmt.Sprintf("Error reading stdin: %s", stdin.Error())
 					kw.GetWorkceptor().nc.GetLogger().Error(errMsg)
+					kw.GetWorkceptor().nc.GetLogger().Error("Pod status at time of error %s", kw.pod.Status.String())
 					kw.UpdateBasicStatus(WorkStateFailed, errMsg, stdout.Size())
 
 					close(stdinErrChan) // signal STDOUT goroutine to stop


### PR DESCRIPTION
We have found a case where the pod is done but dosent return an error and the stdin does not have an EOF. 
As we thought this was not possible we will print the last known kube pod status. 
The format of this status looks something like this:

```
&PodStatus{Phase:Running,Conditions:[]PodCondition{PodCondition{Type:Initialized,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-07-24 09:12:40 +0100 IST,Reason:,Message:,},PodCondition{Type:Ready,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-07-24 09:12:42 +0100 IST,Reason:,Message:,},PodCondition{Type:ContainersReady,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-07-24 09:12:42 +0100 IST,Reason:,Message:,},PodCondition{Type:PodScheduled,Status:True,LastProbeTime:0001-01-01 00:00:00 +0000 UTC,LastTransitionTime:2024-07-24 09:12:40 +0100 IST,Reason:,Message:,},},Message:,Reason:,HostIP:172.18.0.2,PodIP:10.244.0.227,StartTime:2024-07-24 09:12:40 +0100 IST,ContainerStatuses:[]ContainerStatus{ContainerStatus{Name:worker,State:ContainerState{Waiting:nil,Running:&ContainerStateRunning{StartedAt:2024-07-24 09:12:42 +0100 IST,},Terminated:nil,},LastTerminationState:ContainerState{Waiting:nil,Running:nil,Terminated:nil,},Ready:true,RestartCount:0,Image:docker.io/library/alpine:latest,ImageID:docker.io/library/alpine@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5,ContainerID:containerd://67973a68ef23bbb5f76f54534f8c190e8148e8cd599e1f860f88f54e892879d2,Started:*true,AllocatedResources:ResourceList{},Resources:nil,},},QOSClass:BestEffort,InitContainerStatuses:[]ContainerStatus{},NominatedNodeName:,PodIPs:[]PodIP{PodIP{IP:10.244.0.227,},},EphemeralContainerStatuses:[]ContainerStatus{},Resize:,ResourceClaimStatuses:[]PodResourceClaimStatus{},HostIPs:[]HostIP{},}
```

This data was from our unit test but in the real world `Message` and `Reason` will have more information. 