### PR TITLE
POC for allowing runtime env vars DO NOT MERGE

### DIFF
--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -54,16 +54,18 @@ type BaseWorkUnitForWorkUnit interface {
 // commandUnit implements the WorkUnit interface for the Receptor command worker plugin.
 type commandUnit struct {
 	BaseWorkUnitForWorkUnit
-	command            string
-	baseParams         string
-	allowRuntimeParams bool
-	done               bool
+	command             string
+	baseParams          string
+	allowRuntimeParams  bool
+	allowRuntimeEnvVars bool
+	done                bool
 }
 
 // CommandExtraData is the content of the ExtraData JSON field for a command worker.
 type CommandExtraData struct {
-	Pid    int
-	Params string
+	Pid     int
+	Params  string
+	EnvVars string
 }
 
 func termThenKill(cmd *exec.Cmd, doneChan chan bool) {
@@ -97,7 +99,7 @@ func cmdWaiter(cmd *exec.Cmd, doneChan chan bool) {
 }
 
 // commandRunner is run in a separate process, to monitor the subprocess and report back metadata.
-func commandRunner(command string, params string, unitdir string) error {
+func commandRunner(command string, params string, envvars string, unitdir string) error {
 	status := StatusFileData{}
 	status.ExtraData = &CommandExtraData{}
 	statusFilename := path.Join(unitdir, "status")
@@ -157,6 +159,20 @@ func commandRunner(command string, params string, unitdir string) error {
 	}
 	cmd.Stdout = stdout
 	cmd.Stderr = stdout
+
+	// Parse and set environment variables
+	if envvars != "" {
+		// Start with the current environment
+		cmd.Env = os.Environ()
+		
+		// Parse environment variables in format "KEY1=value1,KEY2=value2"
+		envPairs := strings.Split(envvars, ",")
+		for _, pair := range envPairs {
+			if strings.TrimSpace(pair) != "" {
+				cmd.Env = append(cmd.Env, strings.TrimSpace(pair))
+			}
+		}
+	}
 
 	err = cmd.Start()
 	if err != nil {
@@ -246,7 +262,23 @@ func (cw *commandUnit) SetFromParams(params map[string]string) error {
 	if cmdParams != "" && !cw.allowRuntimeParams {
 		return fmt.Errorf("extra params provided but not allowed")
 	}
-	cw.GetStatusCopy().ExtraData.(*CommandExtraData).Params = combineParams(cw.baseParams, cmdParams)
+	
+	envVars, ok := params["envvars"]
+	if !ok {
+		envVars = ""
+	}
+	if envVars != "" && !cw.allowRuntimeEnvVars {
+		return fmt.Errorf("environment variables provided but not allowed")
+	}
+	
+	// Use UpdateFullStatus to properly update the status
+	cw.UpdateFullStatus(func(status *StatusFileData) {
+		if status.ExtraData == nil {
+			status.ExtraData = &CommandExtraData{}
+		}
+		status.ExtraData.(*CommandExtraData).Params = combineParams(cw.baseParams, cmdParams)
+		status.ExtraData.(*CommandExtraData).EnvVars = envVars
+	})
 
 	return nil
 }
@@ -322,6 +354,7 @@ func (cw *commandUnit) Start() error {
 		"--command-runner",
 		fmt.Sprintf("command=%s", cw.command),
 		fmt.Sprintf("params=%s", cw.Status().ExtraData.(*CommandExtraData).Params),
+		fmt.Sprintf("envvars=%s", cw.Status().ExtraData.(*CommandExtraData).EnvVars),
 		fmt.Sprintf("unitdir=%s", cw.UnitDir()))
 
 	return cw.runCommand(cmd)
@@ -391,11 +424,12 @@ func (cw *commandUnit) Release(force bool) error {
 
 // CommandWorkerCfg is the cmdline configuration object for a worker that runs a command.
 type CommandWorkerCfg struct {
-	WorkType           string `required:"true" description:"Name for this worker type"`
-	Command            string `required:"true" description:"Command to run to process units of work"`
-	Params             string `description:"Command-line parameters"`
-	AllowRuntimeParams bool   `description:"Allow users to add more parameters" default:"false"`
-	VerifySignature    bool   `description:"Verify a signed work submission" default:"false"`
+	WorkType             string `required:"true" description:"Name for this worker type"`
+	Command              string `required:"true" description:"Command to run to process units of work"`
+	Params               string `description:"Command-line parameters"`
+	AllowRuntimeParams   bool   `description:"Allow users to add more parameters" default:"false"`
+	AllowRuntimeEnvVars  bool   `description:"Allow users to add environment variables" default:"false"`
+	VerifySignature      bool   `description:"Verify a signed work submission" default:"false"`
 }
 
 func (cfg CommandWorkerCfg) NewWorker(bwu BaseWorkUnitForWorkUnit, w *Workceptor, unitID string, workType string) WorkUnit {
@@ -412,6 +446,7 @@ func (cfg CommandWorkerCfg) NewWorker(bwu BaseWorkUnitForWorkUnit, w *Workceptor
 		command:                 cfg.Command,
 		baseParams:              cfg.Params,
 		allowRuntimeParams:      cfg.AllowRuntimeParams,
+		allowRuntimeEnvVars:     cfg.AllowRuntimeEnvVars,
 	}
 	cw.BaseWorkUnitForWorkUnit.Init(w, unitID, workType, FileSystem{})
 
@@ -440,12 +475,13 @@ func (cfg CommandWorkerCfg) Run() error {
 type commandRunnerCfg struct {
 	Command string `required:"true"`
 	Params  string `required:"true"`
+	EnvVars string `required:"true"`
 	UnitDir string `required:"true"`
 }
 
 // Run runs the action.
 func (cfg commandRunnerCfg) Run() error {
-	err := commandRunner(cfg.Command, cfg.Params, cfg.UnitDir)
+	err := commandRunner(cfg.Command, cfg.Params, cfg.EnvVars, cfg.UnitDir)
 	if err != nil {
 		statusFilename := path.Join(cfg.UnitDir, "status")
 		err2 := (&StatusFileData{}).UpdateBasicStatus(statusFilename, WorkStateFailed, err.Error(), stdoutSize(cfg.UnitDir))

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -48,6 +48,7 @@ type KubeUnit struct {
 	allowRuntimeAuth       bool
 	allowRuntimeCommand    bool
 	allowRuntimeParams     bool
+	allowRuntimeEnvVars    bool
 	allowRuntimePod        bool
 	deletePodOnRestart     bool
 	namePrefix             string
@@ -62,6 +63,7 @@ type KubeExtraData struct {
 	Image         string
 	Command       string
 	Params        string
+	EnvVars       string
 	KubeNamespace string
 	KubeConfig    string
 	KubePod       string
@@ -453,6 +455,57 @@ func (kw *KubeUnit) KubeLoggingWithReconnect(streamWait *sync.WaitGroup, stdout 
 	}
 }
 
+// parseEnvVars parses a comma-separated string of environment variables
+// in format "KEY1=value1,KEY2=value2" and returns a map
+func parseEnvVars(envVarsStr string) map[string]string {
+	if envVarsStr == "" {
+		return nil
+	}
+	
+	envMap := make(map[string]string)
+	envPairs := strings.Split(envVarsStr, ",")
+	for _, pair := range envPairs {
+		trimmedPair := strings.TrimSpace(pair)
+		if trimmedPair != "" {
+			parts := strings.SplitN(trimmedPair, "=", 2)
+			if len(parts) == 2 {
+				key := strings.TrimSpace(parts[0])
+				value := strings.TrimSpace(parts[1])
+				if key != "" {
+					envMap[key] = value
+				}
+			}
+		}
+	}
+	
+	return envMap
+}
+
+// mergeEnvMaps merges two environment variable maps, with the second map taking precedence
+func mergeEnvMaps(base, overlay map[string]string) map[string]string {
+	if base == nil && overlay == nil {
+		return nil
+	}
+	
+	merged := make(map[string]string)
+	
+	// Copy base map
+	if base != nil {
+		for k, v := range base {
+			merged[k] = v
+		}
+	}
+	
+	// Overlay takes precedence
+	if overlay != nil {
+		for k, v := range overlay {
+			merged[k] = v
+		}
+	}
+	
+	return merged
+}
+
 func (kw *KubeUnit) CreatePod(env map[string]string) error {
 	ked := kw.UnredactedStatus().ExtraData.(*KubeExtraData)
 	command, err := shlex.Split(ked.Command)
@@ -524,9 +577,13 @@ func (kw *KubeUnit) CreatePod(env map[string]string) error {
 		Spec:       *spec,
 	}
 
-	if env != nil {
+	// Parse environment variables from user input and merge with passed-in env
+	userEnv := parseEnvVars(ked.EnvVars)
+	finalEnv := mergeEnvMaps(env, userEnv)
+
+	if finalEnv != nil {
 		evs := make([]corev1.EnvVar, 0)
-		for k, v := range env {
+		for k, v := range finalEnv {
 			evs = append(evs, corev1.EnvVar{
 				Name:  k,
 				Value: v,
@@ -1401,11 +1458,13 @@ func (kw *KubeUnit) SetFromParams(params map[string]string) error {
 	userCommand := ""
 	userImage := ""
 	userPod := ""
+	userEnvVars := ""
 	podPendingTimeoutString := ""
 	values := []value{
 		{name: "kube_command", permission: kw.allowRuntimeCommand, setter: setString(&userCommand)},
 		{name: "kube_image", permission: kw.allowRuntimeCommand, setter: setString(&userImage)},
 		{name: "kube_params", permission: kw.allowRuntimeParams, setter: setString(&userParams)},
+		{name: "envvars", permission: kw.allowRuntimeEnvVars, setter: setString(&userEnvVars)},
 		{name: "kube_namespace", permission: kw.allowRuntimeAuth, setter: setString(&ked.KubeNamespace)},
 		{name: "secret_kube_config", permission: kw.allowRuntimeAuth, setter: setString(&ked.KubeConfig)},
 		{name: "secret_kube_pod", permission: kw.allowRuntimePod, setter: setString(&userPod)},
@@ -1454,6 +1513,9 @@ func (kw *KubeUnit) SetFromParams(params map[string]string) error {
 		kw.baseParams = ""
 	} else {
 		ked.Params = combineParams(kw.baseParams, userParams)
+	}
+	if userEnvVars != "" {
+		ked.EnvVars = userEnvVars
 	}
 
 	return nil
@@ -1588,6 +1650,7 @@ type KubeWorkerCfg struct {
 	AllowRuntimeAuth    bool   `description:"Allow passing API parameters at runtime" default:"false"`
 	AllowRuntimeCommand bool   `description:"Allow specifying image & command at runtime" default:"false"`
 	AllowRuntimeParams  bool   `description:"Allow adding command parameters at runtime" default:"false"`
+	AllowRuntimeEnvVars bool   `description:"Allow users to add environment variables" default:"false"`
 	AllowRuntimePod     bool   `description:"Allow passing Pod at runtime" default:"false"`
 	DeletePodOnRestart  bool   `description:"On restart, delete the pod if in pending state" default:"true"`
 	StreamMethod        string `description:"Method for connecting to worker pods: logger or tcp" default:"logger"`
@@ -1630,6 +1693,7 @@ func (cfg KubeWorkerCfg) NewkubeWorker(bwu BaseWorkUnitForWorkUnit, w *Workcepto
 		allowRuntimeAuth:        cfg.AllowRuntimeAuth,
 		allowRuntimeCommand:     cfg.AllowRuntimeCommand,
 		allowRuntimeParams:      cfg.AllowRuntimeParams,
+		allowRuntimeEnvVars:     cfg.AllowRuntimeEnvVars,
 		allowRuntimePod:         cfg.AllowRuntimePod,
 		deletePodOnRestart:      cfg.DeletePodOnRestart,
 		namePrefix:              fmt.Sprintf("%s-", strings.ToLower(cfg.WorkType)),

--- a/receptorctl/receptorctl/cli.py
+++ b/receptorctl/receptorctl/cli.py
@@ -432,6 +432,12 @@ def list_units(ctx, unit_id, node, tlsclient, quiet):
     help="Additional Receptor parameter (key=value format)",
     multiple=True,
 )
+@click.option(
+    "--envvars",
+    "-e",
+    help="Environment variables (key=value format)",
+    multiple=True,
+)
 @click.argument("cmdparams", type=str, required=False, nargs=-1)
 def submit(
     ctx,
@@ -446,6 +452,7 @@ def submit(
     follow,
     rm,
     param,
+    envvars,
     cmdparams,
 ):
     pcmds = 0
@@ -487,6 +494,12 @@ def submit(
                 allparams.append(params["params"])
             allparams.extend(cmdparams)
             params["params"] = " ".join(allparams)
+        
+        # Process environment variables
+        if envvars:
+            envvar_dict = dict(s.split("=", 1) for s in envvars)
+            params["envvars"] = ",".join(f"{k}={v}" for k, v in envvar_dict.items())
+        
         if node == "":
             node = None
         rc = get_rc(ctx)


### PR DESCRIPTION
TODO: 

Turn this POC into production code,
Add unit and integration tests,
Update Docs with new flags, 


How to run this POC:

Receptor config:
# Sample Receptor configuration for testing environment variables POC
---
- node:
    id: test-node

- log-level: debug

- control-service:
    service: control
    filename: /tmp/receptor-test.sock

- work-command:
    worktype: test-env-vars
    command: ./test_env_command.sh
    allowruntimeenvvars: true

- work-command:
    worktype: test-no-env-vars
    command: ./test_env_command.sh
    allowruntimeenvvars: false
    
- work-kubernetes:
    worktype: test-kube-env-allowed
    authmethod: runtime
    allowruntimeauth: true
    allowruntimeenvvars: true
    image: busybox:latest
    command: sh
    params: -c 'echo "=== Kubernetes Environment Variables Test ==="; echo "LOG_LEVEL=\${LOG_LEVEL:-NOT_SET}"; echo "API_KEY=\${API_KEY:-NOT_SET}"; echo "CUSTOM_VAR=\${CUSTOM_VAR:-NOT_SET}"; echo "=== All Environment Variables ==="; env | sort'

- work-kubernetes:
    worktype: test-kube-env-blocked
    authmethod: runtime
    allowruntimeauth: true
    allowruntimeenvvars: false
    image: busybox:latest
    command: sh
    params: -c 'echo "=== Kubernetes Environment Variables Test ==="; echo "LOG_LEVEL=\${LOG_LEVEL:-NOT_SET}"; echo "API_KEY=\${API_KEY:-NOT_SET}"; echo "CUSTOM_VAR=\${CUSTOM_VAR:-NOT_SET}"; echo "=== All Environment Variables ==="; env | sort'

    

Receptorctl command

receptorctl \
        --socket "$RECEPTOR_SOCK" \
        work submit test-env-allowed \
        --envvars LOG_LEVEL=debug \
        --envvars API_KEY=test123 \
        --envvars CUSTOM_VAR=hello_world \
        --no-payload

Fail case:

receptorctl \
        --socket "$RECEPTOR_SOCK" \
        work submit test-env-blocked \
        --envvars LOG_LEVEL=debug \
        --envvars API_KEY=test123 \
        --no-payload
        
Kube commands
receptorctl work submit test-kube-env \
    --param secret_kube_config=@~/.kube/config \
    --envvars LOG_LEVEL=debug \
    --envvars API_KEY=secret123 \
    --envvars CUSTOM_VAR=kube_test \
    --no-payload