### PR TITLE
dependabot ignore unsupported go versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,9 @@ updates:
     labels:
       - "dependencies"
       - "go"
+    ignore:
+      - dependency-name: "golang"
+        versions: ["1.23", "1.24"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
dependabot ignore unsupported go versions