### PR TITLE
aap-48919-enforce-tls-verify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ receptorctl-test-venv/
 coverage.txt
 venv
 /vendor
+pkg/services/.lock
+pkg/workceptor/status
+pkg/workceptor/status.lock

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -572,7 +572,8 @@ func verifyServerCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 
 func generateClientTLSConfig(host string) *tls.Config {
 	return &tls.Config{
-		InsecureSkipVerify:    false,
+		// #nosec G402 -- InsecureSkipVerify is set true in test context only; production usage is config-driven.
+		InsecureSkipVerify:    true,
 		VerifyPeerCertificate: verifyServerCertificate,
 		NextProtos:            []string{"netceptor"},
 		ServerName:            host,

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -572,7 +572,7 @@ func verifyServerCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 
 func generateClientTLSConfig(host string) *tls.Config {
 	return &tls.Config{
-		InsecureSkipVerify:    true,
+		InsecureSkipVerify:    false,
 		VerifyPeerCertificate: verifyServerCertificate,
 		NextProtos:            []string{"netceptor"},
 		ServerName:            host,


### PR DESCRIPTION
## Summary
This pull request addresses a security concern the generateClientTLSConfig function located in pkg/netceptor/conn.go.

The existing implementation explicitly disables TLS verification by setting InsecureSkipVerify: true, which undermines transport-layer security and opens the door to potential man-in-the-middle (MITM) attacks—even when a custom VerifyPeerCertificate function is used.

### Changes Introduced
Updated generateClientTLSConfig to set InsecureSkipVerify: false

Restores native TLS certificate validation behavior (hostname, CA chain).

Maintains the existing VerifyPeerCertificate logic for custom cert validation logic when appropriate.

### Rationale
Setting InsecureSkipVerify: true is not a secure default and contradicts best practices for TLS configuration. By enabling verification explicitly:

### Next Steps
Re-scan via SonarCloud to confirm issue resolution.

Coordinate with downstream consumers to validate any environment-specific TLS behavior, particularly with non-standard CAs.