### PR TITLE
Replace centos stream 9 with ubi9 for container

### DIFF
--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1726694543 AS builder
 ARG VERSION
 
 RUN dnf -y update && \
@@ -9,7 +9,7 @@ ADD source.tar.gz /source
 WORKDIR /source
 RUN make VERSION=${VERSION}
 
-FROM quay.io/centos/centos:stream9
+FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1726694543
 ARG VERSION
 
 LABEL license="ASL2"


### PR DESCRIPTION
Replace centos stream 9 with ubi9 for container to fix mirror list issue in centos stream 9