### PR TITLE
Correct coverage targets

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -40,3 +40,7 @@ component_management:
       name: Receptorctl
       paths:
         - receptorctl/**
+ignore:
+  - "**/*_test.go"
+  - "receptorctl/tests"
+  - "tests"


### PR DESCRIPTION
As recommended by codecov.com, we exclude the tests (go, python, functional) from the code coverage report