### PR TITLE
update check for connection info to have less time complexity in netceptor.go/runProtocol(...)

### DIFF
--- a/pkg/netceptor/netceptor.go
+++ b/pkg/netceptor/netceptor.go
@@ -2003,19 +2003,20 @@ func (s *Netceptor) runProtocol(ctx context.Context, sess BackendSession, bi *Ba
 						return s.sendAndLogConnectionRejection(remoteNodeID, ci, "it is not in the allowed peers list")
 					}
 
+					// Check if there is connection cost for this remoteNodeID
 					remoteNodeCost, ok := bi.nodeCost[remoteNodeID]
 					if ok {
 						ci.Cost = remoteNodeCost
 						connectionCost = remoteNodeCost
 					}
 					s.connLock.Lock()
-					for conn := range s.connections {
-						if remoteNodeID == conn {
-							remoteNodeAccepted = false
 
-							break
-						}
+					// Check if there connInfo for this remoteNodeID
+					_, ok = s.connections[remoteNodeID]
+					if ok {
+						remoteNodeAccepted = false
 					}
+
 					if !remoteNodeAccepted {
 						s.connLock.Unlock()
 


### PR DESCRIPTION
tldr: Changes from using a for loop iterating over all the keys in a map to check for key existence in a map. This change does not make changes to the business logic in this small code block.

longer version:
The code `for conn := range s.connections` will iterate over all the keys in the map `s.connections`. This is a map where the nodeIDs are the keys of the map and the data is a connInfo object. We can simply check to see if the key exists in the map instead of looping over the keys to see if we have a connection to this node. 

even more info:
[In Golang you can use a two-value assignment to test the existence of a key in a map.](https://go.dev/blog/maps) The most common variable to use for existence is "ok".. which I generally refer to as the "if ok" syntax of Golang. 