### PR TITLE
udp_proxy.go: Reorder functions for readibility and increased coverage

### DIFF
--- a/pkg/services/mock_services/udp_proxy.go
+++ b/pkg/services/mock_services/udp_proxy.go
@@ -10,12 +10,10 @@
 package mock_services
 
 import (
-	net "net"
 	reflect "reflect"
 
 	logger "github.com/ansible/receptor/pkg/logger"
 	netceptor "github.com/ansible/receptor/pkg/netceptor"
-	netinterface "github.com/ansible/receptor/pkg/services/interfaces"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -99,76 +97,4 @@ func (m *MockNetcForUDPProxy) NewAddr(node, service string) netceptor.Addr {
 func (mr *MockNetcForUDPProxyMockRecorder) NewAddr(node, service any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewAddr", reflect.TypeOf((*MockNetcForUDPProxy)(nil).NewAddr), node, service)
-}
-
-// MockRunNetceptorToUDPInboundFunc is a mock of RunNetceptorToUDPInboundFunc interface.
-type MockRunNetceptorToUDPInboundFunc struct {
-	ctrl     *gomock.Controller
-	recorder *MockRunNetceptorToUDPInboundFuncMockRecorder
-	isgomock struct{}
-}
-
-// MockRunNetceptorToUDPInboundFuncMockRecorder is the mock recorder for MockRunNetceptorToUDPInboundFunc.
-type MockRunNetceptorToUDPInboundFuncMockRecorder struct {
-	mock *MockRunNetceptorToUDPInboundFunc
-}
-
-// NewMockRunNetceptorToUDPInboundFunc creates a new mock instance.
-func NewMockRunNetceptorToUDPInboundFunc(ctrl *gomock.Controller) *MockRunNetceptorToUDPInboundFunc {
-	mock := &MockRunNetceptorToUDPInboundFunc{ctrl: ctrl}
-	mock.recorder = &MockRunNetceptorToUDPInboundFuncMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRunNetceptorToUDPInboundFunc) EXPECT() *MockRunNetceptorToUDPInboundFuncMockRecorder {
-	return m.recorder
-}
-
-// RunNetceptorToUDPInbound mocks base method.
-func (m *MockRunNetceptorToUDPInboundFunc) RunNetceptorToUDPInbound(pc netceptor.PacketConner, uc netinterface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RunNetceptorToUDPInbound", pc, uc, udpAddr, expectedAddr)
-}
-
-// RunNetceptorToUDPInbound indicates an expected call of RunNetceptorToUDPInbound.
-func (mr *MockRunNetceptorToUDPInboundFuncMockRecorder) RunNetceptorToUDPInbound(pc, uc, udpAddr, expectedAddr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunNetceptorToUDPInbound", reflect.TypeOf((*MockRunNetceptorToUDPInboundFunc)(nil).RunNetceptorToUDPInbound), pc, uc, udpAddr, expectedAddr)
-}
-
-// MockRunNetceptorToUDPOutboundFunc is a mock of RunNetceptorToUDPOutboundFunc interface.
-type MockRunNetceptorToUDPOutboundFunc struct {
-	ctrl     *gomock.Controller
-	recorder *MockRunNetceptorToUDPOutboundFuncMockRecorder
-	isgomock struct{}
-}
-
-// MockRunNetceptorToUDPOutboundFuncMockRecorder is the mock recorder for MockRunNetceptorToUDPOutboundFunc.
-type MockRunNetceptorToUDPOutboundFuncMockRecorder struct {
-	mock *MockRunNetceptorToUDPOutboundFunc
-}
-
-// NewMockRunNetceptorToUDPOutboundFunc creates a new mock instance.
-func NewMockRunNetceptorToUDPOutboundFunc(ctrl *gomock.Controller) *MockRunNetceptorToUDPOutboundFunc {
-	mock := &MockRunNetceptorToUDPOutboundFunc{ctrl: ctrl}
-	mock.recorder = &MockRunNetceptorToUDPOutboundFuncMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockRunNetceptorToUDPOutboundFunc) EXPECT() *MockRunNetceptorToUDPOutboundFuncMockRecorder {
-	return m.recorder
-}
-
-// RunNetceptorToUDPOutbound mocks base method.
-func (m *MockRunNetceptorToUDPOutboundFunc) RunNetceptorToUDPOutbound(pc netceptor.PacketConner, uc netinterface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RunNetceptorToUDPOutbound", pc, uc, udpAddr, expectedAddr)
-}
-
-// RunNetceptorToUDPOutbound indicates an expected call of RunNetceptorToUDPOutbound.
-func (mr *MockRunNetceptorToUDPOutboundFuncMockRecorder) RunNetceptorToUDPOutbound(pc, uc, udpAddr, expectedAddr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunNetceptorToUDPOutbound", reflect.TypeOf((*MockRunNetceptorToUDPOutboundFunc)(nil).RunNetceptorToUDPOutbound), pc, uc, udpAddr, expectedAddr)
 }

--- a/pkg/services/udp_proxy.go
+++ b/pkg/services/udp_proxy.go
@@ -33,62 +33,7 @@ func (n *NetUDPWrapper) DialUDP(network string, laddr *net.UDPAddr, raddr *net.U
 	return net.DialUDP(network, laddr, raddr)
 }
 
-// UDPProxyServiceInbound listens on a UDP port and forwards packets to a remote Receptor service.
-func UDPProxyServiceInbound(s NetcForUDPProxy, host string, port int, node string, service string, nett net_interface.NetterUDP) error {
-	connMap := make(map[string]netceptor.PacketConner)
-	buffer := make([]byte, utils.NormalBufferSize)
-
-	addrStr := fmt.Sprintf("%s:%d", host, port)
-	udpAddr, err := nett.ResolveUDPAddr("udp", addrStr)
-	if err != nil {
-		return fmt.Errorf("could not resolve address %s", addrStr)
-	}
-
-	uc, err := nett.ListenUDP("udp", udpAddr)
-	if err != nil {
-		return fmt.Errorf("error listening on UDP: %s", err)
-	}
-
-	ncAddr := s.NewAddr(node, service)
-
-	go func() {
-		for {
-			n, addr, err := uc.ReadFrom(buffer)
-			if err != nil {
-				s.GetLogger().Error("Error reading from UDP: %s\n", err)
-
-				return
-			}
-			raddrStr := addr.String()
-			pc, ok := connMap[raddrStr]
-			if !ok {
-				pc, err = s.ListenPacket("")
-				if err != nil {
-					s.GetLogger().Error("Error listening on Receptor network: %s\n", err)
-
-					return
-				}
-				s.GetLogger().Debug("Received new UDP connection from %s\n", raddrStr)
-				connMap[raddrStr] = pc
-				go RunNetceptorToUDPInbound(pc, uc, addr, s.NewAddr(node, service))
-			}
-			wn, err := pc.WriteTo(buffer[:n], ncAddr)
-			if err != nil {
-				s.GetLogger().Error("Error sending packet on Receptor network: %s\n", err)
-
-				continue
-			}
-			if wn != n {
-				s.GetLogger().Debug("Not all bytes written on Receptor network\n")
-
-				continue
-			}
-		}
-	}()
-
-	return nil
-}
-
+// processInboundPacket processes a single inbound packet from the Receptor network and forwards it to UDP.
 func processInboundPacket(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr, buf []byte) {
 	n, addr, err := pc.ReadFrom(buf)
 	if err != nil {
@@ -114,65 +59,70 @@ func processInboundPacket(pc netceptor.PacketConner, uc net_interface.UDPConnInt
 	}
 }
 
-type RunNetceptorToUDPInboundFunc interface {
-	RunNetceptorToUDPInbound(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr)
-}
+// runUDPProxyServiceInbound executes the main loop for the UDP inbound proxy
+// Returns false if an error is found, true if it should continue.
+func runUDPProxyServiceInbound(s NetcForUDPProxy, uc net_interface.UDPConnInterface, buffer []byte, connMap map[string]netceptor.PacketConner, ncAddr netceptor.Addr, node string, service string) bool {
+	n, addr, err := uc.ReadFrom(buffer)
+	if err != nil {
+		s.GetLogger().Error("Error reading from UDP: %s\n", err)
 
-type RunNetceptorToUDPInboundImpl struct{}
-
-func RunNetceptorToUDPInbound(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr) {
-	buf := make([]byte, utils.NormalBufferSize)
-	for {
-		processInboundPacket(pc, uc, udpAddr, expectedAddr, buf)
+		return false
 	}
+	raddrStr := addr.String()
+	pc, ok := connMap[raddrStr]
+	if !ok {
+		pc, err = s.ListenPacket("")
+		if err != nil {
+			s.GetLogger().Error("Error listening on Receptor network: %s\n", err)
+
+			return false
+		}
+		s.GetLogger().Debug("Received new UDP connection from %s\n", raddrStr)
+		connMap[raddrStr] = pc
+		go func() {
+			buf := make([]byte, utils.NormalBufferSize)
+			for {
+				processInboundPacket(pc, uc, addr, s.NewAddr(node, service), buf)
+			}
+		}()
+	}
+	wn, err := pc.WriteTo(buffer[:n], ncAddr)
+	if err != nil {
+		s.GetLogger().Error("Error sending packet on Receptor network: %s\n", err)
+
+		return true // continue
+	}
+	if wn != n {
+		s.GetLogger().Debug("Not all bytes written on Receptor network\n")
+
+		return true // continue
+	}
+
+	return true // continue
 }
 
-// UDPProxyServiceOutbound listens on the Receptor network and forwards packets via UDP.
-func UDPProxyServiceOutbound(s NetcForUDPProxy, service string, address string, nett net_interface.NetterUDP) error {
-	connMap := make(map[string]net_interface.UDPConnInterface)
+// UDPProxyServiceInbound listens on a UDP port and forwards packets to a remote Receptor service.
+func UDPProxyServiceInbound(s NetcForUDPProxy, host string, port int, node string, service string, nett net_interface.NetterUDP) error {
+	connMap := make(map[string]netceptor.PacketConner)
 	buffer := make([]byte, utils.NormalBufferSize)
-	udpAddr, err := nett.ResolveUDPAddr("udp", address)
+
+	addrStr := fmt.Sprintf("%s:%d", host, port)
+	udpAddr, err := nett.ResolveUDPAddr("udp", addrStr)
 	if err != nil {
-		return fmt.Errorf("could not resolve UDP address %s", address)
+		return fmt.Errorf("could not resolve address %s", addrStr)
 	}
-	pc, err := s.ListenPacketAndAdvertise(service, map[string]string{
-		"type":    "UDP Proxy",
-		"address": address,
-	})
+
+	uc, err := nett.ListenUDP("udp", udpAddr)
 	if err != nil {
-		return fmt.Errorf("error listening on service %s: %s", service, err)
+		return fmt.Errorf("error listening on UDP: %s", err)
 	}
+
+	ncAddr := s.NewAddr(node, service)
+
 	go func() {
 		for {
-			n, addr, err := pc.ReadFrom(buffer)
-			if err != nil {
-				s.GetLogger().Error("Error reading from Receptor network: %s\n", err)
-
+			if !runUDPProxyServiceInbound(s, uc, buffer, connMap, ncAddr, node, service) {
 				return
-			}
-			raddrStr := addr.String()
-			uc, ok := connMap[raddrStr]
-			if !ok {
-				uc, err = nett.DialUDP("udp", nil, udpAddr)
-				if err != nil {
-					s.GetLogger().Error("Error connecting via UDP: %s\n", err)
-
-					return
-				}
-				s.GetLogger().Debug("Opened new UDP connection to %s\n", raddrStr)
-				connMap[raddrStr] = uc
-				go RunUDPToNetceptorOutbound(uc, pc, addr)
-			}
-			wn, err := uc.Write(buffer[:n])
-			if err != nil {
-				s.GetLogger().Error("Error writing to UDP: %s\n", err)
-
-				continue
-			}
-			if wn != n {
-				s.GetLogger().Debug("Not all bytes written to UDP\n")
-
-				continue
 			}
 		}
 	}()
@@ -180,12 +130,7 @@ func UDPProxyServiceOutbound(s NetcForUDPProxy, service string, address string, 
 	return nil
 }
 
-type RunNetceptorToUDPOutboundFunc interface {
-	RunNetceptorToUDPOutbound(pc netceptor.PacketConner, uc net_interface.UDPConnInterface, udpAddr net.Addr, expectedAddr netceptor.Addr)
-}
-
-type RunNetceptorToUDPOutboundImpl struct{}
-
+// processOutboundPacket processes a single outbound packet from the Receptor network and forwards it to UDP.
 func processOutboundPacket(uc net_interface.UDPConnInterface, pc netceptor.PacketConner, addr net.Addr, buf []byte) {
 	n, err := uc.Read(buf)
 	if err != nil {
@@ -206,11 +151,72 @@ func processOutboundPacket(uc net_interface.UDPConnInterface, pc netceptor.Packe
 	}
 }
 
-func RunUDPToNetceptorOutbound(uc net_interface.UDPConnInterface, pc netceptor.PacketConner, addr net.Addr) {
-	buf := make([]byte, utils.NormalBufferSize)
-	for {
-		processOutboundPacket(uc, pc, addr, buf)
+// runUDPProxyServiceOutbound executes the main loop for the UDP outbound proxy
+// Returns false if an error is found, true if it should continue.
+func runUDPProxyServiceOutbound(s NetcForUDPProxy, pc netceptor.PacketConner, buffer []byte, connMap map[string]net_interface.UDPConnInterface, udpAddr *net.UDPAddr, nett net_interface.NetterUDP) bool {
+	n, addr, err := pc.ReadFrom(buffer)
+	if err != nil {
+		s.GetLogger().Error("Error reading from Receptor network: %s\n", err)
+
+		return false
 	}
+	raddrStr := addr.String()
+	uc, ok := connMap[raddrStr]
+	if !ok {
+		uc, err = nett.DialUDP("udp", nil, udpAddr)
+		if err != nil {
+			s.GetLogger().Error("Error connecting via UDP: %s\n", err)
+
+			return false
+		}
+		s.GetLogger().Debug("Opened new UDP connection to %s\n", raddrStr)
+		connMap[raddrStr] = uc
+		go func() {
+			buf := make([]byte, utils.NormalBufferSize)
+			for {
+				processOutboundPacket(uc, pc, addr, buf)
+			}
+		}()
+	}
+	wn, err := uc.Write(buffer[:n])
+	if err != nil {
+		s.GetLogger().Error("Error writing to UDP: %s\n", err)
+
+		return true // continue
+	}
+	if wn != n {
+		s.GetLogger().Debug("Not all bytes written to UDP\n")
+
+		return true // continue
+	}
+
+	return true // continue
+}
+
+// UDPProxyServiceOutbound listens on the Receptor network and forwards packets via UDP.
+func UDPProxyServiceOutbound(s NetcForUDPProxy, service string, address string, nett net_interface.NetterUDP) error {
+	connMap := make(map[string]net_interface.UDPConnInterface)
+	buffer := make([]byte, utils.NormalBufferSize)
+	udpAddr, err := nett.ResolveUDPAddr("udp", address)
+	if err != nil {
+		return fmt.Errorf("could not resolve UDP address %s", address)
+	}
+	pc, err := s.ListenPacketAndAdvertise(service, map[string]string{
+		"type":    "UDP Proxy",
+		"address": address,
+	})
+	if err != nil {
+		return fmt.Errorf("error listening on service %s: %s", service, err)
+	}
+	go func() {
+		for {
+			if !runUDPProxyServiceOutbound(s, pc, buffer, connMap, udpAddr, nett) {
+				return
+			}
+		}
+	}()
+
+	return nil
 }
 
 // udpProxyInboundCfg is the cmdline configuration object for a UDP inbound proxy.

--- a/pkg/services/udp_proxy_test.go
+++ b/pkg/services/udp_proxy_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/netceptor/mock_netceptor"
+	net_interface "github.com/ansible/receptor/pkg/services/interfaces"
 	mock_net_interface "github.com/ansible/receptor/pkg/services/interfaces/mock_interfaces"
 	"github.com/ansible/receptor/pkg/services/mock_services"
 	"github.com/ansible/receptor/pkg/utils"
@@ -268,6 +269,210 @@ func TestProcessOutboundPacket(t *testing.T) {
 			}
 			buf := make([]byte, utils.NormalBufferSize)
 			processOutboundPacket(mockUDPConnInterface, mockPacketConner, destinationAddr, buf)
+		})
+	}
+}
+
+func TestRunUDPProxyServiceInbound(t *testing.T) {
+	var mockNetceptor *mock_services.MockNetcForUDPProxy
+	var mockUDPConn *mock_net_interface.MockUDPConnInterface
+	var mockPacketCon *mock_netceptor.MockPacketConner
+	tests := []struct {
+		name           string
+		calls          func()
+		expectContinue bool
+	}{
+		{
+			name: "ReadFrom error - should return false",
+			calls: func() {
+				mockUDPConn.EXPECT().ReadFrom(gomock.Any()).Return(0, nil, fmt.Errorf("ReadFrom error")).Times(1)
+			},
+			expectContinue: false,
+		},
+		{
+			name: "ListenPacket error for new connection - should return false",
+			calls: func() {
+				mockUDPConn.EXPECT().ReadFrom(gomock.Any()).Return(1, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetceptor.EXPECT().ListenPacket("").Return(nil, fmt.Errorf("ListenPacket error")).Times(1)
+			},
+			expectContinue: false,
+		},
+		{
+			name: "WriteTo error - should return true (continue)",
+			calls: func() {
+				mockUDPConn.EXPECT().ReadFrom(gomock.Any()).Return(1, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetceptor.EXPECT().ListenPacket("").Return(mockPacketCon, nil).Times(1)
+				mockNetceptor.EXPECT().NewAddr(gomock.Any(), gomock.Any()).Return(netceptor.Addr{}).AnyTimes() // For the goroutine
+				mockPacketCon.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(0, fmt.Errorf("WriteTo error")).Times(1)
+				// Expectations for the goroutine that might run after the test
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(0, nil, fmt.Errorf("test cleanup")).AnyTimes()
+				mockUDPConn.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).AnyTimes()
+			},
+			expectContinue: true,
+		},
+		{
+			name: "Partial write - should return true (continue)",
+			calls: func() {
+				mockUDPConn.EXPECT().ReadFrom(gomock.Any()).Return(10, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetceptor.EXPECT().ListenPacket("").Return(mockPacketCon, nil).Times(1)
+				mockNetceptor.EXPECT().NewAddr(gomock.Any(), gomock.Any()).Return(netceptor.Addr{}).AnyTimes() // For the goroutine
+				mockPacketCon.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(5, nil).Times(1)
+				// Expectations for the goroutine that might run after the test
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(0, nil, fmt.Errorf("test cleanup")).AnyTimes()
+				mockUDPConn.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).AnyTimes()
+			},
+			expectContinue: true,
+		},
+		{
+			name: "Successful write with new connection - should return true (continue)",
+			calls: func() {
+				mockUDPConn.EXPECT().ReadFrom(gomock.Any()).Return(10, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetceptor.EXPECT().ListenPacket("").Return(mockPacketCon, nil).Times(1)
+				mockNetceptor.EXPECT().NewAddr(gomock.Any(), gomock.Any()).Return(netceptor.Addr{}).AnyTimes() // For the goroutine
+				mockPacketCon.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(10, nil).Times(1)
+				// Expectations for the goroutine that might run after the test
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(0, nil, fmt.Errorf("test cleanup")).AnyTimes()
+				mockUDPConn.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).AnyTimes()
+			},
+			expectContinue: true,
+		},
+		{
+			name: "Successful write with existing connection - should return true (continue)",
+			calls: func() {
+				mockUDPConn.EXPECT().ReadFrom(gomock.Any()).Return(10, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockPacketCon.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(10, nil).Times(1)
+			},
+			expectContinue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetceptor, _, mockUDPConn, mockPacketCon = setUpMocks(ctrl)
+			if tt.calls != nil {
+				tt.calls()
+			}
+
+			connMap := make(map[string]netceptor.PacketConner)
+			if tt.name == "Successful write with existing connection - should return true (continue)" {
+				// Pre-populate the connection map for this test
+				connMap["127.0.0.1:8080"] = mockPacketCon
+			}
+
+			buffer := make([]byte, utils.NormalBufferSize)
+			ncAddr := netceptor.Addr{}
+
+			result := runUDPProxyServiceInbound(mockNetceptor, mockUDPConn, buffer, connMap, ncAddr, "testnode", "testservice")
+
+			if result != tt.expectContinue {
+				t.Errorf("Expected runUDPProxyServiceInbound to return %v, but got %v", tt.expectContinue, result)
+			}
+		})
+	}
+}
+
+func TestRunUDPProxyServiceOutbound(t *testing.T) {
+	var mockNetceptor *mock_services.MockNetcForUDPProxy
+	var mockNetter *mock_net_interface.MockNetterUDP
+	var mockUDPConn *mock_net_interface.MockUDPConnInterface
+	var mockPacketCon *mock_netceptor.MockPacketConner
+	tests := []struct {
+		name           string
+		calls          func()
+		expectContinue bool
+	}{
+		{
+			name: "ReadFrom error - should return false",
+			calls: func() {
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(0, nil, fmt.Errorf("ReadFrom error")).Times(1)
+			},
+			expectContinue: false,
+		},
+		{
+			name: "DialUDP error for new connection - should return false",
+			calls: func() {
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(1, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetter.EXPECT().DialUDP("udp", nil, gomock.Any()).Return(nil, fmt.Errorf("DialUDP error")).Times(1)
+			},
+			expectContinue: false,
+		},
+		{
+			name: "Write error - should return true (continue)",
+			calls: func() {
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(1, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetter.EXPECT().DialUDP("udp", nil, gomock.Any()).Return(mockUDPConn, nil).Times(1)
+				mockUDPConn.EXPECT().Write(gomock.Any()).Return(0, fmt.Errorf("Write error")).Times(1)
+				// Expectations for the goroutine that might run after the test
+				mockUDPConn.EXPECT().Read(gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).AnyTimes()
+			},
+			expectContinue: true,
+		},
+		{
+			name: "Partial write - should return true (continue)",
+			calls: func() {
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(10, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetter.EXPECT().DialUDP("udp", nil, gomock.Any()).Return(mockUDPConn, nil).Times(1)
+				mockUDPConn.EXPECT().Write(gomock.Any()).Return(5, nil).Times(1)
+				// Expectations for the goroutine that might run after the test
+				mockUDPConn.EXPECT().Read(gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).AnyTimes()
+			},
+			expectContinue: true,
+		},
+		{
+			name: "Successful write with new connection - should return true (continue)",
+			calls: func() {
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(10, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockNetter.EXPECT().DialUDP("udp", nil, gomock.Any()).Return(mockUDPConn, nil).Times(1)
+				mockUDPConn.EXPECT().Write(gomock.Any()).Return(10, nil).Times(1)
+				// Expectations for the goroutine that might run after the test
+				mockUDPConn.EXPECT().Read(gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().WriteTo(gomock.Any(), gomock.Any()).Return(0, fmt.Errorf("test cleanup")).AnyTimes()
+				mockPacketCon.EXPECT().GetLogger().Return(logger.NewReceptorLogger("")).AnyTimes()
+			},
+			expectContinue: true,
+		},
+		{
+			name: "Successful write with existing connection - should return true (continue)",
+			calls: func() {
+				mockPacketCon.EXPECT().ReadFrom(gomock.Any()).Return(10, &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}, nil).Times(1)
+				mockUDPConn.EXPECT().Write(gomock.Any()).Return(10, nil).Times(1)
+			},
+			expectContinue: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockNetceptor, mockNetter, mockUDPConn, mockPacketCon = setUpMocks(ctrl)
+			if tt.calls != nil {
+				tt.calls()
+			}
+
+			connMap := make(map[string]net_interface.UDPConnInterface)
+			if tt.name == "Successful write with existing connection - should return true (continue)" {
+				// Pre-populate the connection map for this test
+				connMap["127.0.0.1:8080"] = mockUDPConn
+			}
+
+			buffer := make([]byte, utils.NormalBufferSize)
+			udpAddr := &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}
+
+			result := runUDPProxyServiceOutbound(mockNetceptor, mockPacketCon, buffer, connMap, udpAddr, mockNetter)
+
+			if result != tt.expectContinue {
+				t.Errorf("Expected runUDPProxyServiceOutbound to return %v, but got %v", tt.expectContinue, result)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Continuation of AAP-45827

The diff does not display the changes in a readable way, so in order to review this PR I recommend reading `udp_proxy.go` with this in mind:

* Inline functions called within loops are now separate functions: `runUDPProxyServiceInbound` and `runUDPProxyServiceOutbound`.
* Added tests for the new functions.
* Functions have been reordered so a function is always defined before called for the first time.
* Got rid of unused interface `RunNetceptorToUDPOutboundFunc` and types `RunNetceptorToUDPOutboundImpl`