### PR TITLE
Fix panics in workceptor/python_test.go

### DIFF
--- a/pkg/workceptor/python_test.go
+++ b/pkg/workceptor/python_test.go
@@ -23,7 +23,7 @@ func createPythonUnitTestSetup(t *testing.T) (workceptor.WorkUnit, *mock_workcep
 	mockBaseWorkUnit := mock_workceptor.NewMockBaseWorkUnitForWorkUnit(ctrl)
 	mockNetceptor := mock_workceptor.NewMockNetceptorForWorkceptor(ctrl)
 	mockNetceptor.EXPECT().NodeID().Return("NodeID")
-	mockNetceptor.EXPECT().GetLogger()
+	mockNetceptor.EXPECT().GetLogger().AnyTimes()
 
 	w, err := workceptor.New(ctx, mockNetceptor, "/tmp")
 	if err != nil {
@@ -124,14 +124,10 @@ func TestPythonUnitStartFailsOnInvalidConfig(t *testing.T) {
 }
 
 func TestWorkPythonConfigNewWorkerRunsToSuccess(t *testing.T) {
-	_, mockBaseWorkUnitForWorkUnit, mockNetceptorForWorkceptor, _ := createPythonUnitTestSetup(t)
+	_, mockBaseWorkUnitForWorkUnit, mockNetceptorForWorkceptor, w := createPythonUnitTestSetup(t)
 	mockNetceptorForWorkceptor.EXPECT().NodeID().AnyTimes()
 
 	wpc := &workceptor.WorkPythonCfg{}
-	w, err := workceptor.New(context.TODO(), mockNetceptorForWorkceptor, "")
-	if err != nil {
-		t.Errorf("Error when creating workceptor for test: %v", err)
-	}
 	workUnit := wpc.NewWorker(mockBaseWorkUnitForWorkUnit, w, "", "")
 	if workUnit == nil {
 		t.Error("Returned WorkUnit was nil")
@@ -139,17 +135,13 @@ func TestWorkPythonConfigNewWorkerRunsToSuccess(t *testing.T) {
 }
 
 func TestWorkPythonConfigRunRunsToSuccess(t *testing.T) {
-	_, _, mockNetceptorForWorkceptor, _ := createPythonUnitTestSetup(t) //nolint:dogsled
+	_, _, mockNetceptorForWorkceptor, w := createPythonUnitTestSetup(t) //nolint:dogsled
 	mockNetceptorForWorkceptor.EXPECT().NodeID().AnyTimes()
 	mockNetceptorForWorkceptor.EXPECT().AddWorkCommand("", false)
 
 	wpc := &workceptor.WorkPythonCfg{}
-	w, err := workceptor.New(context.TODO(), mockNetceptorForWorkceptor, "")
-	if err != nil {
-		t.Errorf("Error when creating workceptor for test: %v", err)
-	}
 	workceptor.MainInstance = w
-	err = wpc.Run()
+	err := wpc.Run()
 	if err == nil {
 		t.Errorf("Expected deprecation warning but received none.")
 	}

--- a/pkg/workceptor/python_test.go
+++ b/pkg/workceptor/python_test.go
@@ -135,7 +135,7 @@ func TestWorkPythonConfigNewWorkerRunsToSuccess(t *testing.T) {
 }
 
 func TestWorkPythonConfigRunRunsToSuccess(t *testing.T) {
-	_, _, mockNetceptorForWorkceptor, w := createPythonUnitTestSetup(t) //nolint:dogsled
+	_, _, mockNetceptorForWorkceptor, w := createPythonUnitTestSetup(t)
 	mockNetceptorForWorkceptor.EXPECT().NodeID().AnyTimes()
 	mockNetceptorForWorkceptor.EXPECT().AddWorkCommand("", false)
 


### PR DESCRIPTION
Fixes the following test errors I am getting on devel branch:

```
Running tool: /usr/local/go/bin/go test -timeout 30s -run ^(TestPythonUnitStartRunsToSuccess|TestPythonUnitStartFailsOnInvalidConfig|TestWorkPythonConfigNewWorkerRunsToSuccess|TestWorkPythonConfigRunRunsToSuccess)$ github.com/ansible/receptor/pkg/workceptor

--- FAIL: TestWorkPythonConfigNewWorkerRunsToSuccess (0.00s)
    /home/lranjbar/github/ansible/receptor/pkg/workceptor/workceptor.go:354: Unexpected call to *mock_workceptor.MockNetceptorForWorkceptor.GetLogger([]) at /home/lranjbar/github/ansible/receptor/pkg/workceptor/workceptor.go:354 because: 
        expected call at /home/lranjbar/github/ansible/receptor/pkg/workceptor/python_test.go:26 has already been called the max number of times
--- FAIL: TestWorkPythonConfigRunRunsToSuccess (0.00s)
    /home/lranjbar/github/ansible/receptor/pkg/workceptor/workceptor.go:354: Unexpected call to *mock_workceptor.MockNetceptorForWorkceptor.GetLogger([]) at /home/lranjbar/github/ansible/receptor/pkg/workceptor/workceptor.go:354 because: 
        expected call at /home/lranjbar/github/ansible/receptor/pkg/workceptor/python_test.go:26 has already been called the max number of times
    /home/lranjbar/github/ansible/receptor/pkg/workceptor/controller.go:97: missing call(s) to *mock_workceptor.MockNetceptorForWorkceptor.AddWorkCommand(is equal to  (string), is equal to false (bool)) /home/lranjbar/github/ansible/receptor/pkg/workceptor/python_test.go:144
    /home/lranjbar/github/ansible/receptor/pkg/workceptor/controller.go:97: aborting test due to missing call(s)
FAIL
FAIL	github.com/ansible/receptor/pkg/workceptor	0.013s
FAIL

Running tool: /usr/local/go/bin/go test -timeout 30s -run ^(TestPythonUnitStartRunsToSuccess|TestPythonUnitStartFailsOnInvalidConfig|TestWorkPythonConfigNewWorkerRunsToSuccess|TestWorkPythonConfigRunRunsToSuccess)$ github.com/ansible/receptor/pkg/workceptor

--- FAIL: TestWorkPythonConfigNewWorkerRunsToSuccess (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x8b56d2]
FAIL	github.com/ansible/receptor/pkg/workceptor	0.012s
FAIL

Running tool: /usr/local/go/bin/go test -timeout 30s -run ^(TestPythonUnitStartRunsToSuccess|TestPythonUnitStartFailsOnInvalidConfig|TestWorkPythonConfigNewWorkerRunsToSuccess|TestWorkPythonConfigRunRunsToSuccess)$ github.com/ansible/receptor/pkg/workceptor

--- FAIL: TestWorkPythonConfigRunRunsToSuccess (0.00s)
    /home/lranjbar/github/ansible/receptor/pkg/workceptor/controller.go:97: missing call(s) to *mock_workceptor.MockNetceptorForWorkceptor.AddWorkCommand(is equal to  (string), is equal to false (bool)) /home/lranjbar/github/ansible/receptor/pkg/workceptor/python_test.go:140
    /home/lranjbar/github/ansible/receptor/pkg/workceptor/controller.go:97: aborting test due to missing call(s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x8b56d2]
FAIL	github.com/ansible/receptor/pkg/workceptor	0.012s
FAIL
```