### PR TITLE
Update example config syntax

### DIFF
--- a/docs/source/getting_started_guide/creating_a_basic_network.rst
+++ b/docs/source/getting_started_guide/creating_a_basic_network.rst
@@ -24,20 +24,18 @@ Receptor configurations
 
 .. code-block:: yaml
 
-  ---
-  version: 2
-  node:
-    id: foo
+  - node:
+      id: foo
 
-  control-services:
-    - service: control
+  - control-service:
+      service: control
       filename: /tmp/foo.sock
 
-  tcp-peers:
-    - address: localhost:2222
+  - tcp-peer:
+      address: localhost:2222
 
-  log-level:
-    level: debug
+  - log-level:
+      level: debug
 
   ...
 
@@ -46,19 +44,18 @@ Receptor configurations
 .. code-block:: yaml
 
   ---
-  version: 2
-  node:
-    id: bar
+  - node:
+      id: bar
 
-  control-services:
-    - service: control
+  - control-service:
+      service: control
       filename: /tmp/bar.sock
 
-  tcp-listeners:
-    - port: 2222
+  - tcp-listener:
+      port: 2222
 
-  log-level:
-    level: debug
+  - log-level:
+      level: debug
 
   ...
 
@@ -67,19 +64,18 @@ Receptor configurations
 .. code-block:: yaml
 
   ---
-  version: 2
-  node:
-    id: baz
+  - node:
+      id: baz
 
-  control-services:
-    - service: control
+  - control-service:
+      service: control
       filename: /tmp/baz.sock
 
-  tcp-peers:
-    - address: localhost:2222
+  - tcp-peer:
+      address: localhost:2222
 
-  log-level:
-    level: debug
+  - log-level:
+      level: debug
 
   - work-command:
       workType: echo


### PR DESCRIPTION
With documented config at https://ansible.readthedocs.io/projects/receptor/en/devel/getting_started_guide/creating_a_basic_network.html, `receptor` fails to start because it cannot parse the config:

```
$ ./receptor --config foo.yml
Error: error loading config file: yaml: unmarshal errors:
  line 2: cannot unmarshal !!map into []interface {}
```

I updated the structure/syntax, these proceed:

```
$ ./receptor --config foo.yml
...
DEBUG 2025/01/27 16:42:36 foo added service control to listener registry
INFO 2025/01/27 16:42:36 Running control service control
DEBUG 2025/01/27 16:42:36 Running TCP peer connection localhost:2222
INFO 2025/01/27 16:42:36 Connection to baz failed with error: context canceled
INFO 2025/01/27 16:42:36 Initialization complete
...
```
