### PR TITLE
Update Dockerfile to include ansible-runner

### DIFF
--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf -y update && \
     dnf clean all && \
     pip3.12 install --no-cache-dir wheel && \
     pip3.12 install --no-cache-dir dumb-init && \
+    pip3.12 install --no-cache-dir ansible-runner && \
     pip3.12 install --no-cache-dir /tmp/*.whl && \
     rm /tmp/*.whl
 


### PR DESCRIPTION
where this is used in controller/AAP/awx we need ansible-runner for the health check. this brings more in line w/ downstream so we can test downstream AAP w/ upstream receptor image when y'all have new fixes you'd like to try out