### PR TITLE
feat: field ARCH in Makefile shall be optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ clean:
 	@rm -fv receptor-python-worker/dist/*
 	@rm -rfv receptorctl-test-venv/
 
-ARCH=amd64
+ARCH ?= amd64
 OS=linux
 
 KUBECTL_BINARY=./kubectl


### PR DESCRIPTION
Making the field ARCH in the Makefile optional so the `make build-package` can be used for non x86_64 architectures.

AAP-43006