### PR TITLE
Add get_sanitized_results function

### DIFF
--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -84,14 +84,7 @@ def print_error(message, nl=True):
     help="Accept any server cert",
     show_default=True,
 )
-@click.option(
-    "--print-sanitized-results",
-    "print_sanitized_results",
-    default=False,
-    help="Prints results that are unexpected or empty.",
-    show_default=True,
-)
-def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify, print_sanitized_results):
+def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
     ctx.obj = {
         "rc": None,
         "receptorctlVersion": importlib.metadata.version("receptorctl"),
@@ -107,7 +100,6 @@ def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify, 
             key=key,
             cert=cert,
             insecureskipverify=insecureskipverify,
-            print_sanitized_results=print_sanitized_results,
         )
         # Load and stash the versions
         ctx.obj["receptorVersion"] = ctx.obj["rc"].simple_command(

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -84,7 +84,14 @@ def print_error(message, nl=True):
     help="Accept any server cert",
     show_default=True,
 )
-def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
+@click.option(
+    "--print-sanitized-results",
+    "print_sanitized_results",
+    default=False,
+    help="Prints results that are unexpected or empty.",
+    show_default=True,
+)
+def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify, print_sanitized_results):
     ctx.obj = {
         "rc": None,
         "receptorctlVersion": importlib.metadata.version("receptorctl"),
@@ -100,6 +107,7 @@ def cli(ctx, socket, config, tlsclient, rootcas, key, cert, insecureskipverify):
             key=key,
             cert=cert,
             insecureskipverify=insecureskipverify,
+            print_sanitized_results=print_sanitized_results,
         )
         # Load and stash the versions
         ctx.obj["receptorVersion"] = ctx.obj["rc"].simple_command(

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -19,11 +19,11 @@ def contains_json_like_fragments(s):
     """Determines if the input contains substrings that resemble JSON."""
 
     # Pattern to match balanced {...} or [...] in a rough and non-recursive way
-    object_pattern = r'({[^{}[\]]*})'
-    array_pattern = r'(\[[^\[\]{}]*\])'
+    object_pattern = r"({[^{}[\]]*})"
+    array_pattern = r"(\[[^\[\]{}]*\])"
 
     # Find all non-overlapping matches
-    matches = re.findall(f'{object_pattern}|{array_pattern}', s)
+    matches = re.findall(f"{object_pattern}|{array_pattern}", s)
 
     for match in matches:
         # match is a tuple because of regex alternation. Get the first non-empty match.
@@ -37,8 +37,8 @@ def contains_json_like_fragments(s):
 def looks_like_json(s):
     """Basic structural heuristics to decide if a string resembles JSON."""
     s = s.strip()
-    if (s.startswith('{') and s.endswith('}')) or (s.startswith('[') and s.endswith(']')):
-        if re.search(r'"\s*:\s*', s) or re.search(r'("*\w+\s*,*)*', s) or s in ['{}', '[]']:
+    if (s.startswith("{") and s.endswith("}")) or (s.startswith("[") and s.endswith("]")):
+        if re.search(r'"\s*:\s*', s) or re.search(r'("*\w+\s*,*)*', s) or s in ["{}", "[]"]:
             return True
     return False
 
@@ -315,14 +315,16 @@ class ReceptorControl:
             return
 
         try:
-            if text in ['', b'', '\n']:
-                print(f'WARNING: results from work unit were empty: {text}')
+            if text in ["", b"", "\n"]:
+                print(f"WARNING: results from work unit were empty: {text}")
             elif looks_like_json(text):
                 try:
                     _ = json.loads(text)
                 except (ValueError, TypeError):
-                    print(f'WARNING: results appear to be valid JSON but did not parse correctly: {text}')
+                    print(
+                        f"WARNING: results appear to be valid JSON but did not parse correctly: {text}"
+                    )
             elif contains_json_like_fragments(text):
-                print(f'WARNING: results contain both regular text and JSON fragments: {text}')
-        except:
-            pass # Ignore all errors because this function shouldn't halt processing.
+                print(f"WARNING: results contain both regular text and JSON fragments: {text}")
+        except Exception:
+            pass  # Ignore all errors because this function shouldn't halt processing.

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -15,6 +15,34 @@ def shutdown_write(sock):
         sock.shutdown(socket.SHUT_WR)
 
 
+def contains_json_like_fragments(s):
+    """Determines if the input contains substrings that resemble JSON."""
+
+    # Pattern to match balanced {...} or [...] in a rough and non-recursive way
+    object_pattern = r'({[^{}[\]]*})'
+    array_pattern = r'(\[[^\[\]{}]*\])'
+
+    # Find all non-overlapping matches
+    matches = re.findall(f'{object_pattern}|{array_pattern}', s)
+
+    for match in matches:
+        # match is a tuple because of regex alternation. Get the first non-empty match.
+        fragment = next((m for m in match if m), None)
+        if fragment and looks_like_json(fragment):
+            return True
+
+    return False
+
+
+def looks_like_json(s):
+    """Basic structural heuristics to decide if a string resembles JSON."""
+    s = s.strip()
+    if (s.startswith('{') and s.endswith('}')) or (s.startswith('[') and s.endswith(']')):
+        if re.search(r'"\s*:\s*', s) or re.search(r'("*\w+\s*,*)*', s) or s in ['{}', '[]']:
+            return True
+    return False
+
+
 class ReceptorControl:
     def __init__(
         self,
@@ -25,6 +53,7 @@ class ReceptorControl:
         key=None,
         cert=None,
         insecureskipverify=False,
+        print_sanitized_results=False,
     ):
         if config and any((rootcas, key, cert)):
             raise RuntimeError("Cannot specify both config and rootcas, key, cert")
@@ -38,6 +67,7 @@ class ReceptorControl:
         self._key = key
         self._cert = cert
         self._insecureskipverify = insecureskipverify
+        self._print_sanitized_results = print_sanitized_results
         if config and tlsclient:
             self.readconfig(config, tlsclient)
 
@@ -246,6 +276,7 @@ class ReceptorControl:
         self.connect()
         self.writestr(f"work results {unit_id} {startpos}\n")
         text = self.readstr()
+        self.get_sanitized_results(text)
         m = re.compile("Streaming results for work unit (.+)").fullmatch(text)
         if not m:
             errmsg = "Failed to get results"
@@ -277,3 +308,21 @@ class ReceptorControl:
             return sockfile
         else:
             return
+
+    def get_sanitized_results(self, text):
+        """Prints results that are unexpected or empty."""
+        if not self._print_sanitized_results:
+            return
+
+        try:
+            if text in ['', b'', '\n']:
+                print(f'WARNING: results from work unit were empty: {text}')
+            elif looks_like_json(text):
+                try:
+                    _ = json.loads(text)
+                except (ValueError, TypeError):
+                    print(f'WARNING: results appear to be valid JSON but did not parse correctly: {text}')
+            elif contains_json_like_fragments(text):
+                print(f'WARNING: results contain both regular text and JSON fragments: {text}')
+        except:
+            pass # Ignore all errors because this function shouldn't halt processing.

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -305,8 +305,10 @@ class ReceptorControl:
             return sockfile
         else:
             return
-        
-    def get_sanitized_work_results(self, unit_id, startpos=0, return_socket=False, return_sockfile=True):
+
+    def get_sanitized_work_results(
+        self, unit_id, startpos=0, return_socket=False, return_sockfile=True
+    ):
         self.connect()
         self.writestr(f"work results {unit_id} {startpos}\n")
         text = self.readstr()
@@ -315,7 +317,7 @@ class ReceptorControl:
         # is regular text mixed with JSON fragments.
 
         if text in ["", b"", "\n"]:
-                self.writestr(f"WARNING: results from work unit were empty: {text}")
+            self.writestr(f"WARNING: results from work unit were empty: {text}")
         elif looks_like_json(text):
             try:
                 _ = json.loads(text)

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -53,7 +53,6 @@ class ReceptorControl:
         key=None,
         cert=None,
         insecureskipverify=False,
-        print_sanitized_results=False,
     ):
         if config and any((rootcas, key, cert)):
             raise RuntimeError("Cannot specify both config and rootcas, key, cert")
@@ -67,7 +66,6 @@ class ReceptorControl:
         self._key = key
         self._cert = cert
         self._insecureskipverify = insecureskipverify
-        self._print_sanitized_results = print_sanitized_results
         if config and tlsclient:
             self.readconfig(config, tlsclient)
 

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -276,7 +276,6 @@ class ReceptorControl:
         self.connect()
         self.writestr(f"work results {unit_id} {startpos}\n")
         text = self.readstr()
-        self.get_sanitized_results(text)
         m = re.compile("Streaming results for work unit (.+)").fullmatch(text)
         if not m:
             errmsg = "Failed to get results"
@@ -308,23 +307,55 @@ class ReceptorControl:
             return sockfile
         else:
             return
+        
+    def get_sanitized_work_results(self, unit_id, startpos=0, return_socket=False, return_sockfile=True):
+        self.connect()
+        self.writestr(f"work results {unit_id} {startpos}\n")
+        text = self.readstr()
 
-    def get_sanitized_results(self, text):
-        """Prints results that are unexpected or empty."""
-        if not self._print_sanitized_results:
-            return
+        # Check if the text that was read is empty, contains unparsable JSON, or
+        # is regular text mixed with JSON fragments.
 
+        if text in ["", b"", "\n"]:
+                self.writestr(f"WARNING: results from work unit were empty: {text}")
+        elif looks_like_json(text):
+            try:
+                _ = json.loads(text)
+            except (ValueError, TypeError):
+                self.writestr(
+                    f"WARNING: results appear to be valid JSON but did not parse correctly: {text}"
+                )
+        elif contains_json_like_fragments(text):
+            self.writestr(f"WARNING: results contain both regular text and JSON fragments: {text}")
+
+        m = re.compile("Streaming results for work unit (.+)").fullmatch(text)
+        if not m:
+            errmsg = "Failed to get results"
+            if str.startswith(text, "ERROR: "):
+                errmsg = errmsg + ": " + text[7:]
+            raise RuntimeError(errmsg)
+        shutdown_write(self._socket)
+
+        # We return the filelike object created by makefile() by default, or optionally
+        # the socket itself.  Either way, we close the other dup'd handle so the caller's
+        # close will be effective.
+
+        socket = self._socket
+        sockfile = self._sockfile
         try:
-            if text in ["", b"", "\n"]:
-                print(f"WARNING: results from work unit were empty: {text}")
-            elif looks_like_json(text):
-                try:
-                    _ = json.loads(text)
-                except (ValueError, TypeError):
-                    print(
-                        f"WARNING: results appear to be valid JSON but did not parse correctly: {text}"
-                    )
-            elif contains_json_like_fragments(text):
-                print(f"WARNING: results contain both regular text and JSON fragments: {text}")
-        except Exception:
-            pass  # Ignore all errors because this function shouldn't halt processing.
+            if not return_socket:
+                self._socket.close()
+            if not return_sockfile:
+                self._sockfile.close()
+        finally:
+            self._socket = None
+            self._sockfile = None
+
+        if return_socket and return_sockfile:
+            return socket, sockfile
+        elif return_socket:
+            return socket
+        elif return_sockfile:
+            return sockfile
+        else:
+            return


### PR DESCRIPTION
This new function will print a warning and allow regular processing to continue. Warnings are printed under the following conditions.

- The work unit results string is empty.
- The work unit results string looks like JSON but doesn't parse correctly.
- The work unit results string is a mix of regular text and JSON fragments.

[AAP-47152](https://issues.redhat.com/browse/AAP-47152)