### PR TITLE
Tests for udp_proxy.go

### DIFF
--- a/pkg/services/mock_services/udp_proxy.go
+++ b/pkg/services/mock_services/udp_proxy.go
@@ -10,10 +10,12 @@
 package mock_services
 
 import (
+	net "net"
 	reflect "reflect"
 
 	logger "github.com/ansible/receptor/pkg/logger"
 	netceptor "github.com/ansible/receptor/pkg/netceptor"
+	netinterface "github.com/ansible/receptor/pkg/services/interfaces"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -97,4 +99,76 @@ func (m *MockNetcForUDPProxy) NewAddr(node, service string) netceptor.Addr {
 func (mr *MockNetcForUDPProxyMockRecorder) NewAddr(node, service any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddr", reflect.TypeOf((*MockNetcForUDPProxy)(nil).NewAddr), node, service)
+}
+
+// MockRunNetceptorToUDPInboundFunc is a mock of RunNetceptorToUDPInboundFunc interface.
+type MockRunNetceptorToUDPInboundFunc struct {
+	ctrl     *gomock.Controller
+	recorder *MockRunNetceptorToUDPInboundFuncMockRecorder
+	isgomock struct{}
+}
+
+// MockRunNetceptorToUDPInboundFuncMockRecorder is the mock recorder for MockRunNetceptorToUDPInboundFunc.
+type MockRunNetceptorToUDPInboundFuncMockRecorder struct {
+	mock *MockRunNetceptorToUDPInboundFunc
+}
+
+// NewMockRunNetceptorToUDPInboundFunc creates a new mock instance.
+func NewMockRunNetceptorToUDPInboundFunc(ctrl *gomock.Controller) *MockRunNetceptorToUDPInboundFunc {
+	mock := &MockRunNetceptorToUDPInboundFunc{ctrl: ctrl}
+	mock.recorder = &MockRunNetceptorToUDPInboundFuncMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRunNetceptorToUDPInboundFunc) EXPECT() *MockRunNetceptorToUDPInboundFuncMockRecorder {
+	return m.recorder
+}
+
+// RunNetceptorToUDPInbound mocks base method.
+func (m *MockRunNetceptorToUDPInboundFunc) RunNetceptorToUDPInbound(pc netceptor.PacketConner, uc netinterface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RunNetceptorToUDPInbound", pc, uc, udpAddr, expectedAddr)
+}
+
+// RunNetceptorToUDPInbound indicates an expected call of RunNetceptorToUDPInbound.
+func (mr *MockRunNetceptorToUDPInboundFuncMockRecorder) RunNetceptorToUDPInbound(pc, uc, udpAddr, expectedAddr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunNetceptorToUDPInbound", reflect.TypeOf((*MockRunNetceptorToUDPInboundFunc)(nil).RunNetceptorToUDPInbound), pc, uc, udpAddr, expectedAddr)
+}
+
+// MockRunNetceptorToUDPOutboundFunc is a mock of RunNetceptorToUDPOutboundFunc interface.
+type MockRunNetceptorToUDPOutboundFunc struct {
+	ctrl     *gomock.Controller
+	recorder *MockRunNetceptorToUDPOutboundFuncMockRecorder
+	isgomock struct{}
+}
+
+// MockRunNetceptorToUDPOutboundFuncMockRecorder is the mock recorder for MockRunNetceptorToUDPOutboundFunc.
+type MockRunNetceptorToUDPOutboundFuncMockRecorder struct {
+	mock *MockRunNetceptorToUDPOutboundFunc
+}
+
+// NewMockRunNetceptorToUDPOutboundFunc creates a new mock instance.
+func NewMockRunNetceptorToUDPOutboundFunc(ctrl *gomock.Controller) *MockRunNetceptorToUDPOutboundFunc {
+	mock := &MockRunNetceptorToUDPOutboundFunc{ctrl: ctrl}
+	mock.recorder = &MockRunNetceptorToUDPOutboundFuncMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRunNetceptorToUDPOutboundFunc) EXPECT() *MockRunNetceptorToUDPOutboundFuncMockRecorder {
+	return m.recorder
+}
+
+// RunNetceptorToUDPOutbound mocks base method.
+func (m *MockRunNetceptorToUDPOutboundFunc) RunNetceptorToUDPOutbound(pc netceptor.PacketConner, uc netinterface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RunNetceptorToUDPOutbound", pc, uc, udpAddr, expectedAddr)
+}
+
+// RunNetceptorToUDPOutbound indicates an expected call of RunNetceptorToUDPOutbound.
+func (mr *MockRunNetceptorToUDPOutboundFuncMockRecorder) RunNetceptorToUDPOutbound(pc, uc, udpAddr, expectedAddr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunNetceptorToUDPOutbound", reflect.TypeOf((*MockRunNetceptorToUDPOutboundFunc)(nil).RunNetceptorToUDPOutbound), pc, uc, udpAddr, expectedAddr)
 }

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -70,7 +70,7 @@ func UDPProxyServiceInbound(s NetcForUDPProxy, host string, port int, node strin
 				}
 				s.GetLogger().Debug("Received new UDP connection from %s\n", raddrStr)
 				connMap[raddrStr] = pc
-				go runNetceptorToUDPInbound(pc, uc, addr, s.NewAddr(node, service), s.GetLogger())
+				go RunNetceptorToUDPInbound(pc, uc, addr, s.NewAddr(node, service))
 			}
 			wn, err := pc.WriteTo(buffer[:n], ncAddr)
 			if err != nil {
@@ -89,31 +89,41 @@ func UDPProxyServiceInbound(s NetcForUDPProxy, host string, port int, node strin
 	return nil
 }
 
-func runNetceptorToUDPInbound(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr, logger *logger.ReceptorLogger) {
+func processInboundPacket(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr, buf []byte) {
+	n, addr, err := pc.ReadFrom(buf)
+	if err != nil {
+		pc.GetLogger().Error("Error reading from Receptor network: %s\n", err)
+
+		return
+	}
+	if addr.String() != expectedAddr.String() {
+		pc.GetLogger().Debug("Received packet from unexpected source %s\n", addr)
+
+		return
+	}
+	wn, err := uc.WriteTo(buf[:n], udpAddr)
+	if err != nil {
+		pc.GetLogger().Error("Error sending packet via UDP: %s\n", err)
+
+		return
+	}
+	if wn != n {
+		pc.GetLogger().Debug("Not all bytes written via UDP\n")
+
+		return
+	}
+}
+
+type RunNetceptorToUDPInboundFunc interface {
+	RunNetceptorToUDPInbound(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr)
+}
+
+type RunNetceptorToUDPInboundImpl struct{}
+
+func RunNetceptorToUDPInbound(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr) {
 	buf := make([]byte, utils.NormalBufferSize)
 	for {
-		n, addr, err := pc.ReadFrom(buf)
-		if err != nil {
-			pc.GetLogger().Error("Error reading from Receptor network: %s\n", err)
-
-			continue
-		}
-		if addr != expectedAddr {
-			pc.GetLogger().Debug("Received packet from unexpected source %s\n", addr)
-
-			continue
-		}
-		wn, err := uc.WriteTo(buf[:n], udpAddr)
-		if err != nil {
-			pc.GetLogger().Error("Error sending packet via UDP: %s\n", err)
-
-			continue
-		}
-		if wn != n {
-			pc.GetLogger().Debug("Not all bytes written via UDP\n")
-
-			continue
-		}
+		processInboundPacket(pc, uc, udpAddr, expectedAddr, buf)
 	}
 }
 
@@ -151,7 +161,7 @@ func UDPProxyServiceOutbound(s NetcForUDPProxy, service string, address string, 
 				}
 				s.GetLogger().Debug("Opened new UDP connection to %s\n", raddrStr)
 				connMap[raddrStr] = uc
-				go runUDPToNetceptorOutbound(uc, pc, addr, s.GetLogger())
+				go RunUDPToNetceptorOutbound(uc, pc, addr)
 			}
 			wn, err := uc.Write(buffer[:n])
 			if err != nil {
@@ -170,26 +180,36 @@ func UDPProxyServiceOutbound(s NetcForUDPProxy, service string, address string, 
 	return nil
 }
 
-func runUDPToNetceptorOutbound(uc net_interface.UDPConnInterface, pc netceptor.PacketConner, addr net.Addr, logger *logger.ReceptorLogger) {
+type RunNetceptorToUDPOutboundFunc interface {
+	RunNetceptorToUDPOutbound(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr)
+}
+
+type RunNetceptorToUDPOutboundImpl struct{}
+
+func processOutboundPacket(uc net_interface.UDPConnInterface, pc netceptor.PacketConner, addr net.Addr, buf []byte) {
+	n, err := uc.Read(buf)
+	if err != nil {
+		pc.GetLogger().Error("Error reading from UDP: %s\n", err)
+
+		return
+	}
+	wn, err := pc.WriteTo(buf[:n], addr)
+	if err != nil {
+		pc.GetLogger().Error("Error writing to the Receptor network: %s\n", err)
+
+		return
+	}
+	if wn != n {
+		pc.GetLogger().Debug("Not all bytes written to the Netceptor network\n")
+
+		return
+	}
+}
+
+func RunUDPToNetceptorOutbound(uc net_interface.UDPConnInterface, pc netceptor.PacketConner, addr net.Addr) {
 	buf := make([]byte, utils.NormalBufferSize)
 	for {
-		n, err := uc.Read(buf)
-		if err != nil {
-			pc.GetLogger().Error("Error reading from UDP: %s\n", err)
-
-			return
-		}
-		wn, err := pc.WriteTo(buf[:n], addr)
-		if err != nil {
-			pc.GetLogger().Error("Error writing to the Receptor network: %s\n", err)
-
-			continue
-		}
-		if wn != n {
-			pc.GetLogger().Debug("Not all bytes written to the Netceptor network\n")
-
-			continue
-		}
+		processOutboundPacket(uc, pc, addr, buf)
 	}
 }
 

--- a/pkg/services/udp_proxy_test.go
+++ b/pkg/services/udp_proxy_test.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"errors"
+	"fmt"
+	"net"
 	"testing"
 
 	"github.com/ansible/receptor/pkg/logger"
@@ -9,6 +11,7 @@ import (
 	"github.com/ansible/receptor/pkg/netceptor/mock_netceptor"
 	mock_net_interface "github.com/ansible/receptor/pkg/services/interfaces/mock_interfaces"
 	"github.com/ansible/receptor/pkg/services/mock_services"
+	"github.com/ansible/receptor/pkg/utils"
 	"go.uber.org/mock/gomock"
 )
 
@@ -24,8 +27,6 @@ func setUpMocks(ctrl *gomock.Controller) (*mock_services.MockNetcForUDPProxy, *m
 }
 
 func TestUDPProxyServiceInbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	var mockNetceptor *mock_services.MockNetcForUDPProxy
 	var mockNetter *mock_net_interface.MockNetterUDP
 	var mockUDPConn *mock_net_interface.MockUDPConnInterface
@@ -77,8 +78,12 @@ func TestUDPProxyServiceInbound(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			mockNetceptor, mockNetter, mockUDPConn, mockPacketCon = setUpMocks(ctrl)
-			tc.calls()
+			if tc.calls != nil {
+				tc.calls()
+			}
 			err := UDPProxyServiceInbound(mockNetceptor, tc.host, tc.port, tc.node, tc.service, mockNetter)
 			if tc.expectErr {
 				if err == nil {
@@ -94,8 +99,6 @@ func TestUDPProxyServiceInbound(t *testing.T) {
 }
 
 func TestUDPProxyServiceOutbound(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 	var mockNetceptor *mock_services.MockNetcForUDPProxy
 	var mockNetter *mock_net_interface.MockNetterUDP
 	var mockPacketCon *mock_netceptor.MockPacketConner
@@ -135,8 +138,12 @@ func TestUDPProxyServiceOutbound(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			mockNetceptor, mockNetter, _, mockPacketCon = setUpMocks(ctrl)
-			tc.calls()
+			if tc.calls != nil {
+				tc.calls()
+			}
 			err := UDPProxyServiceOutbound(mockNetceptor, tc.service, tc.address, mockNetter)
 			if tc.expectErr {
 				if err == nil {
@@ -147,6 +154,120 @@ func TestUDPProxyServiceOutbound(t *testing.T) {
 			} else if err != nil {
 				t.Errorf("net UDPProxyServiceOutbound error")
 			}
+		})
+	}
+}
+
+func TestProcessInboundPacket(t *testing.T) {
+	expectedAddr := netceptor.Addr{}
+	expectedAddr.SetNetwork("tcp")
+	expectedAddr.SetNode("127.0.0.1")
+	expectedAddr.SetService("2222")
+	expectedUDPAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 2222}
+	unexpectedUDPAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 3333}
+	var mockUDPConnInterface *mock_net_interface.MockUDPConnInterface
+	var mockPacketConner *mock_netceptor.MockPacketConner
+	tests := []struct {
+		name           string
+		expectedAddr   netceptor.Addr
+		calls          func()
+		expectContinue bool
+	}{
+		{
+			name:         "ReadFrom error",
+			expectedAddr: expectedAddr,
+			calls: func() {
+				mockPacketConner.EXPECT().ReadFrom(gomock.Any()).Return(0, expectedUDPAddr, fmt.Errorf("ReadFrom error")).Times(1)
+				mockPacketConner.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).Times(1)
+			},
+		},
+		{
+			name:         "Expected Address mismatch",
+			expectedAddr: expectedAddr,
+			calls: func() {
+				mockPacketConner.EXPECT().ReadFrom(gomock.Any()).Return(0, unexpectedUDPAddr, nil).Times(1)
+				mockPacketConner.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).Times(1)
+			},
+		},
+		{
+			name:         "WriteTo error",
+			expectedAddr: expectedAddr,
+			calls: func() {
+				mockPacketConner.EXPECT().ReadFrom(gomock.Any()).Return(1, expectedUDPAddr, nil).Times(1)
+				mockUDPConnInterface.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(1, fmt.Errorf("WriteTo error")).Times(1)
+				mockPacketConner.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).Times(1)
+			},
+		},
+		{
+			name:         "Written bytes mismatch",
+			expectedAddr: expectedAddr,
+			calls: func() {
+				mockPacketConner.EXPECT().ReadFrom(gomock.Any()).Return(7, expectedUDPAddr, nil).Times(1)
+				mockUDPConnInterface.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(5, nil).Times(1)
+				mockPacketConner.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).Times(1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			_, _, mockUDPConnInterface, mockPacketConner = setUpMocks(ctrl)
+			if tt.calls != nil {
+				tt.calls()
+			}
+			buf := make([]byte, utils.NormalBufferSize)
+			processInboundPacket(mockPacketConner, mockUDPConnInterface, expectedUDPAddr, tt.expectedAddr, buf)
+		})
+	}
+}
+
+func TestProcessOutboundPacket(t *testing.T) {
+	destinationAddr := &net.UDPAddr{IP: net.ParseIP("192.168.0.1"), Port: 2222}
+	var mockPacketConner *mock_netceptor.MockPacketConner
+	var mockUDPConnInterface *mock_net_interface.MockUDPConnInterface
+	tests := []struct {
+		name           string
+		Addr           netceptor.Addr
+		calls          func()
+		expectContinue bool
+	}{
+		{
+			name: "Read error",
+			calls: func() {
+				mockUDPConnInterface.EXPECT().Read(gomock.Any()).Return(1, fmt.Errorf("Read error")).Times(1)
+				mockPacketConner.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).Times(1)
+			},
+		},
+		{
+			name: "WriteTo error",
+			calls: func() {
+				mockUDPConnInterface.EXPECT().Read(gomock.Any()).Return(1, nil).Times(1)
+				mockPacketConner.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(1, fmt.Errorf("WriteTo error")).Times(1)
+				mockPacketConner.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).Times(1)
+			},
+		},
+		{
+			name: "Written bytes mismatch",
+			calls: func() {
+				mockUDPConnInterface.EXPECT().Read(gomock.Any()).Return(7, nil).Times(1)
+				mockPacketConner.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(5, nil).Times(1)
+				mockPacketConner.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).Times(1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			_, _, mockUDPConnInterface, mockPacketConner = setUpMocks(ctrl)
+			if tt.calls != nil {
+				tt.calls()
+			}
+			buf := make([]byte, utils.NormalBufferSize)
+			processOutboundPacket(mockUDPConnInterface, mockPacketConner, destinationAddr, buf)
 		})
 	}
 }


### PR DESCRIPTION
AAP-45827

Changes:

* Move the logic inside the loop of `runNetceptorToUDPInbound` into `processInboundPacket`
* Move the logic inside the loop of `runUDPToNetceptorOutbound` into `processOutboundPacket`
* Make both `runNetceptorToUDPInbound` and `runUDPToNetceptorOutbound` mockable (for follow up PRs)
* Removed `*logger.ReceptorLogger` from the function arguments, as it is not being used.

Also changed:
```
if addr != expectedAddr { // First is net.Addr, second is netceptor.Addr
```

Into:
```
if addr.String() != expectedAddr.String() {
```

I suspect this function is not called in production environments, or otherwise it would have logged:
```
Received packet from unexpected source
```
every time it is called.

