### PR TITLE
Fix flock_test from interrupting utils package tests

### DIFF
--- a/pkg/utils/flock_test.go
+++ b/pkg/utils/flock_test.go
@@ -27,7 +27,7 @@ func TestTryFLock(t *testing.T) {
 			args: args{
 				filename: filepath.Join(os.TempDir(), "good_flock_listener"),
 			},
-			want:    &utils.FLock{0},
+			want:    &utils.FLock{Fd: 0},
 			wantErr: false,
 		},
 		{
@@ -63,7 +63,7 @@ func TestFLock_Unlock(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(f.Name())
-  defer f.Close()
+	defer f.Close()
 
 	var maxInt uintptr
 	if strconv.IntSize == 32 {

--- a/pkg/utils/flock_test.go
+++ b/pkg/utils/flock_test.go
@@ -57,6 +57,12 @@ func TestTryFLock(t *testing.T) {
 }
 
 func TestFLock_Unlock(t *testing.T) {
+	f, err := os.CreateTemp("", "flock-test")
+	if err != nil {
+		t.Error(err)
+	}
+	defer os.Remove(f.Name())
+    defer f.Close()
 	type fields struct {
 		Fd int
 	}
@@ -68,7 +74,7 @@ func TestFLock_Unlock(t *testing.T) {
 		{
 			name: "Positive",
 			fields: fields{
-				Fd: 1,
+				Fd: int(f.Fd()),
 			},
 			wantErr: false,
 		},

--- a/pkg/utils/flock_test.go
+++ b/pkg/utils/flock_test.go
@@ -67,9 +67,9 @@ func TestFLock_Unlock(t *testing.T) {
 
 	var maxInt uintptr
 	if strconv.IntSize == 32 {
-			maxInt = uintptr(1<<31 - 1)
+		maxInt = uintptr(1<<31 - 1)
 	} else {
-			maxInt = uintptr(1<<63 - 1)
+		maxInt = uintptr(1<<63 - 1)
 	}
 
 	fd := f.Fd()

--- a/pkg/utils/flock_test.go
+++ b/pkg/utils/flock_test.go
@@ -6,6 +6,7 @@ package utils_test
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/ansible/receptor/pkg/utils"
@@ -62,7 +63,20 @@ func TestFLock_Unlock(t *testing.T) {
 		t.Error(err)
 	}
 	defer os.Remove(f.Name())
-    defer f.Close()
+  defer f.Close()
+
+	var maxInt uintptr
+	if strconv.IntSize == 32 {
+			maxInt = uintptr(1<<31 - 1)
+	} else {
+			maxInt = uintptr(1<<63 - 1)
+	}
+
+	fd := f.Fd()
+	if fd > maxInt {
+		t.Error(err)
+	}
+
 	type fields struct {
 		Fd int
 	}
@@ -74,7 +88,7 @@ func TestFLock_Unlock(t *testing.T) {
 		{
 			name: "Positive",
 			fields: fields{
-				Fd: int(f.Fd()),
+				Fd: int(f.Fd()), // #nosec G115
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Utils package unit tests are stopping after running flock_test because the test was unlocking FD 1 which is stdout.

This change fixes the test by creating a temp file and unlock it instead of FD 1.