### PR TITLE
AAP-43201 netceptor logging

### DIFF
--- a/pkg/backends/tcp.go
+++ b/pkg/backends/tcp.go
@@ -62,6 +62,10 @@ func (b *TCPDialer) Start(ctx context.Context, wg *sync.WaitGroup) (chan netcept
 				return nil, err
 			}
 
+			if b.logger != nil {
+				b.logger.Debug("TCPDialer connected to TCP %s Address %s\n", b.address, conn.RemoteAddr().String())
+			}
+
 			return newTCPSession(conn, closeChan), nil
 		})
 }

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -254,7 +254,7 @@ func (rl *ReceptorLogger) Log(level int, format string, v ...interface{}) {
 	}
 }
 
-func (rl *ReceptorLogger) appendSuffix(format string, v []interface{}) (string, []interface{}) {
+func (rl *ReceptorLogger) appendSuffix(format string, v []string) (string, []string) {
 	if rl.Suffix != nil {
 		rl.m.Lock()
 		defer rl.m.Unlock()

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -99,7 +99,7 @@ func NewReceptorLogger(prefix string) *ReceptorLogger {
 	}
 }
 
-// NewReceptorLoggerWithSuffix to instantiate a new logger object with a new Suffix
+// NewReceptorLoggerWithSuffix to instantiate a new logger object with a new Suffix.
 func NewReceptorLoggerWithSuffix(prefix string, suffix map[string]string) *ReceptorLogger {
 	logger := NewReceptorLogger(prefix)
 	logger.SetSuffix(suffix)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -88,6 +88,7 @@ type ReceptorLogger struct {
 	log.Logger
 	Prefix string
 	m      sync.Mutex
+	Suffix map[string]string
 }
 
 // NewReceptorLogger to instantiate a new logger object.
@@ -95,6 +96,30 @@ func NewReceptorLogger(prefix string) *ReceptorLogger {
 	return &ReceptorLogger{
 		Logger: *log.New(os.Stdout, prefix, log.LstdFlags),
 		Prefix: prefix,
+	}
+}
+
+func NewReceptorLoggerWithSuffix(prefix string, suffix map[string]string) *ReceptorLogger {
+	logger := NewReceptorLogger(prefix)
+	logger.SetSuffix(suffix)
+
+	return logger
+}
+
+func (rl *ReceptorLogger) SetSuffix(suffix map[string]string) {
+	rl.m.Lock()
+	defer rl.m.Unlock()
+	rl.Suffix = suffix
+}
+
+func (rl *ReceptorLogger) UpdateSuffix(suffix map[string]string) {
+	rl.m.Lock()
+	defer rl.m.Unlock()
+	if rl.Suffix == nil {
+		rl.Suffix = make(map[string]string)
+	}
+	for k, v := range suffix {
+		rl.Suffix[k] = v
 	}
 }
 
@@ -218,8 +243,37 @@ func (rl *ReceptorLogger) Log(level int, format string, v ...interface{}) {
 
 	if logLevel >= level {
 		rl.Logger.SetPrefix(prefix)
+		format, v = rl.appendSuffix(format, v)
 		rl.Logger.Printf(format, v...)
 	}
+}
+
+func (rl *ReceptorLogger) appendSuffix(format string, v []interface{}) (string, []interface{}) {
+	if rl.Suffix != nil {
+		rl.m.Lock()
+		defer rl.m.Unlock()
+
+		var b strings.Builder
+		b.WriteString("{")
+		first := true
+		for k, val := range rl.Suffix {
+			if !first {
+				b.WriteString(",")
+			}
+			first = false
+			b.WriteString(`"`)
+			b.WriteString(k)
+			b.WriteString(`":"`)
+			b.WriteString(val)
+			b.WriteString(`"`)
+		}
+		b.WriteString("}")
+
+		format = strings.ReplaceAll(format, "\n", "") + " %s"
+		v = append(v, b.String())
+	}
+
+	return format, v
 }
 
 // SanitizedLog adds a prefix and prints a given log message.
@@ -245,7 +299,8 @@ func (rl *ReceptorLogger) SanitizedLog(level int, format string, v ...interface{
 	}
 
 	if logLevel >= level {
-		message := fmt.Sprintf(format, v...)
+		message, v := rl.appendSuffix(format, v)
+		message = fmt.Sprintf(message, v...)
 		sanMessage := strings.ReplaceAll(message, "\n", "")
 		rl.Logger.SetPrefix(prefix)
 		rl.Logger.Print(sanMessage)

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -254,7 +254,7 @@ func (rl *ReceptorLogger) Log(level int, format string, v ...interface{}) {
 	}
 }
 
-func (rl *ReceptorLogger) appendSuffix(format string, v []string) (string, []string) {
+func (rl *ReceptorLogger) appendSuffix(format string, v []interface{}) (string, []interface{}) {
 	if rl.Suffix != nil {
 		rl.m.Lock()
 		defer rl.m.Unlock()

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -99,6 +99,7 @@ func NewReceptorLogger(prefix string) *ReceptorLogger {
 	}
 }
 
+// NewReceptorLoggerWithSuffix to instantiate a new logger object with a new Suffix
 func NewReceptorLoggerWithSuffix(prefix string, suffix map[string]string) *ReceptorLogger {
 	logger := NewReceptorLogger(prefix)
 	logger.SetSuffix(suffix)
@@ -106,12 +107,17 @@ func NewReceptorLoggerWithSuffix(prefix string, suffix map[string]string) *Recep
 	return logger
 }
 
+// SetSuffix sets the suffix for the logger, overwriting any existing suffix.
 func (rl *ReceptorLogger) SetSuffix(suffix map[string]string) {
 	rl.m.Lock()
 	defer rl.m.Unlock()
 	rl.Suffix = suffix
 }
 
+// UpdateSuffix allows adding suffix key/value pairs to an existing suffix.
+// If the key already exists, the value will be overwritten.
+// If the suffix is nil, it will be initialized.
+// This is useful for adding additional context to log messages when you want to keep the existing suffix key/value pairs.
 func (rl *ReceptorLogger) UpdateSuffix(suffix map[string]string) {
 	rl.m.Lock()
 	defer rl.m.Unlock()

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -134,7 +134,7 @@ func TestGetLoggerWithSuffix(t *testing.T) {
 		receptorLogger := logger.NewReceptorLoggerWithSuffix("", suffix)
 		receptorLogger.SetOutput(&logBuffer)
 
-		receptorLogger.Error(testname)
+		receptorLogger.Error("%s", testname)
 		if !strings.Contains(logBuffer.String(), testname) {
 			t.Errorf("expected log message %s not found in log: %s", testname, logBuffer.String())
 		}
@@ -154,7 +154,7 @@ func TestGetLoggerWithSuffix(t *testing.T) {
 			"cost": "12",
 		}
 		receptorLogger.UpdateSuffix(updated)
-		receptorLogger.SanitizedError(testname)
+		receptorLogger.SanitizedError("%s", testname)
 
 		if !strings.Contains(logBuffer.String(), testname) {
 			t.Errorf("expected log message %s not found in log: %s", testname, logBuffer.String())

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -3,7 +3,6 @@ package logger_test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -73,14 +72,10 @@ func TestLogLevelToNameWithError(t *testing.T) {
 }
 
 func TestDebugPayload(t *testing.T) {
-	logFilePath := "/tmp/test-output"
+	var logBuffer bytes.Buffer
 	logger.SetGlobalLogLevel(4)
 	receptorLogger := logger.NewReceptorLogger("testDebugPayload")
-	logFile, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
-	if err != nil {
-		t.Error("error creating test-output file")
-	}
-
+	receptorLogger.SetOutput(&logBuffer)
 	payload := "Testing debugPayload"
 	workUnitID := "1234"
 	connectionType := "unix socket"
@@ -105,56 +100,67 @@ func TestDebugPayload(t *testing.T) {
 
 	for _, testCase := range debugPayloadTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			receptorLogger.SetOutput(logFile)
 			receptorLogger.DebugPayload(testCase.debugPayload, testCase.payload, testCase.workUnitID, testCase.connectionType)
+			testOutput := logBuffer.Bytes()
 
-			testOutput, err := os.ReadFile(logFilePath)
-			if err != nil {
-				t.Error("error reading test-output file")
-			}
-			if !bytes.Contains(testOutput, []byte(testCase.expectedLog)) {
+			if !strings.Contains(string(testOutput), testCase.expectedLog) {
 				t.Errorf("failed to log correctly, expected: %v got %v", testCase.expectedLog, string(testOutput))
 			}
-			if err := os.Truncate(logFilePath, 0); err != nil {
-				t.Errorf("failed to truncate: %v", err)
-			}
+			logBuffer.Reset()
 		})
 	}
 }
 
-func TestGetLoggerWithSuffix(t *testing.T) {
-	var logBuffer bytes.Buffer
+func assertSuffixFieldsPresent(t *testing.T, logLine string, expected map[string]string) {
+	t.Helper()
+	for k, v := range expected {
+		needle := `"` + k + `":"` + v + `"`
+		if !strings.Contains(logLine, needle) {
+			t.Errorf("expected key-value pair %s not found in log: %s", needle, logLine)
+		}
+	}
+}
 
+func TestGetLoggerWithSuffix(t *testing.T) {
 	logger.SetGlobalLogLevel(4)
 
-	suffix := map[string]string{
-		"node_id":   "controller",
-		"remote_id": "hop",
-	}
-	receptorLogger := logger.NewReceptorLoggerWithSuffix("", suffix)
-	receptorLogger.SetOutput(&logBuffer)
-	expectedLog := `example message 1 {"node_id":"controller","remote_id":"hop"}`
-	receptorLogger.Error("example message 1")
-	testOutput := logBuffer.Bytes()
+	t.Run("initial suffix", func(t *testing.T) {
+		var logBuffer bytes.Buffer
+		testname := "Initial Suffix Example"
+		suffix := map[string]string{
+			"node_id":   "controller",
+			"remote_id": "hop",
+		}
+		receptorLogger := logger.NewReceptorLoggerWithSuffix("", suffix)
+		receptorLogger.SetOutput(&logBuffer)
 
-	if !strings.Contains(logBuffer.String(), expectedLog) {
-		t.Errorf("failed to log correctly, expected: %v got %v", expectedLog, string(testOutput))
-	}
+		receptorLogger.Error(testname)
+		if !strings.Contains(logBuffer.String(), testname) {
+			t.Errorf("expected log message %s not found in log: %s", testname, logBuffer.String())
+		}
+		assertSuffixFieldsPresent(t, logBuffer.String(), suffix)
+	})
+	t.Run("updated suffix", func(t *testing.T) {
+		var logBuffer bytes.Buffer
+		testname := "Updated Suffix Example"
+		suffix := map[string]string{
+			"node_id":   "controller",
+			"remote_id": "hop",
+		}
+		receptorLogger := logger.NewReceptorLoggerWithSuffix("", suffix)
+		receptorLogger.SetOutput(&logBuffer)
 
-	logBuffer.Reset()
+		updated := map[string]string{
+			"cost": "12",
+		}
+		receptorLogger.UpdateSuffix(updated)
+		receptorLogger.SanitizedError(testname)
 
-	suffix = map[string]string{
-		"node_id":   "controller",
-		"remote_id": "hop",
-		"cost":      "12",
-	}
-	receptorLogger.UpdateSuffix(suffix)
-	expectedLog = `example message 2 {"node_id":"controller","remote_id":"hop","cost":"12"}` // note fields comes out alphabetically
-	receptorLogger.SanitizedError("example message 2")
-	testOutput = logBuffer.Bytes()
+		if !strings.Contains(logBuffer.String(), testname) {
+			t.Errorf("expected log message %s not found in log: %s", testname, logBuffer.String())
+		}
 
-	if !strings.Contains(logBuffer.String(), expectedLog) {
-		t.Errorf("failed to log correctly, expected: %v got %v", expectedLog, string(testOutput))
-	}
-	logBuffer.Reset()
+		assertSuffixFieldsPresent(t, logBuffer.String(), suffix)
+		assertSuffixFieldsPresent(t, logBuffer.String(), updated)
+	})
 }

--- a/pkg/logger/logger_test.go
+++ b/pkg/logger/logger_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/ansible/receptor/pkg/logger"
@@ -119,4 +120,41 @@ func TestDebugPayload(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetLoggerWithSuffix(t *testing.T) {
+	var logBuffer bytes.Buffer
+
+	logger.SetGlobalLogLevel(4)
+
+	suffix := map[string]string{
+		"node_id":   "controller",
+		"remote_id": "hop",
+	}
+	receptorLogger := logger.NewReceptorLoggerWithSuffix("", suffix)
+	receptorLogger.SetOutput(&logBuffer)
+	expectedLog := `example message 1 {"node_id":"controller","remote_id":"hop"}`
+	receptorLogger.Error("example message 1")
+	testOutput := logBuffer.Bytes()
+
+	if !strings.Contains(logBuffer.String(), expectedLog) {
+		t.Errorf("failed to log correctly, expected: %v got %v", expectedLog, string(testOutput))
+	}
+
+	logBuffer.Reset()
+
+	suffix = map[string]string{
+		"node_id":   "controller",
+		"remote_id": "hop",
+		"cost":      "12",
+	}
+	receptorLogger.UpdateSuffix(suffix)
+	expectedLog = `example message 2 {"node_id":"controller","remote_id":"hop","cost":"12"}` // note fields comes out alphabetically
+	receptorLogger.SanitizedError("example message 2")
+	testOutput = logBuffer.Bytes()
+
+	if !strings.Contains(logBuffer.String(), expectedLog) {
+		t.Errorf("failed to log correctly, expected: %v got %v", expectedLog, string(testOutput))
+	}
+	logBuffer.Reset()
 }

--- a/pkg/netceptor/external_backend.go
+++ b/pkg/netceptor/external_backend.go
@@ -204,3 +204,7 @@ func (es *ExternalSession) Close() error {
 
 	return err
 }
+
+func (mc *netMessageConn) RemoteAddr() net.Addr {
+	return mc.conn.RemoteAddr()
+}

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -355,6 +355,7 @@ func NewWithConsts(ctx context.Context, nodeID string,
 		MinVersion: tls.VersionTLS12,
 	}
 	s.AddNameHash(nodeID)
+	s.GetLogger().SetSuffix(map[string]string{"node_id": nodeID})
 	s.context, s.cancelFunc = context.WithCancel(ctx)
 	s.unreachableBroker = utils.NewBroker(s.context, reflect.TypeOf(UnreachableNotification{}))
 	s.routingUpdateBroker = utils.NewBroker(s.context, reflect.TypeOf(map[string]string{}))
@@ -1987,6 +1988,8 @@ func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, bi *Ba
 					if remoteNodeID == s.nodeID {
 						return s.sendAndLogConnectionRejection(remoteNodeID, ci, "it tried to connect using our own node ID")
 					}
+					suffix := map[string]string{"remote_id": remoteNodeID}
+					s.GetLogger().UpdateSuffix(suffix)
 					remoteNodeAccepted := true
 					if bi.allowedPeers != nil {
 						remoteNodeAccepted = false
@@ -2003,6 +2006,7 @@ func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, bi *Ba
 					}
 
 					// Check if there is connection cost for this remoteNodeID
+					// Check if there is connection cost for this remoteNodeID
 					remoteNodeCost, ok := bi.nodeCost[remoteNodeID]
 					if ok {
 						ci.Cost = remoteNodeCost
@@ -2010,10 +2014,20 @@ func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, bi *Ba
 					}
 					s.connLock.Lock()
 
-					// Check if there connInfo for this remoteNodeID
-					_, ok = s.connections[remoteNodeID]
+					// Check if there is already connInfo for this remoteNodeID
+					existingConn, ok := s.connections[remoteNodeID]
 					if ok {
 						remoteNodeAccepted = false
+					}
+					var connError error
+					connError = nil
+
+					// Verify that the existing connection is valid
+					if ok && existingConn != nil {
+						connError = existingConn.Context.Err()
+					}
+					if ok && connError != nil {
+						s.Logger.Error("Initial handshake failed: %s", connError)
 					}
 
 					if !remoteNodeAccepted {

--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -2027,7 +2027,7 @@ func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, bi *Ba
 						connError = existingConn.Context.Err()
 					}
 					if ok && connError != nil {
-						s.Logger.Error("Initial handshake failed: %s", connError)
+						s.Logger.Error("Context for existing connection error: %s", connError)
 					}
 
 					if !remoteNodeAccepted {


### PR DESCRIPTION
This PR is ready to review. 

While it doesn't implement structured logging, it's organized in such a way as to make that easier to add in AAP-44416: Implement dynamic log level changes.

Note that additional diagnostics were added to identify existing connections with initial handshake errors, but does *not* remove them as  that is a bug that is out of scope.  See [PR#1303](https://github.com/ansible/receptor/pull/1303) for details. 

Note that several iterations later, we've decided to leave the logging in netceptor.go the way it is,  just adding a few more log diagnostics and messages. The ability to add suffixes was added the logger with the addition of AddSuffix and UpdateSuffix to the logger itself. All future logs will contain what is in the log suffix.

Example output. See at 15:48:21 I stopped `hop`  and restarted it a few seconds later.
```json
INFO 2025/05/07 15:48:17 Known Connections: {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:17    execution:  {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:17    hop: control(1.00)  {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:17    control: hop(1.00)  {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:17 Routing Table: {"node_id":"execution","remote_id":"hop"}
WARNING 2025/05/07 15:48:21 Backend connection failed (will retry): dial tcp [::1]:2224: connect: connection refused {"remote_id":"hop","node_id":"execution"}
INFO 2025/05/07 15:48:29 Connection established with hop {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:29 Known Connections: {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:29    execution: hop(1.00)  {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:29    hop: control(1.00) execution(1.00)  {"node_id":"execution","remote_id":"hop"}
INFO 2025/05/07 15:48:29    control: hop(1.00)  {"node_id":"execution","remote_id":"hop"}
```