### PR TITLE
change --legacy to --latest to switch v1 to default

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -141,24 +141,22 @@ jobs:
 
       - name: Write out basic config
         run: |
-          cat << EOF > test.yaml
+          cat << EOF > test.cfg
           ---
-          version: 2
-          local-only:
-            local: true
+          - local-only:
 
-          control-services:
-            - service: control
+          - control-service:
+              service: control
               filename: /tmp/receptor.sock
 
-          work-commands:
-            - worktype: cat
+          - work-command:
+              worktype: cat
               command: cat
           EOF
 
       - name: Run receptor (and wait a few seconds for it to boot)
         run: |
-          podman run --name receptor -d -v $PWD/test.yaml:/etc/receptor/receptor.yaml:Z localhost/receptor
+          podman run --name receptor -d -v $PWD/test.cfg:/etc/receptor/receptor.conf:Z localhost/receptor
           sleep 3
           podman logs receptor
 

--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -13,11 +13,11 @@ import (
 )
 
 func main() {
-	var latest bool
+	var isV2 bool
 	newArgs := []string{}
 	for _, arg := range os.Args {
-		if arg == "--latest" {
-			latest = true
+		if arg == "--config-v2" {
+			isV2 = true
 
 			continue
 		}
@@ -26,8 +26,8 @@ func main() {
 
 	os.Args = newArgs
 
-	if latest {
-		fmt.Println("Running latest cli/config")
+	if isV2 {
+		fmt.Println("Running v2 cli/config")
 		cmd.Execute()
 	} else {
 		cmd.RunConfigV1()

--- a/cmd/receptor-cl/receptor.go
+++ b/cmd/receptor-cl/receptor.go
@@ -13,11 +13,11 @@ import (
 )
 
 func main() {
-	var legacy bool
+	var latest bool
 	newArgs := []string{}
 	for _, arg := range os.Args {
-		if arg == "--legacy" {
-			legacy = true
+		if arg == "--latest" {
+			latest = true
 
 			continue
 		}
@@ -26,10 +26,10 @@ func main() {
 
 	os.Args = newArgs
 
-	if !legacy {
+	if latest {
+		fmt.Println("Running latest cli/config")
 		cmd.Execute()
 	} else {
-		fmt.Println("Running old cli/config")
 		cmd.RunConfigV1()
 	}
 

--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -19,7 +19,7 @@ LABEL version="${VERSION}"
 
 COPY receptorctl-${VERSION}-py3-none-any.whl /tmp
 COPY receptor_python_worker-${VERSION}-py3-none-any.whl /tmp
-COPY receptor.yaml /etc/receptor/receptor.yaml
+COPY receptor.conf /etc/receptor/receptor.conf
 
 RUN dnf -y update && \
     dnf -y install python3.12-pip && \
@@ -36,4 +36,4 @@ ENV RECEPTORCTL_SOCKET=/tmp/receptor.sock
 EXPOSE 7323
 
 ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
-CMD ["/usr/bin/receptor", "--config", "/etc/receptor/receptor.yaml"]
+CMD ["/usr/bin/receptor", "-c", "/etc/receptor/receptor.conf"]

--- a/packaging/container/receptor.conf
+++ b/packaging/container/receptor.conf
@@ -1,0 +1,7 @@
+---
+- control-service:
+    service: control
+    filename: /tmp/receptor.sock
+
+- tcp-listener:
+    port: 7323

--- a/packaging/container/receptor.yaml
+++ b/packaging/container/receptor.yaml
@@ -1,8 +1,0 @@
----
-version: 2
-control-services:
-  - service: control
-    filename: /tmp/receptor.sock
-
-tcp-listeners:
-  - port: 7323

--- a/packaging/tc-image/Dockerfile
+++ b/packaging/tc-image/Dockerfile
@@ -3,4 +3,4 @@ FROM receptor:latest
 RUN dnf install tc -y
 
 ENTRYPOINT ["/bin/bash"]
-CMD ["-c", "/usr/bin/receptor --legacy --config /etc/receptor/receptor.conf > /etc/receptor/stdout 2> /etc/receptor/stderr"]
+CMD ["-c", "/usr/bin/receptor --config /etc/receptor/receptor.conf > /etc/receptor/stdout 2> /etc/receptor/stderr"]

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -269,7 +269,7 @@ func (cw *commandUnit) Start() error {
 		receptorBin = "receptor"
 	}
 
-	cmd := exec.Command(receptorBin, "--legacy", "--node", "id=worker",
+	cmd := exec.Command(receptorBin, "--node", "id=worker",
 		"--log-level", levelName,
 		"--command-runner",
 		fmt.Sprintf("command=%s", cw.command),

--- a/receptorctl/tests/conftest.py
+++ b/receptorctl/tests/conftest.py
@@ -266,7 +266,7 @@ def start_nodes(receptor_mesh, receptor_nodes, receptor_bin_path):
         )
         receptor_nodes.nodes.append(
             subprocess.Popen(
-                [receptor_bin_path, "--legacy", "-c", config_file],
+                [receptor_bin_path, "-c", config_file],
                 stdout=receptor_nodes.log_files[i],
                 stderr=receptor_nodes.log_files[i],
             )
@@ -335,7 +335,6 @@ def receptor_mesh_access_control(
 @pytest.fixture(scope="function")
 def receptor_control_args(receptor_mesh):
     args = {
-        "--legacy": None,
         "--socket": f"{receptor_mesh.get_mesh_tmp_dir()}/{receptor_mesh.socket_file_name}",
         "--config": None,
         "--tls": None,

--- a/tests/functional/cli/cli_test.go
+++ b/tests/functional/cli/cli_test.go
@@ -28,7 +28,7 @@ func ConfirmListening(pid int, proto string) (bool, error) {
 
 func TestHelp(t *testing.T) {
 	t.Parallel()
-	cmd := exec.Command("receptor", "--legacy", "--help")
+	cmd := exec.Command("receptor", "--help")
 	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}
@@ -50,7 +50,7 @@ func TestListeners(t *testing.T) {
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
 			receptorStdOut := bytes.Buffer{}
-			cmd := exec.Command("receptor", "--legacy", "--node", "id=test", listener, "port=0")
+			cmd := exec.Command("receptor", "--node", "id=test", listener, "port=0")
 			cmd.Stdout = &receptorStdOut
 			err := cmd.Start()
 			if err != nil {
@@ -98,7 +98,7 @@ func TestSSLListeners(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			cmd := exec.Command("receptor", "--legacy", "--node", "id=test", "--tls-server", "name=server-tls", fmt.Sprintf("cert=%s", crt), fmt.Sprintf("key=%s", key), listener, fmt.Sprintf("port=%d", port), "tls=server-tls")
+			cmd := exec.Command("receptor", "--node", "id=test", "--tls-server", "name=server-tls", fmt.Sprintf("cert=%s", crt), fmt.Sprintf("key=%s", key), listener, fmt.Sprintf("port=%d", port), "tls=server-tls")
 			cmd.Stdout = &receptorStdOut
 			err = cmd.Start()
 			if err != nil {
@@ -143,7 +143,7 @@ func TestNegativeCost(t *testing.T) {
 		t.Run(listener, func(t *testing.T) {
 			t.Parallel()
 			receptorStdOut := bytes.Buffer{}
-			cmd := exec.Command("receptor", "--legacy", "--node", "id=test", listener, "port=0", "cost=-1")
+			cmd := exec.Command("receptor", "--node", "id=test", listener, "port=0", "cost=-1")
 			cmd.Stdout = &receptorStdOut
 			err := cmd.Start()
 			if err != nil {
@@ -185,7 +185,7 @@ func TestCostMap(t *testing.T) {
 				t.Run(costMapCopy, func(t *testing.T) {
 					t.Parallel()
 					receptorStdOut := bytes.Buffer{}
-					cmd := exec.Command("receptor", "--legacy", "--node", "id=test", listener, "port=0", fmt.Sprintf("nodecost=%s", costMapCopy))
+					cmd := exec.Command("receptor", "--node", "id=test", listener, "port=0", fmt.Sprintf("nodecost=%s", costMapCopy))
 					cmd.Stdout = &receptorStdOut
 					err := cmd.Start()
 					if err != nil {
@@ -235,7 +235,7 @@ func TestCosts(t *testing.T) {
 				t.Run(costCopy, func(t *testing.T) {
 					t.Parallel()
 					receptorStdOut := bytes.Buffer{}
-					cmd := exec.Command("receptor", "--legacy", "--node", "id=test", listener, "port=0", fmt.Sprintf("cost=%s", costCopy))
+					cmd := exec.Command("receptor", "--node", "id=test", listener, "port=0", fmt.Sprintf("cost=%s", costCopy))
 					cmd.Stdout = &receptorStdOut
 					err := cmd.Start()
 					if err != nil {


### PR DESCRIPTION
Changing the flag from `--legacy` to `--latest` so that v1 config is set as the default.  `--legacy` broke backwards compatibility and having v2 with `--latest` will allow for further testing of the new config in the meantime.