### PR TITLE
Fix missing coverage in tcp_proxy.go mocking net.Listener struct

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -38,9 +38,9 @@ type QuicConnectionForConn interface {
 	quic.Connection
 }
 
-type acceptResult struct {
-	conn net.Conn
-	err  error
+type AcceptResult struct {
+	Conn net.Conn
+	Err  error
 }
 
 // Listener implements the net.Listener interface via the Receptor network.
@@ -48,8 +48,8 @@ type Listener struct {
 	s          *Netceptor
 	pc         PacketConner
 	ql         *quic.Listener
-	acceptChan chan *acceptResult
-	doneChan   chan struct{}
+	AcceptChan chan *AcceptResult
+	DoneChan   chan struct{}
 	doneOnce   *sync.Once
 }
 
@@ -135,8 +135,8 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		s:          s,
 		pc:         pc,
 		ql:         ql,
-		acceptChan: make(chan *acceptResult),
-		doneChan:   doneChan,
+		AcceptChan: make(chan *AcceptResult),
+		DoneChan:   doneChan,
 		doneOnce:   &sync.Once{},
 	}
 
@@ -187,11 +187,11 @@ func (li *Listener) sendResult(ctx context.Context, conn net.Conn, err error) {
 	select {
 	case <-ctx.Done():
 		return
-	case li.acceptChan <- &acceptResult{
-		conn: conn,
-		err:  err,
+	case li.AcceptChan <- &AcceptResult{
+		Conn: conn,
+		Err:  err,
 	}:
-	case <-li.doneChan:
+	case <-li.DoneChan:
 	}
 }
 
@@ -200,13 +200,13 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
-		case <-li.doneChan:
+		case <-li.DoneChan:
 			return
 		default:
 		}
 		qc, err := li.ql.Accept(ctx)
 		select {
-		case <-li.doneChan:
+		case <-li.DoneChan:
 			return
 		default:
 		}
@@ -220,7 +220,7 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 			defer cancel()
 			qs, err := qc.AcceptStream(ctx)
 			select {
-			case <-li.doneChan:
+			case <-li.DoneChan:
 				_ = qc.CloseWithError(500, "Listener Closed")
 
 				return
@@ -267,7 +267,7 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 			}
 			go func() {
 				select {
-				case <-li.doneChan:
+				case <-li.DoneChan:
 					_ = conn.Close()
 				case <-cctx.Done():
 					_ = conn.Close()
@@ -283,9 +283,9 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 // Accept accepts a connection via the listener.
 func (li *Listener) Accept() (net.Conn, error) {
 	select {
-	case ar := <-li.acceptChan:
-		return ar.conn, ar.err
-	case <-li.doneChan:
+	case ar := <-li.AcceptChan:
+		return ar.Conn, ar.Err
+	case <-li.DoneChan:
 		return nil, fmt.Errorf("listener closed")
 	}
 }
@@ -293,7 +293,7 @@ func (li *Listener) Accept() (net.Conn, error) {
 // Close closes the listener.
 func (li *Listener) Close() error {
 	li.doneOnce.Do(func() {
-		close(li.doneChan)
+		close(li.DoneChan)
 	})
 	perr := li.pc.Close()
 	if qerr := li.ql.Close(); qerr != nil {

--- a/pkg/services/tcp_proxy_test.go
+++ b/pkg/services/tcp_proxy_test.go
@@ -122,16 +122,20 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 	var mockNetceptor *mock_services.MockNetcForTCPProxy
 	var mockNetLib *mock_services.MockNetLib
 	var mockTLSLib *mock_services.MockTLSLib
-	var mockNetListener *mock_services.MockNetListenerTCP
 	var mockUtilsLib *mock_services.MockUtilsLib
+	var mockTCPConn *mock_services.MockTCPConn
+
+	myListener := netceptor.Listener{
+		AcceptChan: make(chan *netceptor.AcceptResult),
+		DoneChan:   make(chan struct{}),
+	}
 
 	type testCoverageItem struct {
 		name                 string
 		expectError          bool
 		expectedErrorMessage string
-		service              string
-		address              string
 		tlsClientConfig      *tls.Config
+		myAcceptResult       netceptor.AcceptResult
 		calls                func()
 	}
 	testCases := []testCoverageItem{
@@ -145,34 +149,47 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 		},
 		{
 			name: "Fail to accept input connections",
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: nil,
+				Err:  errors.New("connection acceptance failed"),
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(nil, errors.New("connection acceptance failed")).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 			},
 		},
 		{
 			name:            "Fail to dial through non-TLS TCP connection",
 			tlsClientConfig: nil,
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: mockTCPConn,
+				Err:  nil,
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(&netceptor.Conn{}, nil).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockNetLib.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(nil, errors.New("non-TLS TCP dial failed")).AnyTimes()
 			},
 		},
 		{
 			name:            "Fail to dial through TLS TCP connection",
 			tlsClientConfig: &tls.Config{},
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: mockTCPConn,
+				Err:  nil,
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(&netceptor.Conn{}, nil).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockTLSLib.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("TLS TCP dial failed")).AnyTimes()
 			},
 		},
 		{
-			name: "Complete connection bridge after successful non-TLS connection",
+			name:            "Complete connection bridge after successful non-TLS connection",
+			tlsClientConfig: &tls.Config{},
+			myAcceptResult: netceptor.AcceptResult{
+				Conn: mockTCPConn,
+				Err:  nil,
+			},
 			calls: func() {
-				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&netceptor.Listener{}, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(&netceptor.Conn{}, nil).AnyTimes()
+				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockTLSLib.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(&tls.Conn{}, nil).AnyTimes()
 				mockUtilsLib.EXPECT().BridgeConns(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 			},
@@ -181,9 +198,12 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockNetceptor, mockNetLib, mockTLSLib, mockNetListener, mockUtilsLib, _ = setUpTCPMocks(ctrl)
+			mockNetceptor, mockNetLib, mockTLSLib, _, mockUtilsLib, mockTCPConn = setUpTCPMocks(ctrl)
 			tc.calls()
-			err := TCPProxyServiceOutbound(mockNetceptor, tc.service, &tls.Config{}, tc.address, tc.tlsClientConfig, mockNetLib, mockTLSLib, mockUtilsLib)
+			go func() {
+				myListener.AcceptChan <- &tc.myAcceptResult
+			}()
+			err := TCPProxyServiceOutbound(mockNetceptor, "", &tls.Config{}, "", tc.tlsClientConfig, mockNetLib, mockTLSLib, mockUtilsLib)
 			if tc.expectError {
 				if err == nil {
 					t.Errorf("TCPProxyServiceOutbound case failed to raise error")

--- a/pkg/services/tcp_proxy_test.go
+++ b/pkg/services/tcp_proxy_test.go
@@ -80,9 +80,12 @@ func TestTCPProxyServiceInbound(t *testing.T) {
 			name:            "Fail to dial to the receptor network after accepting an inbound connection",
 			tlsServerConfig: nil,
 			calls: func() {
-				mockNetLib.EXPECT().Listen(gomock.Any(), gomock.Any()).Return(mockNetListener, nil).Times(1)
-				mockNetListener.EXPECT().Accept().Return(mockTCPConn, nil).AnyTimes()
-				mockNetceptor.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to connect to Receptor network")).AnyTimes()
+				gomock.InOrder(
+					mockNetLib.EXPECT().Listen(gomock.Any(), gomock.Any()).Return(mockNetListener, nil).Times(1),
+					mockNetListener.EXPECT().Accept().Return(mockTCPConn, nil).AnyTimes(),
+					mockNetceptor.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to connect to Receptor network")).AnyTimes(),
+					mockNetListener.EXPECT().Accept().Return(nil, errors.New("failed to accept a new connection")).AnyTimes(),
+				)
 			},
 		},
 		{
@@ -135,7 +138,7 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 		expectError          bool
 		expectedErrorMessage string
 		tlsClientConfig      *tls.Config
-		myAcceptResult       netceptor.AcceptResult
+		myAcceptResults      []netceptor.AcceptResult
 		calls                func()
 	}
 	testCases := []testCoverageItem{
@@ -149,10 +152,10 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 		},
 		{
 			name: "Fail to accept input connections",
-			myAcceptResult: netceptor.AcceptResult{
+			myAcceptResults: []netceptor.AcceptResult{{
 				Conn: nil,
 				Err:  errors.New("connection acceptance failed"),
-			},
+			}},
 			calls: func() {
 				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 			},
@@ -160,10 +163,10 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 		{
 			name:            "Fail to dial through non-TLS TCP connection",
 			tlsClientConfig: nil,
-			myAcceptResult: netceptor.AcceptResult{
+			myAcceptResults: []netceptor.AcceptResult{{
 				Conn: mockTCPConn,
 				Err:  nil,
-			},
+			}},
 			calls: func() {
 				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockNetLib.EXPECT().Dial(gomock.Any(), gomock.Any()).Return(nil, errors.New("non-TLS TCP dial failed")).AnyTimes()
@@ -172,10 +175,10 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 		{
 			name:            "Fail to dial through TLS TCP connection",
 			tlsClientConfig: &tls.Config{},
-			myAcceptResult: netceptor.AcceptResult{
+			myAcceptResults: []netceptor.AcceptResult{{
 				Conn: mockTCPConn,
 				Err:  nil,
-			},
+			}},
 			calls: func() {
 				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
 				mockTLSLib.EXPECT().Dial(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("TLS TCP dial failed")).AnyTimes()
@@ -184,9 +187,15 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 		{
 			name:            "Complete connection bridge after successful non-TLS connection",
 			tlsClientConfig: &tls.Config{},
-			myAcceptResult: netceptor.AcceptResult{
-				Conn: mockTCPConn,
-				Err:  nil,
+			myAcceptResults: []netceptor.AcceptResult{
+				{
+					Conn: mockTCPConn,
+					Err:  nil,
+				},
+				{
+					Conn: nil,
+					Err:  errors.New("failed to accept a new connection"),
+				},
 			},
 			calls: func() {
 				mockNetceptor.EXPECT().ListenAndAdvertise(gomock.Any(), gomock.Any(), gomock.Any()).Return(&myListener, nil).Times(1)
@@ -201,7 +210,9 @@ func TestTCPProxyServiceOutbound(t *testing.T) {
 			mockNetceptor, mockNetLib, mockTLSLib, _, mockUtilsLib, mockTCPConn = setUpTCPMocks(ctrl)
 			tc.calls()
 			go func() {
-				myListener.AcceptChan <- &tc.myAcceptResult
+				for _, message := range tc.myAcceptResults {
+					myListener.AcceptChan <- &message
+				}
 			}()
 			err := TCPProxyServiceOutbound(mockNetceptor, "", &tls.Config{}, "", tc.tlsClientConfig, mockNetLib, mockTLSLib, mockUtilsLib)
 			if tc.expectError {


### PR DESCRIPTION
I've added some changes as suggested by @AaronH88 to increase missing coverage in the tcp_proxy.go package. This was made by leveraging a custom Listener object that contains channels we can use to communicate with the goroutine during test execution.