### PR TITLE
Add unit tests to internal version package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ recepcert
 /net
 .container-flag*
 .VERSION
+.python-version
 kubectl
 /receptorctl/.nox
 /receptorctl/.VERSION

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -102,6 +102,7 @@ linters-settings:
           - "github.com/quic-go/quic-go"
           - "github.com/quic-go/quic-go/logging"
           - "github.com/AaronH88/quic-go"
+          - "github.com/stretchr/testify/assert"
 
 issues:
   # Dont commit the following line.

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,10 @@ require (
 	k8s.io/client-go v0.31.3
 )
 
-require github.com/stretchr/testify v1.10.0 // indirect
+require (
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,11 +15,8 @@ type cmdlineCfg struct{}
 
 // Run runs the action.
 func (cfg cmdlineCfg) Run() error {
-	if Version == "" {
-		fmt.Printf("Version unknown\n")
-	} else {
-		fmt.Printf("%s\n", Version)
-	}
+	validateVersion()
+	fmt.Printf("%s\n", Version)
 
 	return nil
 }
@@ -31,4 +28,12 @@ func init() {
 	}
 	cmdline.RegisterConfigTypeForApp("receptor-version",
 		"version", "Displays the Receptor version.", cmdlineCfg{}, cmdline.Exclusive)
+}
+
+func validateVersion() string {
+	if Version == "" {
+		return "Version unknown"
+	} else {
+		return Version
+	}
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,37 @@
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateVersion(t *testing.T) {
+	type test struct {
+		name     string
+		input    string
+		expected string
+	}
+
+	for _, tt := range []*test{
+		{
+			name:     "version is empty string",
+			input:    "",
+			expected: "Version unknown",
+		},
+		{
+			name:     "version is zero",
+			input:    "0",
+			expected: "0",
+		},
+		{
+			name:     "version is one",
+			input:    "1",
+			expected: "1",
+		},
+	} {
+		Version = tt.input
+		output := validateVersion()
+		assert.Equal(t, tt.expected, output)
+	}
+}


### PR DESCRIPTION
Extremely small refactor to make it easier to capture the output for version here.