### PR TITLE
included -h filter for os.exit

### DIFF
--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -34,7 +34,7 @@ func main() {
 	}
 
 	for _, arg := range os.Args {
-		if arg == "--help" {
+		if arg == "--help" || arg == "-h" {
 			os.Exit(0)
 		}
 	}


### PR DESCRIPTION
Added the `-h` to the check for exiting without spinning up receptor