### PR TITLE
Remove unreachable code in workceptor/remote_work.go

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -360,11 +360,6 @@ func (rw *remoteUnit) monitorRemoteStatus(mw *utils.JobContext, forRelease bool)
 		} else {
 			writeStatusFailures = 0
 		}
-		if err != nil {
-			rw.GetWorkceptor().nc.GetLogger().Error("Error saving local status file: %s\n", err)
-
-			return
-		}
 		if sleepOrDone(mw.Done(), 1*time.Second) {
 			return
 		}


### PR DESCRIPTION
The variable `err` is always nil here because it is checked against `err != nil` on lines 347-351 and returned.

There is not another function populating `err` here. I think there was a Save() function that was called in the past but this is no longer called.