### PR TITLE
Convert test coverage report to junit format

### DIFF
--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -1,0 +1,65 @@
+---
+name: Generate junit test report
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:  # yamllint disable-line rule:empty-values
+  push:
+    branches: [devel]
+
+env:
+  DESIRED_GO_VERSION: '1.20'
+
+jobs:
+  go_test_coverage:
+    name: go test coverage
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.DESIRED_GO_VERSION }}
+
+      - name: build and install receptor
+        run: |
+          make build-all
+          sudo cp ./receptor /usr/local/bin/receptor
+
+      - name: Download kind binary
+        run: curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 && chmod +x ./kind
+
+      - name: Create k8s cluster
+        run: ./kind create cluster
+
+      - name: Interact with the cluster
+        run: kubectl get nodes
+
+      - name: Run receptor tests with coverage
+        run: make coverage -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
+
+      - name: get k8s logs
+        if: ${{ failure() }}
+        run: .github/workflows/artifact-k8s-logs.sh
+
+      - name: remove sockets before archiving logs
+        if: ${{ failure() }}
+        run: find /tmp/receptor-testing -name controlsock -delete
+
+      - name: Artifact receptor data
+        uses: actions/upload-artifact@v4.4.0
+        if: ${{ failure() }}
+        with:
+          name: test-logs
+          path: /tmp/receptor-testing
+
+      - name: Archive receptor binary
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: receptor
+          path: /usr/local/bin/receptor

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -43,8 +43,7 @@ jobs:
       - name: Install go junit reporting
         run: make go-junit-report
 
-      - name: Run receptor tests with coverage
-        run: make coverage -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
+      - name: Run receptor tests
         run: PATH="${PWD}:${PATH}" go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
 
       - name: get k8s logs

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -41,7 +41,7 @@ jobs:
         run: kubectl get nodes
 
       - name: Install go junit reporting
-        run: make go-junit-report
+        run: go install github.com/jstemmer/go-junit-report/v2@latest
 
       - name: Run receptor tests
         run: PATH="${PWD}:${PATH}" go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -44,7 +44,7 @@ jobs:
         run: go install github.com/jstemmer/go-junit-report/v2@latest
 
       - name: Run receptor tests
-        run: go test -v 2>&1 ./...
+        run: go test -v 2>&1 ./... | go-junit-report > report.xml
 
       - name: get k8s logs
         if: ${{ failure() }}

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -44,7 +44,6 @@ jobs:
         run: go install github.com/jstemmer/go-junit-report/v2@latest
 
       - name: Run receptor tests
-        run: PATH="${PWD}:${PATH}" go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
         run: go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
 
       - name: get k8s logs

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -46,7 +46,6 @@ jobs:
       - name: Run receptor tests
         run: go test -v 2>&1 ./... | go-junit-report > report.xml
 
-
       - name: get k8s logs
         if: ${{ failure() }}
         run: .github/workflows/artifact-k8s-logs.sh

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Run receptor tests
         run: PATH="${PWD}:${PATH}" go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
+        run: go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
 
       - name: get k8s logs
         if: ${{ failure() }}

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -40,8 +40,12 @@ jobs:
       - name: Interact with the cluster
         run: kubectl get nodes
 
+      - name: Install go junit reporting
+        run: make go-junit-report
+
       - name: Run receptor tests with coverage
         run: make coverage -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
+        run: PATH="${PWD}:${PATH}" go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
 
       - name: get k8s logs
         if: ${{ failure() }}

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Run receptor tests
         run: go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
+        run: go test -v 2>&1 ./...
 
       - name: get k8s logs
         if: ${{ failure() }}

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -21,9 +21,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -48,6 +45,9 @@ jobs:
 
       - name: Run receptor tests
         run: go test -v 2>&1 ./... | go-junit-report > report.xml
+
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
 
       - name: get k8s logs
         if: ${{ failure() }}

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -44,7 +44,6 @@ jobs:
         run: go install github.com/jstemmer/go-junit-report/v2@latest
 
       - name: Run receptor tests
-        run: go test -v 2>&1 ./... | go-junit-report -set-exit-code > report.xml
         run: go test -v 2>&1 ./...
 
       - name: get k8s logs

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -46,8 +46,6 @@ jobs:
       - name: Run receptor tests
         run: go test -v 2>&1 ./... | go-junit-report > report.xml
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
 
       - name: get k8s logs
         if: ${{ failure() }}

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,20 @@ build-package:
 	cd dist/ && \
 	$(CHECKSUM_PROGRAM) $(DIST).tar.gz >> checksums.txt
 
+GO-JUNIT-REPORT = $(shell pwd)/go-junit-report
+go-junit-report: ## Download go-junit-report locally if necessary.
+ifeq (,$(wildcard $(GO-JUNIT-REPORT)))
+ifeq (,$(shell which go-junit-report 2>/dev/null))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(GO-JUNIT-REPORT)) ;\
+	GOBIN=$(dir $(GO-JUNIT-REPORT)) $(GO) install github.com/jstemmer/go-junit-report/v2@latest;\
+	}
+else
+GO-JUNIT-REPORT = $(shell which go-junit-report)
+endif
+endif
+
 RUNTEST ?=
 ifeq ($(RUNTEST),)
 TESTCMD =
@@ -227,4 +241,4 @@ tc-image: container
 	@cp receptor packaging/tc-image/
 	@$(CONTAINERCMD) build packaging/tc-image -t receptor-tc
 
-.PHONY: lint format fmt pre-commit build-all test clean testloop container version receptorctl-tests kubetest
+.PHONY: lint format fmt pre-commit build-all test clean testloop container version receptorctl-tests kubetest go-junit-report

--- a/Makefile
+++ b/Makefile
@@ -140,20 +140,6 @@ build-package:
 	cd dist/ && \
 	$(CHECKSUM_PROGRAM) $(DIST).tar.gz >> checksums.txt
 
-GO-JUNIT-REPORT = $(shell pwd)/go-junit-report
-go-junit-report: ## Download go-junit-report locally if necessary.
-ifeq (,$(wildcard $(GO-JUNIT-REPORT)))
-ifeq (,$(shell which go-junit-report 2>/dev/null))
-	@{ \
-	set -e ;\
-	mkdir -p $(dir $(GO-JUNIT-REPORT)) ;\
-	GOBIN=$(dir $(GO-JUNIT-REPORT)) go install github.com/jstemmer/go-junit-report/v2@latest;\
-	}
-else
-GO-JUNIT-REPORT = $(shell which go-junit-report)
-endif
-endif
-
 RUNTEST ?=
 ifeq ($(RUNTEST),)
 TESTCMD =
@@ -241,4 +227,4 @@ tc-image: container
 	@cp receptor packaging/tc-image/
 	@$(CONTAINERCMD) build packaging/tc-image -t receptor-tc
 
-.PHONY: lint format fmt pre-commit build-all test clean testloop container version receptorctl-tests kubetest go-junit-report
+.PHONY: lint format fmt pre-commit build-all test clean testloop container version receptorctl-tests kubetest

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ ifeq (,$(shell which go-junit-report 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(GO-JUNIT-REPORT)) ;\
-	GOBIN=$(dir $(GO-JUNIT-REPORT)) $(GO) install github.com/jstemmer/go-junit-report/v2@latest;\
+	GOBIN=$(dir $(GO-JUNIT-REPORT)) go install github.com/jstemmer/go-junit-report/v2@latest;\
 	}
 else
 GO-JUNIT-REPORT = $(shell which go-junit-report)


### PR DESCRIPTION
To track the test results from receptor we need them to be in a JUnit compatible format. This PR adds https://github.com/jstemmer/go-junit-report to convert the test output into an xml report.