### PR TITLE
Update hostnames in getting started guide to be consistent

### DIFF
--- a/docs/source/getting_started_guide/trying_sample_commands.rst
+++ b/docs/source/getting_started_guide/trying_sample_commands.rst
@@ -11,17 +11,17 @@ Try Sample Commands
 
     receptorctl --socket /tmp/foo.sock status
 
-2. Ping node mal from node foo
+2. Ping node baz from node foo
 
 .. code-block:: bash
 
-    receptorctl --socket /tmp/foo.sock ping mal
+    receptorctl --socket /tmp/foo.sock ping baz
 
-3. Submit work from foo to mal and stream results back to foo
+3. Submit work from foo to baz and stream results back to foo
 
 .. code-block:: bash
 
-    seq 10 | receptorctl --socket /tmp/foo.sock work submit --node mal echo --payload - -f
+    seq 10 | receptorctl --socket /tmp/foo.sock work submit --node baz echo --payload - -f
 
 4. List work units
 


### PR DESCRIPTION
In #1043 the hostname of the 3rd example host was changed from `mal` to `baz` in docs/source/getting_started_guide/creating_a_basic_network.rst.  This PR applies the rename to the next page in the guide, docs/source/getting_started_guide/trying_sample_commands.rst.  No further instances of the hostname ` mal ` should be present in the docs with this change.