### PR TITLE
Additional unit tests for pkg/netceptor/conn.go

### DIFF
--- a/pkg/netceptor/conn_internal_test.go
+++ b/pkg/netceptor/conn_internal_test.go
@@ -4,27 +4,38 @@ import (
 	"context"
 	"crypto/x509"
 	"os"
+	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
-func TestGenerateServerTLSConfig(t *testing.T) {
+// TestServerTLSConfig tests the GenerateServerTLSConfig function.
+func TestServerTLSConfig(t *testing.T) {
 	// Call the function
 	config := generateServerTLSConfig()
 
 	// Verify the result
-	assert.NotNil(t, config)
-	assert.Equal(t, []string{"netceptor"}, config.NextProtos)
-	assert.Len(t, config.Certificates, 1)
+	if config == nil {
+		t.Fatal("Expected config to be non-nil")
+	}
+	if len(config.NextProtos) != 1 || config.NextProtos[0] != "netceptor" {
+		t.Errorf("Expected NextProtos to be ['netceptor'], got %v", config.NextProtos)
+	}
+	if len(config.Certificates) != 1 {
+		t.Errorf("Expected 1 certificate, got %d", len(config.Certificates))
+	}
 
 	// Verify the certificate
 	cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
-	assert.NoError(t, err)
-	assert.Equal(t, "netceptor-insecure-common-name", cert.Subject.CommonName)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
+	if cert.Subject.CommonName != "netceptor-insecure-common-name" {
+		t.Errorf("Expected CommonName to be 'netceptor-insecure-common-name', got '%s'", cert.Subject.CommonName)
+	}
 }
 
-func TestVerifyServerCertificate(t *testing.T) {
+// TestServerCertVerification tests the VerifyServerCertificate function.
+func TestServerCertVerification(t *testing.T) {
 	// Generate a server TLS config to get a valid certificate
 	config := generateServerTLSConfig()
 	rawCert := config.Certificates[0].Certificate[0]
@@ -55,26 +66,43 @@ func TestVerifyServerCertificate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := verifyServerCertificate(tt.rawCerts, nil)
 			if tt.expectError {
-				assert.Error(t, err)
+				if err == nil {
+					t.Errorf("Expected error for test case '%s', but got nil", tt.name)
+				}
 			} else {
-				assert.NoError(t, err)
+				if err != nil {
+					t.Errorf("Expected no error for test case '%s', but got: %v", tt.name, err)
+				}
 			}
 		})
 	}
 }
 
-func TestGenerateClientTLSConfig(t *testing.T) {
+// TestClientTLSConfig tests the GenerateClientTLSConfig function.
+func TestClientTLSConfig(t *testing.T) {
 	// Call the function
 	host := "test-host"
 	config := generateClientTLSConfig(host)
 
 	// Verify the result
-	assert.NotNil(t, config)
-	assert.True(t, config.InsecureSkipVerify)
-	assert.NotNil(t, config.VerifyPeerCertificate)
-	assert.Equal(t, []string{"netceptor"}, config.NextProtos)
-	assert.Equal(t, host, config.ServerName)
+	if config == nil {
+		t.Fatal("Expected config to be non-nil")
+	}
+	if !config.InsecureSkipVerify {
+		t.Error("Expected InsecureSkipVerify to be true")
+	}
+	if config.VerifyPeerCertificate == nil {
+		t.Error("Expected VerifyPeerCertificate to be non-nil")
+	}
+	if len(config.NextProtos) != 1 || config.NextProtos[0] != "netceptor" {
+		t.Errorf("Expected NextProtos to be ['netceptor'], got %v", config.NextProtos)
+	}
+	if config.ServerName != host {
+		t.Errorf("Expected ServerName to be '%s', got '%s'", host, config.ServerName)
+	}
 }
+
+// TestNetceptorListen tests the Listen method functionality.
 func TestNetceptorListen(t *testing.T) {
 	// Skip this test in CI environments or when network operations are not possible
 	if os.Getenv("CI") != "" {
@@ -126,25 +154,43 @@ func TestNetceptorListen(t *testing.T) {
 			listener, err := s.Listen(tt.serviceName, nil)
 
 			if tt.expectError {
-				assert.Error(t, err)
-				assert.Nil(t, listener)
-				if tt.expectedErrorSubstr != "" {
-					assert.Contains(t, err.Error(), tt.expectedErrorSubstr)
+				if err == nil {
+					t.Errorf("Expected error for test case '%s', but got nil", tt.name)
+				}
+				if listener != nil {
+					t.Errorf("Expected listener to be nil for test case '%s', but got non-nil", tt.name)
+				}
+				if tt.expectedErrorSubstr != "" && err != nil {
+					if !strings.Contains(err.Error(), tt.expectedErrorSubstr) {
+						t.Errorf("Expected error to contain '%s', but got '%s'", tt.expectedErrorSubstr, err.Error())
+					}
 				}
 			} else {
-				assert.NoError(t, err)
-				assert.NotNil(t, listener)
+				if err != nil {
+					t.Errorf("Expected no error for test case '%s', but got: %v", tt.name, err)
+				}
+				if listener == nil {
+					t.Errorf("Expected listener to be non-nil for test case '%s'", tt.name)
+				}
 
 				if tt.needsCleanup && listener != nil {
 					err = listener.Close()
-					assert.NoError(t, err)
+					if err != nil {
+						t.Errorf("Failed to close listener for test case '%s': %v", tt.name, err)
+					}
 				}
 			}
 		})
 	}
 }
 
+// TestNetceptorListenAndAdvertise tests basic functionality of the ListenAndAdvertise method.
 func TestNetceptorListenAndAdvertise(t *testing.T) {
+	// Skip this test in CI environments or when network operations are not possible
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping test in CI environment")
+	}
+
 	// Create a Netceptor instance
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -160,13 +206,18 @@ func TestNetceptorListenAndAdvertise(t *testing.T) {
 	}
 
 	// Verify the listener
-	assert.NotNil(t, listener)
+	if listener == nil {
+		t.Fatal("Expected listener to be non-nil")
+	}
 
 	// Clean up
 	err = listener.Close()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("Failed to close listener: %v", err)
+	}
 }
 
+// TestNetceptorDialInvalidService tests that Dial returns an error for invalid services.
 func TestNetceptorDialInvalidService(t *testing.T) {
 	// Create a Netceptor instance
 	ctx, cancel := context.WithCancel(context.Background())
@@ -177,10 +228,15 @@ func TestNetceptorDialInvalidService(t *testing.T) {
 	conn, err := s.Dial("non-existent-node", "non-existent-service", nil)
 
 	// Verify the result - we expect an error because the node doesn't exist
-	assert.Error(t, err)
-	assert.Nil(t, conn)
+	if err == nil {
+		t.Error("Expected error when dialing non-existent service, but got nil")
+	}
+	if conn != nil {
+		t.Error("Expected conn to be nil when dialing non-existent service, but got non-nil")
+	}
 }
 
+// TestNetceptorDialContextCanceled tests that DialContext returns an error when the context is canceled.
 func TestNetceptorDialContextCanceled(t *testing.T) {
 	// Create a Netceptor instance
 	ctx, cancel := context.WithCancel(context.Background())
@@ -195,7 +251,13 @@ func TestNetceptorDialContextCanceled(t *testing.T) {
 	conn, err := s.DialContext(canceledCtx, "non-existent-node", "non-existent-service", nil)
 
 	// Verify the result - we expect a context canceled error
-	assert.Error(t, err)
-	assert.Nil(t, conn)
-	assert.Contains(t, err.Error(), "context canceled")
+	if err == nil {
+		t.Error("Expected error when dialing with canceled context, but got nil")
+	}
+	if conn != nil {
+		t.Error("Expected conn to be nil when dialing with canceled context, but got non-nil")
+	}
+	if err != nil && !strings.Contains(err.Error(), "context canceled") {
+		t.Errorf("Expected error to contain 'context canceled', but got '%s'", err.Error())
+	}
 }

--- a/pkg/netceptor/conn_internal_test.go
+++ b/pkg/netceptor/conn_internal_test.go
@@ -3,7 +3,6 @@ package netceptor
 import (
 	"context"
 	"crypto/x509"
-	"os"
 	"strings"
 	"testing"
 )

--- a/pkg/netceptor/conn_internal_test.go
+++ b/pkg/netceptor/conn_internal_test.go
@@ -1,0 +1,185 @@
+package netceptor
+
+import (
+	"context"
+	"crypto/x509"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestServerTLSConfig tests the GenerateServerTLSConfig function.
+func TestServerTLSConfig(t *testing.T) {
+	// Call the function
+	config := generateServerTLSConfig()
+
+	// Verify the result
+	assert.NotNil(t, config)
+	assert.Equal(t, []string{"netceptor"}, config.NextProtos)
+	assert.Len(t, config.Certificates, 1)
+
+	// Verify the certificate
+	cert, err := x509.ParseCertificate(config.Certificates[0].Certificate[0])
+	assert.NoError(t, err)
+	assert.Equal(t, "netceptor-insecure-common-name", cert.Subject.CommonName)
+}
+
+// TestServerCertVerification tests the VerifyServerCertificate function.
+func TestServerCertVerification(t *testing.T) {
+	// Generate a server TLS config to get a valid certificate
+	config := generateServerTLSConfig()
+	rawCert := config.Certificates[0].Certificate[0]
+
+	// Test with a valid certificate
+	err := verifyServerCertificate([][]byte{rawCert}, nil)
+	assert.NoError(t, err)
+
+	// Test with no certificates
+	err = verifyServerCertificate([][]byte{}, nil)
+	assert.Error(t, err)
+
+	// Test with invalid certificate data
+	err = verifyServerCertificate([][]byte{{1, 2, 3, 4}}, nil)
+	assert.Error(t, err)
+}
+
+// TestClientTLSConfig tests the GenerateClientTLSConfig function.
+func TestClientTLSConfig(t *testing.T) {
+	// Call the function
+	host := "test-host"
+	config := generateClientTLSConfig(host)
+
+	// Verify the result
+	assert.NotNil(t, config)
+	assert.True(t, config.InsecureSkipVerify)
+	assert.NotNil(t, config.VerifyPeerCertificate)
+	assert.Equal(t, []string{"netceptor"}, config.NextProtos)
+	assert.Equal(t, host, config.ServerName)
+}
+
+// Skip the tracer test since it's difficult to test without mocking
+// the quic.ConnectionID type
+
+// TestNetceptorListen tests basic functionality of the Listen method.
+func TestNetceptorListen(t *testing.T) {
+	// Skip this test in CI environments or when network operations are not possible
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping test in CI environment")
+	}
+
+	// Create a Netceptor instance
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := New(ctx, "test-node")
+
+	// Generate a random service name
+	serviceName := randString(8)
+
+	// Call Listen
+	listener, err := s.Listen(serviceName, nil)
+	if err != nil {
+		t.Fatalf("Failed to listen: %v", err)
+	}
+
+	// Verify the listener
+	assert.NotNil(t, listener)
+
+	// Clean up
+	err = listener.Close()
+	assert.NoError(t, err)
+}
+
+// TestNetceptorListenServiceTooLong tests that Listen returns an error for service names that are too long.
+func TestNetceptorListenServiceTooLong(t *testing.T) {
+	// Create a Netceptor instance
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := New(ctx, "test-node")
+
+	// Call Listen with a service name that's too long
+	listener, err := s.Listen("service-name-too-long", nil)
+
+	// Verify the result
+	assert.Error(t, err)
+	assert.Nil(t, listener)
+	assert.Contains(t, err.Error(), "service name service-name-too-long too long")
+}
+
+// Helper function to generate a random string.
+func randString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = charset[time.Now().UnixNano()%int64(len(charset))]
+		time.Sleep(1 * time.Nanosecond) // Ensure uniqueness
+	}
+
+	return string(result)
+}
+
+// TestNetceptorListenAndAdvertise tests basic functionality of the ListenAndAdvertise method.
+func TestNetceptorListenAndAdvertise(t *testing.T) {
+	// Skip this test in CI environments or when network operations are not possible
+	if os.Getenv("CI") != "" {
+		t.Skip("Skipping test in CI environment")
+	}
+
+	// Create a Netceptor instance
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := New(ctx, "test-node")
+
+	// Generate a random service name
+	serviceName := randString(8)
+
+	// Call ListenAndAdvertise
+	tags := map[string]string{"tag1": "value1"}
+	listener, err := s.ListenAndAdvertise(serviceName, nil, tags)
+	if err != nil {
+		t.Fatalf("Failed to listen and advertise: %v", err)
+	}
+
+	// Verify the listener
+	assert.NotNil(t, listener)
+
+	// Clean up
+	err = listener.Close()
+	assert.NoError(t, err)
+}
+
+// TestNetceptorDialInvalidService tests that Dial returns an error for invalid services.
+func TestNetceptorDialInvalidService(t *testing.T) {
+	// Create a Netceptor instance
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := New(ctx, "test-node")
+
+	// Call Dial with a non-existent node and service
+	conn, err := s.Dial("non-existent-node", "non-existent-service", nil)
+
+	// Verify the result - we expect an error because the node doesn't exist
+	assert.Error(t, err)
+	assert.Nil(t, conn)
+}
+
+// TestNetceptorDialContextCanceled tests that DialContext returns an error when the context is canceled.
+func TestNetceptorDialContextCanceled(t *testing.T) {
+	// Create a Netceptor instance
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	s := New(ctx, "test-node")
+
+	// Create a canceled context
+	canceledCtx, cancelFunc := context.WithCancel(context.Background())
+	cancelFunc()
+
+	// Call DialContext with the canceled context
+	conn, err := s.DialContext(canceledCtx, "non-existent-node", "non-existent-service", nil)
+
+	// Verify the result - we expect a context canceled error
+	assert.Error(t, err)
+	assert.Nil(t, conn)
+	assert.Contains(t, err.Error(), "context canceled")
+}

--- a/pkg/netceptor/conn_internal_test.go
+++ b/pkg/netceptor/conn_internal_test.go
@@ -5,13 +5,11 @@ import (
 	"crypto/x509"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// TestServerTLSConfig tests the GenerateServerTLSConfig function.
-func TestServerTLSConfig(t *testing.T) {
+func TestGenerateServerTLSConfig(t *testing.T) {
 	// Call the function
 	config := generateServerTLSConfig()
 
@@ -26,27 +24,46 @@ func TestServerTLSConfig(t *testing.T) {
 	assert.Equal(t, "netceptor-insecure-common-name", cert.Subject.CommonName)
 }
 
-// TestServerCertVerification tests the VerifyServerCertificate function.
-func TestServerCertVerification(t *testing.T) {
+func TestVerifyServerCertificate(t *testing.T) {
 	// Generate a server TLS config to get a valid certificate
 	config := generateServerTLSConfig()
 	rawCert := config.Certificates[0].Certificate[0]
 
-	// Test with a valid certificate
-	err := verifyServerCertificate([][]byte{rawCert}, nil)
-	assert.NoError(t, err)
+	tests := []struct {
+		name        string
+		rawCerts    [][]byte
+		expectError bool
+	}{
+		{
+			name:        "Valid certificate",
+			rawCerts:    [][]byte{rawCert},
+			expectError: false,
+		},
+		{
+			name:        "No certificates",
+			rawCerts:    [][]byte{},
+			expectError: true,
+		},
+		{
+			name:        "Invalid certificate data",
+			rawCerts:    [][]byte{{1, 2, 3, 4}},
+			expectError: true,
+		},
+	}
 
-	// Test with no certificates
-	err = verifyServerCertificate([][]byte{}, nil)
-	assert.Error(t, err)
-
-	// Test with invalid certificate data
-	err = verifyServerCertificate([][]byte{{1, 2, 3, 4}}, nil)
-	assert.Error(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyServerCertificate(tt.rawCerts, nil)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }
 
-// TestClientTLSConfig tests the GenerateClientTLSConfig function.
-func TestClientTLSConfig(t *testing.T) {
+func TestGenerateClientTLSConfig(t *testing.T) {
 	// Call the function
 	host := "test-host"
 	config := generateClientTLSConfig(host)
@@ -58,81 +75,82 @@ func TestClientTLSConfig(t *testing.T) {
 	assert.Equal(t, []string{"netceptor"}, config.NextProtos)
 	assert.Equal(t, host, config.ServerName)
 }
-
-// Skip the tracer test since it's difficult to test without mocking
-// the quic.ConnectionID type
-
-// TestNetceptorListen tests basic functionality of the Listen method.
 func TestNetceptorListen(t *testing.T) {
 	// Skip this test in CI environments or when network operations are not possible
 	if os.Getenv("CI") != "" {
 		t.Skip("Skipping test in CI environment")
 	}
 
-	// Create a Netceptor instance
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	s := New(ctx, "test-node")
-
-	// Generate a random service name
-	serviceName := randString(8)
-
-	// Call Listen
-	listener, err := s.Listen(serviceName, nil)
-	if err != nil {
-		t.Fatalf("Failed to listen: %v", err)
+	tests := []struct {
+		name                string
+		serviceName         string
+		expectError         bool
+		expectedErrorSubstr string
+		needsCleanup        bool
+	}{
+		{
+			name:         "Valid service name",
+			serviceName:  "abcd", // 4 characters, within the 8-character limit
+			expectError:  false,
+			needsCleanup: true,
+		},
+		{
+			name:                "Service name too long",
+			serviceName:         "service-name-too-long", // 22 characters, exceeds 8-character limit
+			expectError:         true,
+			expectedErrorSubstr: "service name service-name-too-long too long",
+			needsCleanup:        false,
+		},
+		{
+			name:         "Empty service name gets ephemeral",
+			serviceName:  "", // Empty service name should get an ephemeral service
+			expectError:  false,
+			needsCleanup: true,
+		},
+		{
+			name:         "Maximum length service name",
+			serviceName:  "abcd1234", // 8 characters, maximum allowed length
+			expectError:  false,
+			needsCleanup: true,
+		},
 	}
 
-	// Verify the listener
-	assert.NotNil(t, listener)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a Netceptor instance for each test case
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			s := New(ctx, "test-node")
 
-	// Clean up
-	err = listener.Close()
-	assert.NoError(t, err)
-}
+			// Call Listen
+			listener, err := s.Listen(tt.serviceName, nil)
 
-// TestNetceptorListenServiceTooLong tests that Listen returns an error for service names that are too long.
-func TestNetceptorListenServiceTooLong(t *testing.T) {
-	// Create a Netceptor instance
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	s := New(ctx, "test-node")
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, listener)
+				if tt.expectedErrorSubstr != "" {
+					assert.Contains(t, err.Error(), tt.expectedErrorSubstr)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, listener)
 
-	// Call Listen with a service name that's too long
-	listener, err := s.Listen("service-name-too-long", nil)
-
-	// Verify the result
-	assert.Error(t, err)
-	assert.Nil(t, listener)
-	assert.Contains(t, err.Error(), "service name service-name-too-long too long")
-}
-
-// Helper function to generate a random string.
-func randString(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	result := make([]byte, length)
-	for i := range result {
-		result[i] = charset[time.Now().UnixNano()%int64(len(charset))]
-		time.Sleep(1 * time.Nanosecond) // Ensure uniqueness
+				if tt.needsCleanup && listener != nil {
+					err = listener.Close()
+					assert.NoError(t, err)
+				}
+			}
+		})
 	}
-
-	return string(result)
 }
 
-// TestNetceptorListenAndAdvertise tests basic functionality of the ListenAndAdvertise method.
 func TestNetceptorListenAndAdvertise(t *testing.T) {
-	// Skip this test in CI environments or when network operations are not possible
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping test in CI environment")
-	}
-
 	// Create a Netceptor instance
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	s := New(ctx, "test-node")
 
-	// Generate a random service name
-	serviceName := randString(8)
+	serviceName := "test-svc"
 
 	// Call ListenAndAdvertise
 	tags := map[string]string{"tag1": "value1"}
@@ -149,7 +167,6 @@ func TestNetceptorListenAndAdvertise(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestNetceptorDialInvalidService tests that Dial returns an error for invalid services.
 func TestNetceptorDialInvalidService(t *testing.T) {
 	// Create a Netceptor instance
 	ctx, cancel := context.WithCancel(context.Background())
@@ -164,7 +181,6 @@ func TestNetceptorDialInvalidService(t *testing.T) {
 	assert.Nil(t, conn)
 }
 
-// TestNetceptorDialContextCanceled tests that DialContext returns an error when the context is canceled.
 func TestNetceptorDialContextCanceled(t *testing.T) {
 	// Create a Netceptor instance
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/netceptor/conn_internal_test.go
+++ b/pkg/netceptor/conn_internal_test.go
@@ -104,10 +104,6 @@ func TestClientTLSConfig(t *testing.T) {
 
 // TestNetceptorListen tests the Listen method functionality.
 func TestNetceptorListen(t *testing.T) {
-	// Skip this test in CI environments or when network operations are not possible
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping test in CI environment")
-	}
 
 	tests := []struct {
 		name                string
@@ -186,11 +182,6 @@ func TestNetceptorListen(t *testing.T) {
 
 // TestNetceptorListenAndAdvertise tests basic functionality of the ListenAndAdvertise method.
 func TestNetceptorListenAndAdvertise(t *testing.T) {
-	// Skip this test in CI environments or when network operations are not possible
-	if os.Getenv("CI") != "" {
-		t.Skip("Skipping test in CI environment")
-	}
-
 	// Create a Netceptor instance
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/netceptor/conn_internal_test.go
+++ b/pkg/netceptor/conn_internal_test.go
@@ -103,7 +103,6 @@ func TestClientTLSConfig(t *testing.T) {
 
 // TestNetceptorListen tests the Listen method functionality.
 func TestNetceptorListen(t *testing.T) {
-
 	tests := []struct {
 		name                string
 		serviceName         string


### PR DESCRIPTION
Additional unit tests for `conn.go` to augment what we have in `conn_test.go`. These are added to a new file `conn_internal_tests.go` in `package netceptor` so that we can test netceptor private methods and fields.

Replaces https://github.com/ansible/receptor/pull/1320 and https://github.com/ansible/receptor/pull/1317