### PR TITLE
Add debug log for work unit payloads

### DIFF
--- a/docs/source/user_guide/configuration_options.rst
+++ b/docs/source/user_guide/configuration_options.rst
@@ -63,19 +63,21 @@ Log level
       - string
 
 Add payload debuging using `RECEPTOR_PAYLOAD_DEBUG=int` envorment variable and using log level debug.
-... list-table: `RECEPTOR_PAYLOAD_DEBUG` options:
+
+.. list-table:: RECEPTOR_PAYLOAD_DEBUG options
     :header-rows: 1
     :widths: auto
-  * - Debug level
-    - Description
-  * - 0
-    - No payload debug log
-  * - 1
-    - Log connection type
-  * - 2
-    - Log connection type and work unit id
-  * - 3
-    - Log connection type, work unit id and payload
+
+    * - Debug level
+      - Description
+    * - 0
+      - No payload debug log
+    * - 1
+      - Log connection type
+    * - 2
+      - Log connection type and work unit id
+    * - 3
+      - Log connection type, work unit id and payload
 
 **Warning: Payload Debugging May Expose Sensitive Data**
 

--- a/docs/source/user_guide/configuration_options.rst
+++ b/docs/source/user_guide/configuration_options.rst
@@ -63,11 +63,19 @@ Log level
       - string
 
 Add payload debuging using `RECEPTOR_PAYLOAD_DEBUG=int` envorment variable and using log level debug.
-`RECEPTOR_PAYLOAD_DEBUG` options:
-* 0: No payload debug log
-* 1: Log connection type
-* 2: Log connection type and work unit id
-* 3: Log connection type, work unit id and payload
+... list-table: `RECEPTOR_PAYLOAD_DEBUG` options:
+    :header-rows: 1
+    :widths: auto
+  * - Debug level
+    - Description
+  * - 0
+    - No payload debug log
+  * - 1
+    - Log connection type
+  * - 2
+    - Log connection type and work unit id
+  * - 3
+    - Log connection type, work unit id and payload
 
 **Warning: Payload Debugging May Expose Sensitive Data**
 

--- a/docs/source/user_guide/configuration_options.rst
+++ b/docs/source/user_guide/configuration_options.rst
@@ -62,6 +62,9 @@ Log level
       - Error
       - string
 
+Add payload debuging using `RECEPTOR_PAYLOAD_DEBUG=int` envorment variable and using log level debug.
+`RECEPTOR_PAYLOAD_DEBUG` options [0,1,2,3]
+
 .. code-block:: yaml
 
   log-level:

--- a/docs/source/user_guide/configuration_options.rst
+++ b/docs/source/user_guide/configuration_options.rst
@@ -63,7 +63,15 @@ Log level
       - string
 
 Add payload debuging using `RECEPTOR_PAYLOAD_DEBUG=int` envorment variable and using log level debug.
-`RECEPTOR_PAYLOAD_DEBUG` options [0,1,2,3]
+`RECEPTOR_PAYLOAD_DEBUG` options:
+- 0: No payload debug log
+- 1: Log connection type
+- 2: Log connection type and work unit id
+- 3: Log connection type, work unit id and payload
+
+**Warning: Payload Debugging May Expose Sensitive Data**
+
+Please be aware that using payload debugging can potentially reveal sensitive information. This includes, but is not limited to, personal data, authentication tokens, and system configurations. Ensure that you only use debugging tools in a secure environment and avoid sharing debug output with unauthorized users. Always follow your organization's data protection policies when handling sensitive information. Proceed with caution!
 
 .. code-block:: yaml
 

--- a/docs/source/user_guide/configuration_options.rst
+++ b/docs/source/user_guide/configuration_options.rst
@@ -64,10 +64,10 @@ Log level
 
 Add payload debuging using `RECEPTOR_PAYLOAD_DEBUG=int` envorment variable and using log level debug.
 `RECEPTOR_PAYLOAD_DEBUG` options:
-- 0: No payload debug log
-- 1: Log connection type
-- 2: Log connection type and work unit id
-- 3: Log connection type, work unit id and payload
+* 0: No payload debug log
+* 1: Log connection type
+* 2: Log connection type and work unit id
+* 3: Log connection type, work unit id and payload
 
 **Warning: Payload Debugging May Expose Sensitive Data**
 

--- a/docs/source/user_guide/configuration_options.rst
+++ b/docs/source/user_guide/configuration_options.rst
@@ -62,16 +62,16 @@ Log level
       - Error
       - string
 
-Add payload debuging using `RECEPTOR_PAYLOAD_DEBUG=int` envorment variable and using log level debug.
+Add payload tracing using `RECEPTOR_PAYLOAD_TRACE_LEVEL=int` envorment variable and using log level debug.
 
-.. list-table:: RECEPTOR_PAYLOAD_DEBUG options
+.. list-table:: RECEPTOR_PAYLOAD_TRACE_LEVEL options
     :header-rows: 1
     :widths: auto
 
-    * - Debug level
+    * - Tracing level
       - Description
     * - 0
-      - No payload debug log
+      - No payload tracing log
     * - 1
       - Log connection type
     * - 2
@@ -79,9 +79,9 @@ Add payload debuging using `RECEPTOR_PAYLOAD_DEBUG=int` envorment variable and u
     * - 3
       - Log connection type, work unit id and payload
 
-**Warning: Payload Debugging May Expose Sensitive Data**
+**Warning: Payload Tracing May Expose Sensitive Data**
 
-Please be aware that using payload debugging can potentially reveal sensitive information. This includes, but is not limited to, personal data, authentication tokens, and system configurations. Ensure that you only use debugging tools in a secure environment and avoid sharing debug output with unauthorized users. Always follow your organization's data protection policies when handling sensitive information. Proceed with caution!
+Please be aware that using payload tracing can potentially reveal sensitive information. This includes, but is not limited to, personal data, authentication tokens, and system configurations. Ensure that you only use tracing tools in a secure environment and avoid sharing trace output with unauthorized users. Always follow your organization's data protection policies when handling sensitive information. Proceed with caution!
 
 .. code-block:: yaml
 

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -145,6 +145,7 @@ func (s *SockControl) ReadFromConn(message string, out io.Writer, io Copier) err
 		if _, err := out.Write([]byte(data)); err != nil {
 			return err
 		}
+
 		fallthrough
 	case payloadDebug > 0:
 		var connectType string

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -4,6 +4,7 @@
 package controlsvc
 
 import (
+	"bufio"
 	"context"
 	"crypto/tls"
 	"encoding/json"
@@ -122,8 +123,35 @@ func (s *SockControl) ReadFromConn(message string, out io.Writer, io Copier) err
 	if err := s.WriteMessage(message); err != nil {
 		return err
 	}
-	if _, err := io.Copy(out, s.conn); err != nil {
-		return err
+	isPayloadDebug := os.Getenv("RECEPTOR_PAYLOAD_DEBUG")
+	if isPayloadDebug != "" {
+		var data string
+		reader := bufio.NewReader(s.conn)
+
+		for {
+			var connectType string
+			if s.conn.LocalAddr().Network() == "unix" {
+				connectType = "unix socket"
+			} else {
+				connectType = "network connection"
+			}
+			response, err := reader.ReadString('\n')
+			if err != nil {
+				if err.Error() != "EOF" {
+					MainInstance.nc.GetLogger().Error("Error reading from %v: %v \n", connectType, err)
+				}
+				break
+			}
+			data += response
+			MainInstance.nc.GetLogger().Debug("Response from %v: %v", connectType, response)
+		}
+		if _, err := out.Write([]byte(data)); err != nil {
+			return err
+		}
+	} else {
+		if _, err := io.Copy(out, s.conn); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -141,6 +141,7 @@ func (s *SockControl) ReadFromConn(message string, out io.Writer, io Copier) err
 					MainInstance.nc.GetLogger().Error("Error reading from %v: %v \n", connectType, err)
 				}
 				break
+				
 			}
 			data += response
 			MainInstance.nc.GetLogger().Debug("Response from %v: %v", connectType, response)

--- a/pkg/controlsvc/controlsvc.go
+++ b/pkg/controlsvc/controlsvc.go
@@ -140,8 +140,8 @@ func (s *SockControl) ReadFromConn(message string, out io.Writer, io Copier) err
 				if err.Error() != "EOF" {
 					MainInstance.nc.GetLogger().Error("Error reading from %v: %v \n", connectType, err)
 				}
+
 				break
-				
 			}
 			data += response
 			MainInstance.nc.GetLogger().Debug("Response from %v: %v", connectType, response)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -172,7 +172,7 @@ func (rl *ReceptorLogger) DebugPayload(payloadDebug int, payload string, workUni
 		}
 	default:
 	}
-	rl.Debug(fmt.Sprintf("PACKET TRACING ENABLED: %s%s%s", connectionTypeMessage, workunitIDMessage, payloadMessage)) // no-lint: vet
+	rl.Debug(fmt.Sprintf("PACKET TRACING ENABLED: %s%s%s", connectionTypeMessage, workunitIDMessage, payloadMessage))// no-lint:govet
 }
 
 // SanitizedDebug contains extra information helpful to developers.

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -172,7 +172,7 @@ func (rl *ReceptorLogger) DebugPayload(payloadDebug int, payload string, workUni
 		}
 	default:
 	}
-	rl.Debug(fmt.Sprintf("PACKET TRACING ENABLED: %s%s%s", connectionTypeMessage, workunitIDMessage, payloadMessage))
+	rl.Debug(fmt.Sprintf("PACKET TRACING ENABLED: %s%s%s", connectionTypeMessage, workunitIDMessage, payloadMessage)) // no-lint: vet
 }
 
 // SanitizedDebug contains extra information helpful to developers.

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -172,7 +172,7 @@ func (rl *ReceptorLogger) DebugPayload(payloadDebug int, payload string, workUni
 		}
 	default:
 	}
-	rl.Debug(fmt.Sprintf("PACKET TRACING ENABLED: %s%s%s", connectionTypeMessage, workunitIDMessage, payloadMessage))// no-lint:govet
+	rl.Debug(fmt.Sprintf("PACKET TRACING ENABLED: %s%s%s", connectionTypeMessage, workunitIDMessage, payloadMessage)) //nolint:govet
 }
 
 // SanitizedDebug contains extra information helpful to developers.

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -148,6 +148,31 @@ func (rl *ReceptorLogger) Debug(format string, v ...interface{}) {
 	rl.Log(DebugLevel, format, v...)
 }
 
+// Debug payload data.
+func (rl *ReceptorLogger) DebugPayload(payloadDebug int, payload string, workUnitID string, connectionType string) {
+	switch payloadDebug {
+	case 3:
+		if workUnitID != "" {
+			rl.Debug("Work unit %v stdin: %v", workUnitID, payload)
+		} else {
+			rl.Debug("Response reading from conn: %v", payload)
+		}
+
+		fallthrough
+	case 2:
+		if payloadDebug == 2 && workUnitID != "" {
+			rl.Debug("Work unit %v received command\n", workUnitID)
+		}
+
+		fallthrough
+	case 1:
+		if connectionType != "" {
+			rl.Debug("Reading from %v", connectionType)
+		}
+	default:
+	}
+}
+
 // SanitizedDebug contains extra information helpful to developers.
 func (rl *ReceptorLogger) SanitizedDebug(format string, v ...interface{}) {
 	rl.SanitizedLog(DebugLevel, format, v...)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -150,27 +150,29 @@ func (rl *ReceptorLogger) Debug(format string, v ...interface{}) {
 
 // Debug payload data.
 func (rl *ReceptorLogger) DebugPayload(payloadDebug int, payload string, workUnitID string, connectionType string) {
+	var payloadMessage string
+	var workunitIDMessage string
+	var connectionTypeMessage string
 	switch payloadDebug {
 	case 3:
-		if workUnitID != "" {
-			rl.Debug("Work unit %v stdin: %v", workUnitID, payload)
-		} else {
-			rl.Debug("Response reading from conn: %v", payload)
-		}
+		payloadMessage = fmt.Sprintf(" with a payload of: %s", payload)
 
 		fallthrough
 	case 2:
-		if payloadDebug == 2 && workUnitID != "" {
-			rl.Debug("Work unit %v received command\n", workUnitID)
+		if workUnitID != "" {
+			workunitIDMessage = fmt.Sprintf(" with work unit %s", workUnitID)
+		} else {
+			workunitIDMessage = ", work unit not created yet"
 		}
 
 		fallthrough
 	case 1:
 		if connectionType != "" {
-			rl.Debug("Reading from %v", connectionType)
+			connectionTypeMessage = fmt.Sprintf("Reading from %s", connectionType)
 		}
 	default:
 	}
+	rl.Debug(fmt.Sprintf("PACKET TRACING ENABLED: %s%s%s", connectionTypeMessage, workunitIDMessage, payloadMessage))
 }
 
 // SanitizedDebug contains extra information helpful to developers.

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -1,7 +1,9 @@
 package logger_test
 
 import (
+	"bytes"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/ansible/receptor/pkg/logger"
@@ -66,5 +68,55 @@ func TestLogLevelToNameWithError(t *testing.T) {
 	_, err := receptorLogger.LogLevelToName(123)
 	if err == nil {
 		t.Error("should have error")
+	}
+}
+
+func TestDebugPayload(t *testing.T) {
+	logFilePath := "/tmp/test-output"
+	logger.SetGlobalLogLevel(4)
+	receptorLogger := logger.NewReceptorLogger("testDebugPayload")
+	logFile, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Error("error creating test-output file")
+	}
+
+	payload := "Testing debugPayload"
+	workUnitID := "1234"
+	connectionType := "unix socket"
+
+	debugPayloadTestCases := []struct {
+		name           string
+		debugPayload   int
+		payload        string
+		workUnitID     string
+		connectionType string
+		expectedLogs   []string
+	}{
+		{name: "debugPayload no log", debugPayload: 0, payload: "", workUnitID: "", connectionType: "", expectedLogs: []string{}},
+		{name: "debugPayload log level 1", debugPayload: 1, payload: "", workUnitID: "", connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType)}},
+		{name: "debugPayload log level 2 with workUnitID", debugPayload: 2, payload: "", workUnitID: workUnitID, connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType), fmt.Sprintf("Work unit %v received command", workUnitID)}},
+		{name: "debugPayload log level 2 without workUnitID", debugPayload: 2, payload: "", workUnitID: "", connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType)}},
+		{name: "debugPayload log level 3 with workUnitID", debugPayload: 3, payload: payload, workUnitID: workUnitID, connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType), fmt.Sprintf("Work unit %v stdin: %v", workUnitID, payload)}},
+		{name: "debugPayload log level 3 without workUnitID", debugPayload: 3, payload: payload, workUnitID: "", connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType), fmt.Sprintf("Response reading from conn: %v", payload)}},
+	}
+
+	for _, testCase := range debugPayloadTestCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			receptorLogger.SetOutput(logFile)
+			receptorLogger.DebugPayload(testCase.debugPayload, testCase.payload, testCase.workUnitID, testCase.connectionType)
+
+			testOutput, err := os.ReadFile(logFilePath)
+			if err != nil {
+				t.Error("error reading test-output file")
+			}
+			for _, expectedlog := range testCase.expectedLogs {
+				if !bytes.Contains(testOutput, []byte(expectedlog)) {
+					t.Errorf("failed to log correctly, expected: %v got %v", expectedlog, string(testOutput))
+				}
+			}
+			if err := os.Truncate(logFilePath, 0); err != nil {
+				t.Errorf("failed to truncate: %v", err)
+			}
+		})
 	}
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -90,14 +90,16 @@ func TestDebugPayload(t *testing.T) {
 		payload        string
 		workUnitID     string
 		connectionType string
-		expectedLogs   []string
+		expectedLog    string
 	}{
-		{name: "debugPayload no log", debugPayload: 0, payload: "", workUnitID: "", connectionType: "", expectedLogs: []string{}},
-		{name: "debugPayload log level 1", debugPayload: 1, payload: "", workUnitID: "", connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType)}},
-		{name: "debugPayload log level 2 with workUnitID", debugPayload: 2, payload: "", workUnitID: workUnitID, connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType), fmt.Sprintf("Work unit %v received command", workUnitID)}},
-		{name: "debugPayload log level 2 without workUnitID", debugPayload: 2, payload: "", workUnitID: "", connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType)}},
-		{name: "debugPayload log level 3 with workUnitID", debugPayload: 3, payload: payload, workUnitID: workUnitID, connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType), fmt.Sprintf("Work unit %v stdin: %v", workUnitID, payload)}},
-		{name: "debugPayload log level 3 without workUnitID", debugPayload: 3, payload: payload, workUnitID: "", connectionType: connectionType, expectedLogs: []string{fmt.Sprintf("Reading from %v", connectionType), fmt.Sprintf("Response reading from conn: %v", payload)}},
+		{name: "debugPayload no log", debugPayload: 0, payload: "", workUnitID: "", connectionType: "", expectedLog: ""},
+		{name: "debugPayload log level 1", debugPayload: 1, payload: "", workUnitID: "", connectionType: connectionType, expectedLog: fmt.Sprintf("PACKET TRACING ENABLED: Reading from %v", connectionType)},
+		{name: "debugPayload log level 2 with workUnitID", debugPayload: 2, payload: "", workUnitID: workUnitID, connectionType: connectionType, expectedLog: fmt.Sprintf("PACKET TRACING ENABLED: Reading from %v with work unit %v", connectionType, workUnitID)},
+		{name: "debugPayload log level 2 without workUnitID", debugPayload: 2, payload: "", workUnitID: "", connectionType: connectionType, expectedLog: fmt.Sprintf("PACKET TRACING ENABLED: Reading from %v", connectionType)},
+		{name: "debugPayload log level 3 with workUnitID", debugPayload: 3, payload: payload, workUnitID: workUnitID, connectionType: connectionType, expectedLog: fmt.Sprintf("PACKET TRACING ENABLED: Reading from %v with work unit %v with a payload of: %v", connectionType, workUnitID, payload)},
+		{name: "debugPayload log level 3 without workUnitID", debugPayload: 3, payload: payload, workUnitID: "", connectionType: connectionType, expectedLog: fmt.Sprintf("PACKET TRACING ENABLED: Reading from %v, work unit not created yet with a payload of: %v", connectionType, payload)},
+		{name: "debugPayload log level 3 without workUnitID and payload is new line", debugPayload: 3, payload: "\n", workUnitID: "", connectionType: connectionType, expectedLog: fmt.Sprintf("PACKET TRACING ENABLED: Reading from %v, work unit not created yet with a payload of: %v", connectionType, "\n")},
+		{name: "debugPayload log level 3 without workUnitID or payload", debugPayload: 3, payload: "", workUnitID: "", connectionType: connectionType, expectedLog: fmt.Sprintf("PACKET TRACING ENABLED: Reading from %v, work unit not created yet with a payload of: %v", connectionType, "")},
 	}
 
 	for _, testCase := range debugPayloadTestCases {
@@ -109,10 +111,8 @@ func TestDebugPayload(t *testing.T) {
 			if err != nil {
 				t.Error("error reading test-output file")
 			}
-			for _, expectedlog := range testCase.expectedLogs {
-				if !bytes.Contains(testOutput, []byte(expectedlog)) {
-					t.Errorf("failed to log correctly, expected: %v got %v", expectedlog, string(testOutput))
-				}
+			if !bytes.Contains(testOutput, []byte(testCase.expectedLog)) {
+				t.Errorf("failed to log correctly, expected: %v got %v", testCase.expectedLog, string(testOutput))
 			}
 			if err := os.Truncate(logFilePath, 0); err != nil {
 				t.Errorf("failed to truncate: %v", err)

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -118,7 +118,7 @@ func commandRunner(command string, params string, unitdir string) error {
 	if isPayloadDebug != "" {
 		var data string
 		splitUnitDir := strings.Split(unitdir, "/")
-		workUnitID := splitUnitDir[len(splitUnitDir) - 1]
+		workUnitID := splitUnitDir[len(splitUnitDir)-1]
 		reader := bufio.NewReader(stdin)
 		stdinStream, err := cmd.StdinPipe()
 		if err != nil {

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -131,6 +131,7 @@ func commandRunner(command string, params string, unitdir string) error {
 					MainInstance.nc.GetLogger().Error("Error reading work unit %v stdin: %v\n", workUnitID, err)
 				}
 				break
+				
 			}
 			data += response
 			MainInstance.nc.GetLogger().Debug("Work unit %v stdin: %v", workUnitID, response)

--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -130,8 +130,8 @@ func commandRunner(command string, params string, unitdir string) error {
 				if err.Error() != "EOF" {
 					MainInstance.nc.GetLogger().Error("Error reading work unit %v stdin: %v\n", workUnitID, err)
 				}
+
 				break
-				
 			}
 			data += response
 			MainInstance.nc.GetLogger().Debug("Work unit %v stdin: %v", workUnitID, response)

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -8,6 +8,8 @@ import (
 	"io"
 	"os"
 	"path"
+	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -111,6 +113,7 @@ func (sw *STDoutWriter) SetWriter(writer FileWriteCloser) {
 // STDinReader reads from a stdin file and provides a Done function.
 type STDinReader struct {
 	reader   FileReadCloser
+	workUnit string
 	lasterr  error
 	doneChan chan struct{}
 	doneOnce sync.Once
@@ -120,6 +123,8 @@ var errFileSizeZero = errors.New("file is empty")
 
 // NewStdinReader allocates a new stdinReader, which reads from a stdin file and provides a Done function.
 func NewStdinReader(fs FileSystemer, unitdir string) (*STDinReader, error) {
+	splitUnitDir := strings.Split(unitdir, "/")
+	workUnitID := splitUnitDir[len(splitUnitDir)-1]
 	stdinpath := path.Join(unitdir, "stdin")
 	stat, err := fs.Stat(stdinpath)
 	if err != nil {
@@ -135,6 +140,7 @@ func NewStdinReader(fs FileSystemer, unitdir string) (*STDinReader, error) {
 
 	return &STDinReader{
 		reader:   reader,
+		workUnit: workUnitID,
 		lasterr:  nil,
 		doneChan: make(chan struct{}),
 		doneOnce: sync.Once{},
@@ -143,6 +149,23 @@ func NewStdinReader(fs FileSystemer, unitdir string) (*STDinReader, error) {
 
 // Read reads data from the stdout file, implementing io.Reader.
 func (sr *STDinReader) Read(p []byte) (n int, err error) {
+	payloadDebug, _ := strconv.Atoi(os.Getenv("RECEPTOR_PAYLOAD_TRACE_LEVEL"))
+
+	if payloadDebug != 0 {
+		isNotEmpty := func() bool {
+			for _, v := range p {
+				if v != 0 {
+					return true
+				}
+			}
+
+			return false
+		}()
+		if isNotEmpty {
+			payload := string(p)
+			MainInstance.nc.GetLogger().DebugPayload(payloadDebug, payload, sr.workUnit, "")
+		}
+	}
 	n, err = sr.reader.Read(p)
 	if err != nil {
 		sr.lasterr = err

--- a/pkg/workceptor/stdio_utils.go
+++ b/pkg/workceptor/stdio_utils.go
@@ -163,7 +163,7 @@ func (sr *STDinReader) Read(p []byte) (n int, err error) {
 		}()
 		if isNotEmpty {
 			payload := string(p)
-			MainInstance.nc.GetLogger().DebugPayload(payloadDebug, payload, sr.workUnit, "")
+			MainInstance.nc.GetLogger().DebugPayload(payloadDebug, payload, sr.workUnit, "kube api")
 		}
 	}
 	n, err = sr.reader.Read(p)


### PR DESCRIPTION
Add debug log for work unit payloads using RECEPTOR_PAYLOAD_DEBUG env var

Control output:
![Screenshot from 2024-09-18 13-11-28](https://github.com/user-attachments/assets/6f14a108-b1f6-4971-b935-dff8cc3343c4)

Control status:
![Screenshot from 2024-09-18 13-04-05](https://github.com/user-attachments/assets/8f0fa725-769c-4db4-b9a2-1c876510fbf1)

Execution output:
![image](https://github.com/user-attachments/assets/5c42f73d-5f53-492b-be31-292b9b546aa1)

![Screenshot from 2024-09-18 13-04-33](https://github.com/user-attachments/assets/2e6d66ce-d1f9-4df1-a6e3-28fb1d831f74)
