### PR TITLE
Update OSWrapper calls to be consistent

### DIFF
--- a/pkg/certificates/ca.go
+++ b/pkg/certificates/ca.go
@@ -43,7 +43,7 @@ type CA struct {
 
 // LoadFromPEMFile loads certificate data from a PEM file.
 func LoadFromPEMFile(filename string, osWrapper Oser) ([]interface{}, error) {
-	content, err := Oser.ReadFile(osWrapper, filename)
+	content, err := osWrapper.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/certificates/cli.go
+++ b/pkg/certificates/cli.go
@@ -15,15 +15,6 @@ import (
 	"github.com/spf13/viper"
 )
 
-// Oser is the function calls interfaces for mocking os.
-// type Oser interface {
-//	ReadFile(name string) ([]byte, error)
-//	WriteFile(name string, data []byte, perm fs.FileMode) error
-//}
-
-// OsWrapper is the Wrapper structure for Oser.
-// type OsWrapper struct{}
-
 // InitCA Initialize Certificate Authority.
 func InitCA(opts *CertOptions, certOut, keyOut string, osWrapper Oser) error {
 	ca, err := CreateCA(opts, &RsaWrapper{})


### PR DESCRIPTION
This change makes calls to OSWrapper consistent to the others in the file and removes old commented code.