### PR TITLE
Fix coverage of TestTCPProxyServiceOutbound function in tcp_proxy.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/ghjm/cmdline v0.1.2
-	github.com/golang-jwt/jwt/v4 v4.5.1
+	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/google/go-cmp v0.6.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZ
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -38,9 +38,9 @@ type QuicConnectionForConn interface {
 	quic.Connection
 }
 
-type acceptResult struct {
-	conn net.Conn
-	err  error
+type AcceptResult struct {
+	Conn net.Conn
+	Err  error
 }
 
 // Listener implements the net.Listener interface via the Receptor network.
@@ -48,8 +48,8 @@ type Listener struct {
 	s          *Netceptor
 	pc         PacketConner
 	ql         *quic.Listener
-	acceptChan chan *acceptResult
-	doneChan   chan struct{}
+	AcceptChan chan *AcceptResult
+	DoneChan   chan struct{}
 	doneOnce   *sync.Once
 }
 
@@ -135,8 +135,8 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		s:          s,
 		pc:         pc,
 		ql:         ql,
-		acceptChan: make(chan *acceptResult),
-		doneChan:   doneChan,
+		AcceptChan: make(chan *AcceptResult),
+		DoneChan:   doneChan,
 		doneOnce:   &sync.Once{},
 	}
 
@@ -187,11 +187,11 @@ func (li *Listener) sendResult(ctx context.Context, conn net.Conn, err error) {
 	select {
 	case <-ctx.Done():
 		return
-	case li.acceptChan <- &acceptResult{
-		conn: conn,
-		err:  err,
+	case li.AcceptChan <- &AcceptResult{
+		Conn: conn,
+		Err:  err,
 	}:
-	case <-li.doneChan:
+	case <-li.DoneChan:
 	}
 }
 
@@ -200,13 +200,13 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-li.doneChan:
+		case <-li.DoneChan:
 			return
 		default:
 		}
 		qc, err := li.ql.Accept(ctx)
 		select {
-		case <-li.doneChan:
+		case <-li.DoneChan:
 			return
 		default:
 		}
@@ -220,7 +220,7 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 			defer cancel()
 			qs, err := qc.AcceptStream(ctx)
 			select {
-			case <-li.doneChan:
+			case <-li.DoneChan:
 				_ = qc.CloseWithError(500, "Listener Closed")
 
 				return
@@ -267,7 +267,7 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 			}
 			go func() {
 				select {
-				case <-li.doneChan:
+				case <-li.DoneChan:
 					_ = conn.Close()
 				case <-cctx.Done():
 					_ = conn.Close()
@@ -283,9 +283,9 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 // Accept accepts a connection via the listener.
 func (li *Listener) Accept() (net.Conn, error) {
 	select {
-	case ar := <-li.acceptChan:
-		return ar.conn, ar.err
-	case <-li.doneChan:
+	case ar := <-li.AcceptChan:
+		return ar.Conn, ar.Err
+	case <-li.DoneChan:
 		return nil, fmt.Errorf("listener closed")
 	}
 }
@@ -293,7 +293,7 @@ func (li *Listener) Accept() (net.Conn, error) {
 // Close closes the listener.
 func (li *Listener) Close() error {
 	li.doneOnce.Do(func() {
-		close(li.doneChan)
+		close(li.DoneChan)
 	})
 	perr := li.pc.Close()
 	if qerr := li.ql.Close(); qerr != nil {

--- a/pkg/services/tcp_proxy_test.go
+++ b/pkg/services/tcp_proxy_test.go
@@ -122,16 +122,20 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 	var mockNetceptor *mock_services.MockNetcForTCPProxy
 	var mockNetLib *mock_services.MockNetLib
 	var mockTLSLib *mock_services.MockTLSLib
-	var mockNetListener *mock_services.MockNetListenerTCP
 	var mockUtilsLib *mock_services.MockUtilsLib
+	var mockTCPConn *mock_services.MockTCPConn
+
+	myListener := netceptor.Listener{
+		AcceptChan: make(chan *netceptor.AcceptResult),
+		DoneChan:   make(chan struct{}),
+	}
 
 	type testCoverageItem struct {
 		name                 string
 		expectError          bool
 		expectedErrorMessage string
-		service              string
-		address              string
 		tlsClientConfig      *tls.Config
+		myAcceptResult       netceptor.AcceptResult
 		calls                func()
 	}
 	testCases := []testCoverageItem{
@@ -145,34 +149,47 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 		},
 		{
 			name: "Fail to accept input connections",
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: nil,
+				Err:  errors.New("connection acceptance failed"),
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(nil, errors.New("connection acceptance failed")).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 			},
 		},
 		{
 			name:            "Fail to dial through non-TLS TCP connection",
 			tlsClientConfig: nil,
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: mockTCPConn,
+				Err:  nil,
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(&netceptor.Conn{}, nil).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockNetLib.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(nil, errors.New("non-TLS TCP dial failed")).AnyTimes()
 			},
 		},
 		{
 			name:            "Fail to dial through TLS TCP connection",
 			tlsClientConfig: &tls.Config{},
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: mockTCPConn,
+				Err:  nil,
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(&netceptor.Conn{}, nil).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockTLSLib.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("TLS TCP dial failed")).AnyTimes()
 			},
 		},
 		{
-			name: "Complete connection bridge after successful non-TLS connection",
+			name:            "Complete connection bridge after successful non-TLS connection",
+			tlsClientConfig: &tls.Config{},
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: mockTCPConn,
+				Err:  nil,
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(&netceptor.Conn{}, nil).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockTLSLib.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tls.Conn{}, nil).AnyTimes()
 				mockUtilsLib.EXPECT().BridgeConns(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
@@ -181,9 +198,12 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockNetceptor, mockNetLib, mockTLSLib, mockNetListener, mockUtilsLib, _ = setUpTCPMocks(ctrl)
+			mockNetceptor, mockNetLib, mockTLSLib, _, mockUtilsLib, mockTCPConn = setUpTCPMocks(ctrl)
 			tc.calls()
-			err := TCPProxyServiceOutbound(mockNetceptor, tc.service, &tls.Config{}, tc.address, tc.tlsClientConfig, mockNetLib, mockTLSLib, mockUtilsLib)
+			go func() {
+				myListener.AcceptChan <- &tc.myAcceptResult
+			}()
+			err := TCPProxyServiceOutbound(mockNetceptor, "", &tls.Config{}, "", tc.tlsClientConfig, mockNetLib, mockTLSLib, mockUtilsLib)
 			if tc.expectError {
 				if err == nil {
 					t.Errorf("TCPProxyServiceOutbound case failed to raise error")

--- a/pkg/services/tcp_proxy_test.go
+++ b/pkg/services/tcp_proxy_test.go
@@ -102,7 +102,6 @@ func TestTCPProxyServiceInbound(t *testing.T) {
 			mockNetceptor, mockNetLib, mockTLSLib, mockNetListener, mockUtilsLib, mockTCPConn = setUpTCPMocks(ctrl)
 			tc.calls()
 			err := TCPProxyServiceInbound(mockNetceptor, tc.host, tc.port, tc.tlsServerConfig, tc.node, tc.service, tc.tlsClientConfig, mockNetLib, mockTLSLib, mockUtilsLib)
-			// netceptor.MainInstance.GetServerTLSConfig = func(name string) (*tls.Config, error) {return nil, nil}
 			if tc.expectError {
 				if err == nil {
 					t.Errorf("TCPProxyServiceInbound failed to raise error")
@@ -200,9 +199,10 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 
 func TestTCPProxyInboundCfgRun(t *testing.T) {
 	type testCoverageItem struct {
-		name        string
-		expectError bool
-		configObj   TCPProxyInboundCfg
+		name                 string
+		expectError          bool
+		expectedErrorMessage string
+		configObj            TCPProxyInboundCfg
 	}
 
 	testCases := []testCoverageItem{
@@ -215,8 +215,9 @@ func TestTCPProxyInboundCfgRun(t *testing.T) {
 			},
 		},
 		{
-			name:        "Required parameters set wrong TLS Client Config",
-			expectError: true,
+			name:                 "Required parameters set wrong TLS Client Config",
+			expectError:          true,
+			expectedErrorMessage: "unknown TLS config gibberish",
 			configObj: TCPProxyInboundCfg{
 				Port:          8000,
 				RemoteNode:    "",
@@ -225,8 +226,9 @@ func TestTCPProxyInboundCfgRun(t *testing.T) {
 			},
 		},
 		{
-			name:        "Required parameters set wrong TLS Server Config",
-			expectError: true,
+			name:                 "Required parameters set wrong TLS Server Config",
+			expectError:          true,
+			expectedErrorMessage: "unknown TLS config gibberish",
 			configObj: TCPProxyInboundCfg{
 				Port:          8000,
 				RemoteNode:    "",
@@ -239,8 +241,14 @@ func TestTCPProxyInboundCfgRun(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.configObj.Run()
-			if !tc.expectError && err != nil {
-				t.Errorf("This test case wasn't expected to return an error")
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Test case failed to raise error")
+				} else if tc.expectedErrorMessage != err.Error() {
+					t.Errorf("Test expected error message: '%s', but got: '%s'", tc.expectedErrorMessage, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("This test case wasn't expected to return an error: '%s'", err.Error())
 			}
 		})
 	}
@@ -248,9 +256,10 @@ func TestTCPProxyInboundCfgRun(t *testing.T) {
 
 func TestTCPProxyOutboundCfgRun(t *testing.T) {
 	type testCoverageItem struct {
-		name        string
-		expectError bool
-		configObj   TCPProxyOutboundCfg
+		name                 string
+		expectError          bool
+		expectedErrorMessage string
+		configObj            TCPProxyOutboundCfg
 	}
 
 	testCases := []testCoverageItem{
@@ -262,8 +271,9 @@ func TestTCPProxyOutboundCfgRun(t *testing.T) {
 			},
 		},
 		{
-			name:        "Required parameters set wrong TLS Server Config",
-			expectError: true,
+			name:                 "Required parameters set wrong TLS Server Config",
+			expectError:          true,
+			expectedErrorMessage: "unknown TLS config gibberish",
 			configObj: TCPProxyOutboundCfg{
 				Service:   "",
 				Address:   "0.0.0.0:8000",
@@ -271,16 +281,18 @@ func TestTCPProxyOutboundCfgRun(t *testing.T) {
 			},
 		},
 		{
-			name:        "Required parameters set missing port in Address",
-			expectError: true,
+			name:                 "Required parameters set missing port in Address",
+			expectError:          true,
+			expectedErrorMessage: "address 0.0.0.0: missing port in address",
 			configObj: TCPProxyOutboundCfg{
 				Service: "",
 				Address: "0.0.0.0",
 			},
 		},
 		{
-			name:        "Required parameters set wrong TLS Client Config",
-			expectError: true,
+			name:                 "Required parameters set wrong TLS Client Config",
+			expectError:          true,
+			expectedErrorMessage: "unknown TLS config gibberish",
 			configObj: TCPProxyOutboundCfg{
 				Service:   "",
 				Address:   "0.0.0.0:8000",
@@ -292,8 +304,14 @@ func TestTCPProxyOutboundCfgRun(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.configObj.Run()
-			if !tc.expectError && err != nil {
-				t.Errorf("This test case wasn't expected to return an error: %s", err)
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Test case failed to raise error")
+				} else if tc.expectedErrorMessage != err.Error() {
+					t.Errorf("Test expected error message: '%s', but got: '%s'", tc.expectedErrorMessage, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("This test case wasn't expected to return an error: '%s'", err.Error())
 			}
 		})
 	}

--- a/pkg/services/tcp_proxy_test.go
+++ b/pkg/services/tcp_proxy_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"testing"
@@ -192,6 +193,107 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 				}
 			} else if err != nil {
 				t.Errorf("TCPProxyServiceOutbound unexpected case error")
+			}
+		})
+	}
+}
+
+func TestTCPProxyInboundCfgRun(t *testing.T) {
+	type testCoverageItem struct {
+		name        string
+		expectError bool
+		configObj   TCPProxyInboundCfg
+	}
+
+	testCases := []testCoverageItem{
+		{
+			name: "Required parameters set no errors raised",
+			configObj: TCPProxyInboundCfg{
+				Port:          8000,
+				RemoteNode:    "",
+				RemoteService: "",
+			},
+		},
+		{
+			name:        "Required parameters set wrong TLS Client Config",
+			expectError: true,
+			configObj: TCPProxyInboundCfg{
+				Port:          8000,
+				RemoteNode:    "",
+				RemoteService: "",
+				TLSClient:     "gibberish",
+			},
+		},
+		{
+			name:        "Required parameters set wrong TLS Server Config",
+			expectError: true,
+			configObj: TCPProxyInboundCfg{
+				Port:          8000,
+				RemoteNode:    "",
+				RemoteService: "",
+				TLSServer:     "gibberish",
+			},
+		},
+	}
+	netceptor.MainInstance = netceptor.New(context.Background(), "test_tcp_proxy_inbound_cfg_run")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.configObj.Run()
+			if !tc.expectError && err != nil {
+				t.Errorf("This test case wasn't expected to return an error")
+			}
+		})
+	}
+}
+
+func TestTCPProxyOutboundCfgRun(t *testing.T) {
+	type testCoverageItem struct {
+		name        string
+		expectError bool
+		configObj   TCPProxyOutboundCfg
+	}
+
+	testCases := []testCoverageItem{
+		{
+			name: "Required parameters set no errors raised",
+			configObj: TCPProxyOutboundCfg{
+				Service: "",
+				Address: "0.0.0.0:8000",
+			},
+		},
+		{
+			name:        "Required parameters set wrong TLS Server Config",
+			expectError: true,
+			configObj: TCPProxyOutboundCfg{
+				Service:   "",
+				Address:   "0.0.0.0:8000",
+				TLSServer: "gibberish",
+			},
+		},
+		{
+			name:        "Required parameters set missing port in Address",
+			expectError: true,
+			configObj: TCPProxyOutboundCfg{
+				Service: "",
+				Address: "0.0.0.0",
+			},
+		},
+		{
+			name:        "Required parameters set wrong TLS Client Config",
+			expectError: true,
+			configObj: TCPProxyOutboundCfg{
+				Service:   "",
+				Address:   "0.0.0.0:8000",
+				TLSClient: "gibberish",
+			},
+		},
+	}
+	netceptor.MainInstance = netceptor.New(context.Background(), "test_tcp_proxy_outbound_cfg_run")
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.configObj.Run()
+			if !tc.expectError && err != nil {
+				t.Errorf("This test case wasn't expected to return an error: %s", err)
 			}
 		})
 	}

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -379,6 +379,25 @@ func (kw *KubeUnit) KubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 
 					return
 				}
+
+				if err == io.EOF {
+					if line != "" {
+						_, err = stdout.Write([]byte(line + "\n"))
+						if err != nil {
+							*stdoutErr = fmt.Errorf("writing final line to stdout: %s", err)
+							kw.GetWorkceptor().nc.GetLogger().Error("Error writing final line to stdout: %s", err)
+
+							return
+						}
+					}
+					kw.GetWorkceptor().nc.GetLogger().Info("Detected EOF for pod %s/%s.",
+						podNamespace,
+						podName,
+					)
+
+					return
+				}
+
 				kw.GetWorkceptor().nc.GetLogger().Info(
 					"Detected Error: %s for pod %s/%s. Will retry %d more times.",
 					err,
@@ -439,7 +458,6 @@ func (kw *KubeUnit) KubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 			remainingRetries = retries // each time we read successfully, reset this counter
 			successfulWrite = true
 		}
-
 		logStream.Close()
 	}
 }

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -541,6 +541,51 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 				mockKubeAPI.EXPECT().NewSPDYExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(&exec, nil).AnyTimes()
 			},
 		},
+		{
+			name: "Kube error 503",
+			expectedCalls: func() {
+				mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				config := rest.Config{}
+				mockKubeAPI.EXPECT().InClusterConfig().Return(&config, nil)
+				mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
+				clientset := kubernetes.Clientset{}
+				mockKubeAPI.EXPECT().NewForConfig(gomock.Any()).Return(&clientset, nil)
+				lock := &sync.RWMutex{}
+				mockBaseWorkUnit.EXPECT().GetStatusLock().Return(lock).AnyTimes()
+				mockBaseWorkUnit.EXPECT().MonitorLocalStatus().AnyTimes()
+				mockBaseWorkUnit.EXPECT().UnitDir().Return("TestDir2").AnyTimes()
+				kubeExtraData := workceptor.KubeExtraData{}
+				status := workceptor.StatusFileData{ExtraData: &kubeExtraData}
+				mockBaseWorkUnit.EXPECT().GetStatusWithoutExtraData().Return(&status).AnyTimes()
+				mockBaseWorkUnit.EXPECT().GetStatusCopy().Return(status).AnyTimes()
+				mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
+				pod := corev1.Pod{TypeMeta: metav1.TypeMeta{}, ObjectMeta: metav1.ObjectMeta{Name: "Test_Name"}, Spec: corev1.PodSpec{}, Status: corev1.PodStatus{}}
+				mockKubeAPI.EXPECT().Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&pod, nil).AnyTimes()
+				mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).AnyTimes()
+				field := hasTerm{}
+				mockKubeAPI.EXPECT().OneTermEqualSelector(gomock.Any(), gomock.Any()).Return(&field).AnyTimes()
+				ev := watch.Event{Object: &pod}
+				mockKubeAPI.EXPECT().UntilWithSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&ev, nil).AnyTimes()
+				mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&pod, nil).AnyTimes()
+				req := fakerest.RESTClient{
+					Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+						resp := &http.Response{
+							StatusCode: http.StatusServiceUnavailable, // 503
+							Body:       io.NopCloser(strings.NewReader("kube error")),
+						}
+
+						return resp, nil
+					}),
+					NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				}
+				mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+				logger := logger.NewReceptorLogger("")
+				mockNetceptor.EXPECT().GetLogger().Return(logger).AnyTimes()
+				mockKubeAPI.EXPECT().SubResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+				exec := ex{}
+				mockKubeAPI.EXPECT().NewSPDYExecutor(gomock.Any(), gomock.Any(), gomock.Any()).Return(&exec, nil).AnyTimes()
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I've added some changes as suggested by @AaronH88 to increase missing coverage in the tcp_proxy.go package. This was made by leveraging a custom Listener object that contains channels we can use to communicate with the goroutine during test execution