### PR TITLE
Add a pod status check after EOF detection

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -386,6 +386,27 @@ func (kw *KubeUnit) KubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 						podName,
 					)
 
+					// check container status again
+					pod, err := kw.KubeAPIWrapperInstance.Get(kw.GetContext(), kw.clientset, podNamespace, podName, metav1.GetOptions{})
+					if err != nil {
+						kw.GetWorkceptor().nc.GetLogger().Error(err.Error())
+						kw.UpdateBasicStatus(WorkStateFailed, err.Error(), stdout.Size())
+					}
+
+					// kw.GetWorkceptor().nc.GetLogger().Debug(pod.Status.String())
+					// wait for container status to terminate
+					for pod.Status.ContainerStatuses[0].State.Terminated == nil {
+						pod, _ = kw.KubeAPIWrapperInstance.Get(kw.GetContext(), kw.clientset, podNamespace, podName, metav1.GetOptions{})
+					}
+
+					// if the pod's container finished unsuccessfully - add an error
+					if pod.Status.ContainerStatuses[0].State.Terminated != nil && pod.Status.ContainerStatuses[0].State.Terminated.ExitCode != 0 {
+						errmsg := fmt.Sprintf("pod exited unexpectedly reason: %s (%d)",
+							pod.Status.ContainerStatuses[0].State.Terminated.Reason, pod.Status.ContainerStatuses[0].State.Terminated.ExitCode)
+						kw.GetWorkceptor().nc.GetLogger().Error(errmsg)
+						kw.UpdateBasicStatus(WorkStateFailed, errmsg, stdout.Size())
+					}
+
 					return
 				}
 


### PR DESCRIPTION
In researching the bug: [AAP-46484](https://issues.redhat.com/browse/AAP-46484) 
Jobs are in failed status with message "Receptor detail: Finished"

Receptor is returning a WorkStateSuccessful with a truncated stdout. This causes parsing JSON errors by ansible-runner.

The reproducer we have so far is shows that when a container exits with a failure exit code (non-zero exit code) receptor will pass the truncated stdout as a success. We can force this path by creating a container with low memory that causes k8s to OOMKill the container and pod.

This adds a check to grab the terminated state of the container and sends an error message if the container exited with a failure of some kind.