### PR TITLE
AAP-46619 Get pod container status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ venv
 pkg/services/.lock
 pkg/workceptor/status
 pkg/workceptor/status.lock
+**/__debug_*

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,11 @@ require (
 )
 
 require (
+	github.com/pkg/errors v0.9.1 // indirect
+	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
+)
+
+require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/testify v1.10.0
 )

--- a/go.mod
+++ b/go.mod
@@ -33,11 +33,6 @@ require (
 )
 
 require (
-	github.com/pkg/errors v0.9.1 // indirect
-	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
-)
-
-require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/stretchr/testify v1.10.0
 )

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -177,6 +177,8 @@ var ErrPodFailed = fmt.Errorf("pod failed to start")
 // ErrImagePullBackOff is returned when the image for the container in the Pod cannot be pulled.
 var ErrImagePullBackOff = fmt.Errorf("container failed to start")
 
+const WorkerContainerName = "worker"
+
 // podRunningAndReady is a completion criterion for pod ready to be attached to.
 func podRunningAndReady(kw KubeUnit) func(event watch.Event) (bool, error) {
 	imagePullBackOffRetries := 3
@@ -249,7 +251,7 @@ func (kw *KubeUnit) kubeLoggingConnectionHandler(timestamps bool, sinceTime time
 	podNamespace := kw.Pod.Namespace
 	podName := kw.Pod.Name
 	podOptions := &corev1.PodLogOptions{
-		Container: "worker",
+		Container: WorkerContainerName,
 		Follow:    true,
 	}
 	if timestamps {
@@ -486,7 +488,7 @@ func (kw *KubeUnit) CreatePod(env map[string]string) error {
 		foundWorker := false
 		spec = &pod.Spec
 		for i := range spec.Containers {
-			if spec.Containers[i].Name == "worker" {
+			if spec.Containers[i].Name == WorkerContainerName {
 				spec.Containers[i].Stdin = true
 				spec.Containers[i].StdinOnce = true
 				foundWorker = true
@@ -517,7 +519,7 @@ func (kw *KubeUnit) CreatePod(env map[string]string) error {
 		}
 		spec = &corev1.PodSpec{
 			Containers: []corev1.Container{{
-				Name:      "worker",
+				Name:      WorkerContainerName,
 				Image:     ked.Image,
 				Command:   command,
 				Args:      params,
@@ -601,7 +603,7 @@ func (kw *KubeUnit) CreatePod(env map[string]string) error {
 	if err == ErrPodCompleted {
 		// Hao: shouldn't we also call kw.Cancel() in these cases?
 		for _, cstat := range kw.Pod.Status.ContainerStatuses {
-			if cstat.Name == "worker" {
+			if cstat.Name == WorkerContainerName {
 				if cstat.State.Terminated != nil && cstat.State.Terminated.ExitCode != 0 {
 					return fmt.Errorf("container failed with exit code %d: %s", cstat.State.Terminated.ExitCode, cstat.State.Terminated.Message)
 				}
@@ -632,7 +634,7 @@ func (kw *KubeUnit) CreatePod(env map[string]string) error {
 			}
 
 			for _, cstat := range kw.Pod.Status.ContainerStatuses {
-				if cstat.Name == "worker" {
+				if cstat.Name == WorkerContainerName {
 					if cstat.State.Waiting != nil {
 						return fmt.Errorf("%s, %s", err.Error(), cstat.State.Waiting.Reason)
 					}
@@ -732,7 +734,7 @@ func (kw *KubeUnit) runWorkUsingLogger() {
 
 		req.VersionedParams(
 			&corev1.PodExecOptions{
-				Container: "worker",
+				Container: WorkerContainerName,
 				Stdin:     true,
 				Stdout:    false,
 				Stderr:    false,

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -7,7 +7,6 @@ import (
 )
 
 type KubePodStateHelper interface {
-	GetPodStatus(pod *corev1.Pod) (bool, error)
 	PodHealthy(pod *corev1.Pod, containerName string) (bool, error)
 	PodContainerHealthy(pod *corev1.Pod, containerName string) (bool, error)
 }

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -30,7 +30,7 @@ func (kw KubeUnit) PodContainerHealthy(pod *corev1.Pod, containerName string) (b
 	if foundContainer == nil {
 		return false, fmt.Errorf("pod does not contain container %s", containerName)
 	}
-	if foundContainer.State.Waiting != nil { // means it is waiting, so application logic has not completed yet. Normal behavior when job completes successfully.
+	if foundContainer.State.Waiting != nil { // means it is waiting, so application logic has not completed yet.
 		return false, fmt.Errorf("container %s is waiting: %s %s", containerName, foundContainer.State.Waiting.Reason, foundContainer.State.Waiting.Message)
 	}
 	if foundContainer.State.Terminated == nil { // means it is waiting or running, so application logic has not completed yet. Normal behavior when job completes successfully.

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -51,10 +51,10 @@ func (kw KubeUnit) PodHealthy(pod *corev1.Pod, containerName string) (bool, erro
 		return false, fmt.Errorf("pod is nil")
 	}
 
-	containerDiag := fmt.Sprintf("container %s is healthy", containerName)
+	var containerDiag string = ""
 	containerOk, containerError := kw.PodContainerHealthy(pod, containerName)
 	if containerError != nil {
-		containerDiag = fmt.Sprintf("%v", containerError)
+		containerDiag = fmt.Sprintf(" %v", containerError)
 	}
 
 	switch pod.Status.Phase {
@@ -64,11 +64,11 @@ func (kw KubeUnit) PodHealthy(pod *corev1.Pod, containerName string) (bool, erro
 			podError = fmt.Errorf("%s message: %s", podError, pod.Status.Message)
 		}
 
-		return false, fmt.Errorf("%s %v", podError, containerDiag)
+		return false, fmt.Errorf("%s%s", podError, containerDiag)
 
 	case corev1.PodSucceeded, corev1.PodRunning, corev1.PodPending:
 		return containerOk, containerError
 	default:
-		return false, fmt.Errorf("unknown phase: %s %s", pod.Status.Phase, containerDiag)
+		return false, fmt.Errorf("unknown phase: %s%s", pod.Status.Phase, containerDiag)
 	}
 }

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -43,45 +43,24 @@ func (kw KubeUnit) PodHealthy(pod *corev1.Pod, containerName string) (bool, erro
 		return false, fmt.Errorf("pod is nil")
 	}
 
-	for _, cs := range pod.Status.ContainerStatuses {
-		// Check if this is the container we care about first
-		if cs.Name == containerName {
-			switch pod.Status.Phase {
-			case corev1.PodFailed:
-				podError := fmt.Errorf("pod failed with reason: %s", pod.Status.Reason)
-				if pod.Status.Message != "" {
-					podError = fmt.Errorf("%s: %s", podError.Error(), pod.Status.Message)
-				}
-				ok, containerError := kw.PodContainerHealthy(pod, containerName)
-				if !ok || containerError != nil {
-					return false, fmt.Errorf("%s %v", podError.Error(), containerError)
-				}
+	containerDiag := fmt.Sprintf("container %s is healthy", containerName)
+	containerOk, containerError := kw.PodContainerHealthy(pod, containerName)
+	if containerError != nil {
+		containerDiag = fmt.Sprintf("%v", containerError)
+	}
 
-				return false, podError
-
-			case corev1.PodSucceeded:
-				return true, nil
-			case corev1.PodRunning, corev1.PodPending:
-				return true, nil
-			default:
-				return false, fmt.Errorf("unknown phase: %s", pod.Status.Phase)
-			}
+	switch pod.Status.Phase {
+	case corev1.PodFailed:
+		podError := fmt.Errorf("pod failed with reason: %s", pod.Status.Reason)
+		if pod.Status.Message != "" {
+			podError = fmt.Errorf("%s message: %s", podError, pod.Status.Message)
 		}
+
+		return false, fmt.Errorf("%s %v", podError, containerDiag)
+
+	case corev1.PodSucceeded, corev1.PodRunning, corev1.PodPending:
+		return containerOk, containerError
+	default:
+		return false, fmt.Errorf("unknown phase: %s %s", pod.Status.Phase, containerDiag)
 	}
-
-	return false, fmt.Errorf("pod does not contain container %s", containerName)
-}
-
-// GetPodStatus checks if the pod has successfully completed its application logic and infrastructure is healthy.
-func (kw KubeUnit) GetPodStatus(pod *corev1.Pod) (bool, error) {
-	if pod == nil {
-		return false, fmt.Errorf("pod is nil")
-	}
-
-	ok, err := kw.PodHealthy(pod, WorkerContainerName)
-	if !ok || err != nil {
-		return ok, err
-	}
-
-	return ok, nil
 }

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -31,6 +31,9 @@ func (kw KubeUnit) PodContainerHealthy(pod *corev1.Pod, containerName string) (b
 	if foundContainer == nil {
 		return false, fmt.Errorf("pod does not contain container %s", containerName)
 	}
+	if foundContainer.State.Waiting != nil { // means it is waiting, so application logic has not completed yet. Normal behavior when job completes successfully.
+		return false, fmt.Errorf("container %s is waiting: %s %s", containerName, foundContainer.State.Waiting.Reason, foundContainer.State.Waiting.Message)
+	}
 	if foundContainer.State.Terminated == nil { // means it is waiting or running, so application logic has not completed yet. Normal behavior when job completes successfully.
 		return true, nil
 	}
@@ -42,8 +45,7 @@ func (kw KubeUnit) PodContainerHealthy(pod *corev1.Pod, containerName string) (b
 	return true, nil // container terminated with exit code of 0
 }
 
-// PodInfrastructureSuccess checks if the pod has either successfully started, is pending or is running, or has is successfully terminated.
-// Any other state is considered an infrastructure failure.
+// PodHealthy checks if the pod and container are in a healthy state.
 func (kw KubeUnit) PodHealthy(pod *corev1.Pod, containerName string) (bool, error) {
 	if pod == nil {
 		return false, fmt.Errorf("pod is nil")

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -19,21 +19,27 @@ func (kw KubeUnit) PodContainerHealthy(pod *corev1.Pod, containerName string) (b
 		return false, fmt.Errorf("pod is nil")
 	}
 
-	for _, cs := range pod.Status.ContainerStatuses {
+	var foundContainer *corev1.ContainerStatus = nil
+
+	for i, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == containerName {
-			if cs.State.Terminated == nil { // means it is waiting or running, so application logic has not completed yet. Normal behavior when job completes successfully.
-				return true, nil
-			}
+			foundContainer = &pod.Status.ContainerStatuses[i]
 
-			if cs.State.Terminated.ExitCode != 0 { // exit code of 0 means success
-				return false, fmt.Errorf("container %s exited with code %d: %s", cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
-			}
-
-			return true, nil // container terminated with exit code of 0
+			break
 		}
 	}
+	if foundContainer == nil {
+		return false, fmt.Errorf("pod does not contain container %s", containerName)
+	}
+	if foundContainer.State.Terminated == nil { // means it is waiting or running, so application logic has not completed yet. Normal behavior when job completes successfully.
+		return true, nil
+	}
 
-	return false, fmt.Errorf("pod does not contain container %s", containerName)
+	if foundContainer.State.Terminated.ExitCode != 0 { // exit code of 0 means success
+		return false, fmt.Errorf("container %s exited with code %d: %s", containerName, foundContainer.State.Terminated.ExitCode, foundContainer.State.Terminated.Reason)
+	}
+
+	return true, nil // container terminated with exit code of 0
 }
 
 // PodInfrastructureSuccess checks if the pod has either successfully started, is pending or is running, or has is successfully terminated.

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -1,0 +1,82 @@
+package workceptor
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+type KubePodStateHelper interface {
+	GetPodStatus(pod *corev1.Pod) (bool, error)
+	PodHealthy(pod *corev1.Pod, containerName string) (bool, error)
+	PodContainerHealthy(pod *corev1.Pod, containerName string) (bool, error)
+}
+
+// PodContainerHealthy checks if the pod has successfully completed its application logic.
+// this is called after podInfrastructureSuccess has confirmed the pod is in a terminal state.
+func (kw KubeUnit) PodContainerHealthy(pod *corev1.Pod, containerName string) (bool, error) {
+	if pod == nil {
+		return false, fmt.Errorf("pod is nil")
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName {
+			if cs.State.Terminated == nil { // means it is waiting or running, so application logic has not completed yet. Normal behavior when job completes successfully.
+				return true, nil
+			}
+
+			if cs.State.Terminated.ExitCode != 0 { // exit code of 0 means success
+				return false, fmt.Errorf("container %s exited with code %d: %s", cs.Name, cs.State.Terminated.ExitCode, cs.State.Terminated.Reason)
+			}
+
+			return true, nil // container terminated with exit code of 0
+		}
+	}
+
+	return false, fmt.Errorf("pod does not contain container %s", containerName)
+}
+
+// PodInfrastructureSuccess checks if the pod has either successfully started, is pending or is running, or has is successfully terminated.
+// Any other state is considered an infrastructure failure.
+func (kw KubeUnit) PodHealthy(pod *corev1.Pod, containerName string) (bool, error) {
+	if pod == nil {
+		return false, fmt.Errorf("pod is nil")
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		// Check if this is the container we care about first
+		if cs.Name == containerName {
+			switch pod.Status.Phase {
+			case corev1.PodFailed:
+				ok, err := kw.PodContainerHealthy(pod, containerName)
+				if !ok || err != nil {
+					return false, err
+				}
+
+				return true, nil
+			case corev1.PodSucceeded:
+				return true, nil
+			case corev1.PodRunning, corev1.PodPending:
+				return true, nil
+			default:
+				return false, fmt.Errorf("unknown phase: %s", pod.Status.Phase)
+			}
+		}
+	}
+
+	return false, fmt.Errorf("pod does not contain container %s", containerName)
+}
+
+// GetPodStatus checks if the pod has successfully completed its application logic and infrastructure is healthy.
+func (kw KubeUnit) GetPodStatus(pod *corev1.Pod) (bool, error) {
+	if pod == nil {
+		return false, fmt.Errorf("pod is nil")
+	}
+
+	ok, err := kw.PodHealthy(pod, WorkerContainerName)
+	if !ok || err != nil {
+		return ok, err
+	}
+
+	return ok, nil
+}

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -34,32 +34,33 @@ func (kw KubeUnit) PodContainerHealthy(pod *corev1.Pod, containerName string) (b
 	state := foundContainer.State
 
 	// Check if container is running and ready
-    if state.Running != nil {
-        return foundContainer.Ready, nil // Use Ready field for health
-    }
+	if state.Running != nil {
+		return foundContainer.Ready, nil // Use Ready field for health
+	}
 
-   // Check if container terminated successfully
-    if state.Terminated != nil {
-        if state.Terminated.ExitCode == 0 {
-            return true, nil // Successfully completed
-        }
-        return false, fmt.Errorf("container %s failed with exit code %d: %s %s", 
-            containerName, state.Terminated.ExitCode, state.Terminated.Reason,  state.Terminated.Message)
-    }
+	// Check if container terminated successfully
+	if state.Terminated != nil {
+		if state.Terminated.ExitCode == 0 {
+			return true, nil // Successfully completed
+		}
 
-    // Container is waiting - usually not healthy yet
-    if state.Waiting != nil {
-        // Check if it's a problematic waiting state
-        reason := state.Waiting.Reason
-        if reason == "ImagePullBackOff" || reason == "ErrImagePull" || 
-           reason == "CrashLoopBackOff" || reason == "CreateContainerConfigError" {
-            return false, fmt.Errorf("container %s in error state: %s %s", containerName, reason, state.Waiting.Message)
-        }
-        // Normal waiting states like "ContainerCreating", "PodInitializing"
-        return false, nil // Not healthy yet, but not an error
-    }
+		return false, fmt.Errorf("container %s failed with exit code %d: %s %s",
+			containerName, state.Terminated.ExitCode, state.Terminated.Reason, state.Terminated.Message)
+	}
 
-	 return false, fmt.Errorf("container %s in unknown state: %v", containerName, state)
+	// Container is waiting - usually not healthy yet
+	if state.Waiting != nil {
+		// Check if it's a problematic waiting state
+		reason := state.Waiting.Reason
+		if reason == "ImagePullBackOff" || reason == "ErrImagePull" ||
+			reason == "CrashLoopBackOff" || reason == "CreateContainerConfigError" {
+			return false, fmt.Errorf("container %s in error state: %s %s", containerName, reason, state.Waiting.Message)
+		}
+		// Normal waiting states like "ContainerCreating", "PodInitializing"
+		return false, nil // Not healthy yet, but not an error
+	}
+
+	return false, fmt.Errorf("container %s in unknown state: %v", containerName, state)
 }
 
 // PodHealthy checks if the pod and container are in a healthy state.

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -30,18 +30,36 @@ func (kw KubeUnit) PodContainerHealthy(pod *corev1.Pod, containerName string) (b
 	if foundContainer == nil {
 		return false, fmt.Errorf("pod does not contain container %s", containerName)
 	}
-	if foundContainer.State.Waiting != nil { // means it is waiting, so application logic has not completed yet.
-		return false, fmt.Errorf("container %s is waiting: %s %s", containerName, foundContainer.State.Waiting.Reason, foundContainer.State.Waiting.Message)
-	}
-	if foundContainer.State.Terminated == nil { // means it is waiting or running, so application logic has not completed yet. Normal behavior when job completes successfully.
-		return true, nil
-	}
 
-	if foundContainer.State.Terminated.ExitCode != 0 { // exit code of 0 means success
-		return false, fmt.Errorf("container %s exited with code %d: %s", containerName, foundContainer.State.Terminated.ExitCode, foundContainer.State.Terminated.Reason)
-	}
+	state := foundContainer.State
 
-	return true, nil // container terminated with exit code of 0
+	// Check if container is running and ready
+    if state.Running != nil {
+        return foundContainer.Ready, nil // Use Ready field for health
+    }
+
+   // Check if container terminated successfully
+    if state.Terminated != nil {
+        if state.Terminated.ExitCode == 0 {
+            return true, nil // Successfully completed
+        }
+        return false, fmt.Errorf("container %s failed with exit code %d: %s %s", 
+            containerName, state.Terminated.ExitCode, state.Terminated.Reason,  state.Terminated.Message)
+    }
+
+    // Container is waiting - usually not healthy yet
+    if state.Waiting != nil {
+        // Check if it's a problematic waiting state
+        reason := state.Waiting.Reason
+        if reason == "ImagePullBackOff" || reason == "ErrImagePull" || 
+           reason == "CrashLoopBackOff" || reason == "CreateContainerConfigError" {
+            return false, fmt.Errorf("container %s in error state: %s %s", containerName, reason, state.Waiting.Message)
+        }
+        // Normal waiting states like "ContainerCreating", "PodInitializing"
+        return false, nil // Not healthy yet, but not an error
+    }
+
+	 return false, fmt.Errorf("container %s in unknown state: %v", containerName, state)
 }
 
 // PodHealthy checks if the pod and container are in a healthy state.

--- a/pkg/workceptor/pod.go
+++ b/pkg/workceptor/pod.go
@@ -48,12 +48,17 @@ func (kw KubeUnit) PodHealthy(pod *corev1.Pod, containerName string) (bool, erro
 		if cs.Name == containerName {
 			switch pod.Status.Phase {
 			case corev1.PodFailed:
-				ok, err := kw.PodContainerHealthy(pod, containerName)
-				if !ok || err != nil {
-					return false, err
+				podError := fmt.Errorf("pod failed with reason: %s", pod.Status.Reason)
+				if pod.Status.Message != "" {
+					podError = fmt.Errorf("%s: %s", podError.Error(), pod.Status.Message)
+				}
+				ok, containerError := kw.PodContainerHealthy(pod, containerName)
+				if !ok || containerError != nil {
+					return false, fmt.Errorf("%s %v", podError.Error(), containerError)
 				}
 
-				return true, nil
+				return false, podError
+
 			case corev1.PodSucceeded:
 				return true, nil
 			case corev1.PodRunning, corev1.PodPending:

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -38,14 +38,14 @@ var podInfraError = &corev1.Pod{
 	},
 	Status: corev1.PodStatus{
 		Phase:  corev1.PodFailed,
-		Reason: "Pod OOMKilled",
+		Reason: "OOMKilled",
 		ContainerStatuses: []corev1.ContainerStatus{
 			{
 				Name: "worker",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 137,
-						Reason:   "Container OOMKill",
+						Reason:   "OOMKill",
 					},
 				},
 			},

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -217,7 +217,7 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "pod: pod failed with reason: Pod OOMKilled container: container worker exited with code 137: Container OOMKilled too",
+			wantError: "pod failed with reason: Pod OOMKilled container worker exited with code 137: Container OOMKill",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -38,14 +38,14 @@ var podInfraError = &corev1.Pod{
 	},
 	Status: corev1.PodStatus{
 		Phase:  corev1.PodFailed,
-		Reason: "OOMKilled",
+		Reason: "Pod OOMKilled",
 		ContainerStatuses: []corev1.ContainerStatus{
 			{
 				Name: "worker",
 				State: corev1.ContainerState{
 					Terminated: &corev1.ContainerStateTerminated{
 						ExitCode: 137,
-						Reason:   "OOMKill",
+						Reason:   "Container OOMKill",
 					},
 				},
 			},
@@ -117,6 +117,34 @@ var podUnknownPhase = &corev1.Pod{
 	},
 }
 
+var podMultipleContainers = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "multi-container-pod",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodRunning,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{
+						StartedAt: metav1.Now(),
+					},
+				},
+			},
+			{
+				Name: "helper",
+				State: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{
+						StartedAt: metav1.Now(),
+					},
+				},
+			},
+		},
+	},
+}
+
 func TestPodHeathy(t *testing.T) {
 	kw, err := startNetceptorNodeWithWorkceptor()
 	if err != nil {
@@ -168,6 +196,28 @@ func TestPodHeathy(t *testing.T) {
 			wantOk:    false,
 			wantErr:   true,
 			wantError: "unknown phase: NotARealPhase",
+		},
+		{
+			name:      "pod with multiple containers",
+			pod:       podMultipleContainers,
+			container: "worker",
+			wantOk:    true,
+			wantErr:   false,
+		},
+		{
+			name:      "pod with multiple containers, different container",
+			pod:       podMultipleContainers,
+			container: "helper",
+			wantOk:    true,
+			wantErr:   false,
+		},
+		{
+			name:      "pod with oomkill error",
+			pod:       podInfraError,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod: pod failed with reason: Pod OOMKilled container: container worker exited with code 137: Container OOMKilled too",
 		},
 	}
 	for _, tt := range tests {
@@ -286,7 +336,7 @@ func TestGetPodStatus(t *testing.T) {
 			pod:       podInfraError,
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "container worker exited with code 137: OOMKill",
+			wantError: "pod failed with reason: Pod OOMKilled container worker exited with code 137: Container OOMKill",
 		},
 		{
 			name:      "application failure",

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -240,7 +240,7 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "pod failed with reason: Pod OOMKilled container worker exited with code 137: Container OOMKill",
+			wantError: "pod failed with reason: OOMKilled container worker exited with code 137: OOMKill",
 		},
 		{
 			name:      "pod with application error",

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -155,6 +155,7 @@ var podMultipleContainers = &corev1.Pod{
 						StartedAt: metav1.Now(),
 					},
 				},
+				Ready: true,
 			},
 			{
 				Name: "helper",
@@ -163,6 +164,7 @@ var podMultipleContainers = &corev1.Pod{
 						StartedAt: metav1.Now(),
 					},
 				},
+				Ready: true,
 			},
 		},
 	},
@@ -182,6 +184,27 @@ var podImagePullBackOff = &corev1.Pod{
 					Waiting: &corev1.ContainerStateWaiting{
 						Reason:  "ImagePullBackOff",
 						Message: "Back-off pulling image",
+					},
+				},
+			},
+		},
+	},
+}
+
+var podCreateContainerConfigError = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "pod-Create-Container-ConfigErrorf",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CreateContainerConfigError",
+						Message: "Create container error",
 					},
 				},
 			},
@@ -231,6 +254,27 @@ var podCrashLoopBackOff = &corev1.Pod{
 	},
 }
 
+var podCreating = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "pod-creating",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ContainerCreating",
+						Message: "Container is being created",
+					},
+				},
+			},
+		},
+	},
+}
+
 func TestPodHeathy(t *testing.T) {
 	kw, err := startNetceptorNodeWithWorkceptor()
 	if err != nil {
@@ -251,7 +295,7 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "container worker is waiting: ErrImagePull Error when pulling image",
+			wantError: "container worker in error state: ErrImagePull Error when pulling image",
 		},
 		{
 			name:      "backoff image backoff pod",
@@ -259,7 +303,15 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "container worker is waiting: ImagePullBackOff Back-off pulling image",
+			wantError: "container worker in error state: ImagePullBackOff Back-off pulling image",
+		},
+		{
+			name:      "Create Container Config Error pod",
+			pod:       podCreateContainerConfigError,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker in error state: CreateContainerConfigError Create container error",
 		},
 		{
 			name:      "crash loop backoff pod",
@@ -267,7 +319,14 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "ontainer worker is waiting: CrashLoopBackOff Error when starting image",
+			wantError: "container worker in error state: CrashLoopBackOff Error when starting image",
+		},
+		{
+			name:      "pod creating",
+			pod:       podCreating,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   false,
 		},
 		{
 			name:      "nil pod",
@@ -282,8 +341,7 @@ func TestPodHeathy(t *testing.T) {
 			pod:       podPending,
 			container: "worker",
 			wantOk:    false,
-			wantErr:   true,
-			wantError: "container worker is waiting: ContainerCreating Container is being created",
+			wantErr:   false,
 		},
 		{
 			name:      "container missing",
@@ -328,7 +386,7 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "pod failed with reason: OOMKilled container worker exited with code 137: OOMKill",
+			wantError: "pod failed with reason: OOMKilled container worker failed with exit code 137: OOMKill",
 		},
 		{
 			name:      "pod with application error",
@@ -336,7 +394,7 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "pod failed with reason: Error container worker exited with code 1: Error",
+			wantError: "pod failed with reason: Error container worker failed with exit code 1: Error ",
 		},
 		{
 			name:      "pod with oomkill error and message",
@@ -344,7 +402,7 @@ func TestPodHeathy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "pod failed with reason: Pod OOMKilled message: The pod was killed because it ran out of memory container worker exited with code 137: Container OOMKill",
+			wantError: "pod failed with reason: Pod OOMKilled message: The pod was killed because it ran out of memory container worker failed with exit code 137: Container OOMKill ",
 		},
 	}
 	for _, tt := range tests {
@@ -397,8 +455,7 @@ func TestPodContainerHealthy(t *testing.T) {
 			pod:       podPending,
 			container: "worker",
 			wantOk:    false,
-			wantErr:   true,
-			wantError: "container worker is waiting: ContainerCreating Container is being created",
+			wantErr:   false,
 		},
 		{
 			name:      "container missing",
@@ -421,7 +478,7 @@ func TestPodContainerHealthy(t *testing.T) {
 			container: "worker",
 			wantOk:    false,
 			wantErr:   true,
-			wantError: "container worker is waiting: ImagePullBackOff Back-off pulling image",
+			wantError: "container worker in error state: ImagePullBackOff Back-off pulling image",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -1,0 +1,340 @@
+package workceptor_test
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var podSuccess = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "test-pod",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodSucceeded,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: nil,
+					Running: nil,
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 0,
+						Reason:   "Success",
+					},
+				},
+			},
+		},
+	},
+}
+
+var podInfraError = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "infra-error-pod",
+	},
+	Status: corev1.PodStatus{
+		Phase:  corev1.PodFailed,
+		Reason: "OOMKilled",
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "OOMKill",
+					},
+				},
+			},
+		},
+	},
+}
+
+var podAppError = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "app-error-pod",
+	},
+	Status: corev1.PodStatus{
+		Phase:  corev1.PodFailed,
+		Reason: "Error",
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1,
+						Reason:   "Error",
+					},
+				},
+			},
+		},
+	},
+}
+
+var podPending = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "pending-pod",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ContainerCreating",
+						Message: "Container is being created",
+					},
+				},
+			},
+		},
+	},
+}
+
+var podUnknownPhase = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "unknown-phase-pod",
+	},
+	Status: corev1.PodStatus{
+		Phase: "NotARealPhase",
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ContainerCreating",
+						Message: "Container is being created",
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestPodHeathy(t *testing.T) {
+	kw, err := startNetceptorNodeWithWorkceptor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		container string
+		wantOk    bool
+		wantErr   bool
+		wantError string
+	}{
+		{
+			name:      "nil pod",
+			pod:       nil,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod is nil",
+		},
+		{
+			name:      "pod not terminated",
+			pod:       podPending,
+			container: "worker",
+			wantOk:    true,
+			wantErr:   false,
+		},
+		{
+			name:      "container missing",
+			pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "no-container-pod", Namespace: "default"}},
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod does not contain container worker",
+		},
+		{
+			name:      "container healthy",
+			pod:       podSuccess,
+			container: "worker",
+			wantOk:    true,
+			wantErr:   false,
+		},
+		{
+			name:      "pod unknown phase",
+			pod:       podUnknownPhase,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "unknown phase: NotARealPhase",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, err := kw.PodHealthy(tt.pod, tt.container)
+			if ok != tt.wantOk || (err != nil) != tt.wantErr {
+				t.Errorf("Failed %s case: ok=%v wantok=%v err=%v", tt.name, ok, tt.wantOk, err)
+			}
+			if err != nil && tt.wantErr == false {
+				t.Errorf("Expected error message got '%s'", err.Error())
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error message '%s', got nil error", tt.wantError)
+				} else if !strings.Contains(err.Error(), tt.wantError) {
+					t.Errorf("Expected error message '%s', got '%s'", tt.wantError, err.Error())
+				}
+			}
+			if tt.wantError == "" && err != nil {
+				t.Errorf("Unexpected error for %s case: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestPodContainerHealthy(t *testing.T) {
+	kw, err := startNetceptorNodeWithWorkceptor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		container string
+		wantOk    bool
+		wantErr   bool
+		wantError string
+	}{
+		{
+			name:      "nil pod",
+			pod:       nil,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod is nil",
+		},
+		{
+			name:      "pod not terminated",
+			pod:       podPending,
+			container: "worker",
+			wantOk:    true,
+			wantErr:   false,
+		},
+		{
+			name:      "container missing",
+			pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "no-container-pod", Namespace: "default"}},
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod does not contain container worker",
+		},
+		{
+			name:      "container healthy",
+			pod:       podSuccess,
+			container: "worker",
+			wantOk:    true,
+			wantErr:   false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, err := kw.PodContainerHealthy(tt.pod, tt.container)
+			if ok != tt.wantOk || (err != nil) != tt.wantErr {
+				t.Errorf("Failed %s case: ok=%v wantok=%v err=%v", tt.name, ok, tt.wantOk, err)
+			}
+			if err != nil && tt.wantErr == false {
+				t.Errorf("Expected error message got '%s'", err.Error())
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error message '%s', got nil error", tt.wantError)
+				} else if !strings.Contains(err.Error(), tt.wantError) {
+					t.Errorf("Expected error message '%s', got '%s'", tt.wantError, err.Error())
+				}
+			}
+			if tt.wantError == "" && err != nil {
+				t.Errorf("Unexpected error for %s case: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestGetPodStatus(t *testing.T) {
+	kw, err := startNetceptorNodeWithWorkceptor()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		pod       *corev1.Pod
+		wantOk    bool
+		wantErr   bool
+		wantError string
+	}{
+		{
+			name:      "nil pod",
+			pod:       nil,
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod is nil",
+		},
+		{
+			name:      "infrastructure failure",
+			pod:       podInfraError,
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker exited with code 137: OOMKill",
+		},
+		{
+			name:      "application failure",
+			pod:       podAppError,
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker exited with code 1: Error",
+		},
+		{
+			name:    "success case",
+			pod:     podSuccess,
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name:    "pending pod",
+			pod:     podPending,
+			wantOk:  true,
+			wantErr: false,
+		},
+		{
+			name:      "pod with no container",
+			pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "no-container-pod", Namespace: "default"}},
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod does not contain container worker",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ok, err := kw.GetPodStatus(tt.pod)
+			if ok != tt.wantOk || (err != nil) != tt.wantErr {
+				t.Errorf("Failed %s case: ok=%v wantok=%v err=%v", tt.name, ok, tt.wantOk, err)
+			}
+			if err != nil && tt.wantErr == false {
+				t.Errorf("Expected error message got '%s'", err.Error())
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("Expected error message '%s', got nil error", tt.wantError)
+				} else if !strings.Contains(err.Error(), tt.wantError) {
+					t.Errorf("Expected error message '%s', got '%s'", tt.wantError, err.Error())
+				}
+			}
+			if tt.wantError == "" && err != nil {
+				t.Errorf("Unexpected error for %s case: %v", tt.name, err)
+			}
+		})
+	}
+}

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -53,6 +53,29 @@ var podInfraError = &corev1.Pod{
 	},
 }
 
+var podInfraErrorWithMessage = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "infra-error-pod",
+	},
+	Status: corev1.PodStatus{
+		Phase:   corev1.PodFailed,
+		Reason:  "Pod OOMKilled",
+		Message: "The pod was killed because it ran out of memory",
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 137,
+						Reason:   "Container OOMKill",
+					},
+				},
+			},
+		},
+	},
+}
+
 var podAppError = &corev1.Pod{
 	ObjectMeta: metav1.ObjectMeta{
 		Namespace: "default",
@@ -219,6 +242,22 @@ func TestPodHeathy(t *testing.T) {
 			wantErr:   true,
 			wantError: "pod failed with reason: Pod OOMKilled container worker exited with code 137: Container OOMKill",
 		},
+		{
+			name:      "pod with application error",
+			pod:       podAppError,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod failed with reason: Error container worker exited with code 1: Error",
+		},
+		{
+			name:      "pod with oomkill error and message",
+			pod:       podInfraErrorWithMessage,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "pod failed with reason: Pod OOMKilled message: The pod was killed because it ran out of memory container worker exited with code 137: Container OOMKill",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -291,84 +330,6 @@ func TestPodContainerHealthy(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ok, err := kw.PodContainerHealthy(tt.pod, tt.container)
-			if ok != tt.wantOk || (err != nil) != tt.wantErr {
-				t.Errorf("Failed %s case: ok=%v wantok=%v err=%v", tt.name, ok, tt.wantOk, err)
-			}
-			if err != nil && tt.wantErr == false {
-				t.Errorf("Expected error message got '%s'", err.Error())
-			}
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("Expected error message '%s', got nil error", tt.wantError)
-				} else if !strings.Contains(err.Error(), tt.wantError) {
-					t.Errorf("Expected error message '%s', got '%s'", tt.wantError, err.Error())
-				}
-			}
-			if tt.wantError == "" && err != nil {
-				t.Errorf("Unexpected error for %s case: %v", tt.name, err)
-			}
-		})
-	}
-}
-
-func TestGetPodStatus(t *testing.T) {
-	kw, err := startNetceptorNodeWithWorkceptor()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		name      string
-		pod       *corev1.Pod
-		wantOk    bool
-		wantErr   bool
-		wantError string
-	}{
-		{
-			name:      "nil pod",
-			pod:       nil,
-			wantOk:    false,
-			wantErr:   true,
-			wantError: "pod is nil",
-		},
-		{
-			name:      "infrastructure failure",
-			pod:       podInfraError,
-			wantOk:    false,
-			wantErr:   true,
-			wantError: "pod failed with reason: Pod OOMKilled container worker exited with code 137: Container OOMKill",
-		},
-		{
-			name:      "application failure",
-			pod:       podAppError,
-			wantOk:    false,
-			wantErr:   true,
-			wantError: "container worker exited with code 1: Error",
-		},
-		{
-			name:    "success case",
-			pod:     podSuccess,
-			wantOk:  true,
-			wantErr: false,
-		},
-		{
-			name:    "pending pod",
-			pod:     podPending,
-			wantOk:  true,
-			wantErr: false,
-		},
-		{
-			name:      "pod with no container",
-			pod:       &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "no-container-pod", Namespace: "default"}},
-			wantOk:    false,
-			wantErr:   true,
-			wantError: "pod does not contain container worker",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ok, err := kw.GetPodStatus(tt.pod)
 			if ok != tt.wantOk || (err != nil) != tt.wantErr {
 				t.Errorf("Failed %s case: ok=%v wantok=%v err=%v", tt.name, ok, tt.wantOk, err)
 			}

--- a/pkg/workceptor/pod_test.go
+++ b/pkg/workceptor/pod_test.go
@@ -168,6 +168,69 @@ var podMultipleContainers = &corev1.Pod{
 	},
 }
 
+var podImagePullBackOff = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "pod-image-pull-backoff",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ImagePullBackOff",
+						Message: "Back-off pulling image",
+					},
+				},
+			},
+		},
+	},
+}
+
+var podErrImagePull = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "pod-error-image-pull",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "ErrImagePull",
+						Message: "Error when pulling image",
+					},
+				},
+			},
+		},
+	},
+}
+
+var podCrashLoopBackOff = &corev1.Pod{
+	ObjectMeta: metav1.ObjectMeta{
+		Namespace: "default",
+		Name:      "pod-crash-loop-backoff",
+	},
+	Status: corev1.PodStatus{
+		Phase: corev1.PodPending,
+		ContainerStatuses: []corev1.ContainerStatus{
+			{
+				Name: "worker",
+				State: corev1.ContainerState{
+					Waiting: &corev1.ContainerStateWaiting{
+						Reason:  "CrashLoopBackOff",
+						Message: "Error when starting image",
+					},
+				},
+			},
+		},
+	},
+}
+
 func TestPodHeathy(t *testing.T) {
 	kw, err := startNetceptorNodeWithWorkceptor()
 	if err != nil {
@@ -183,6 +246,30 @@ func TestPodHeathy(t *testing.T) {
 		wantError string
 	}{
 		{
+			name:      "pod err image pull",
+			pod:       podErrImagePull,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker is waiting: ErrImagePull Error when pulling image",
+		},
+		{
+			name:      "backoff image backoff pod",
+			pod:       podImagePullBackOff,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker is waiting: ImagePullBackOff Back-off pulling image",
+		},
+		{
+			name:      "crash loop backoff pod",
+			pod:       podCrashLoopBackOff,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "ontainer worker is waiting: CrashLoopBackOff Error when starting image",
+		},
+		{
 			name:      "nil pod",
 			pod:       nil,
 			container: "worker",
@@ -194,8 +281,9 @@ func TestPodHeathy(t *testing.T) {
 			name:      "pod not terminated",
 			pod:       podPending,
 			container: "worker",
-			wantOk:    true,
-			wantErr:   false,
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker is waiting: ContainerCreating Container is being created",
 		},
 		{
 			name:      "container missing",
@@ -308,8 +396,9 @@ func TestPodContainerHealthy(t *testing.T) {
 			name:      "pod not terminated",
 			pod:       podPending,
 			container: "worker",
-			wantOk:    true,
-			wantErr:   false,
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker is waiting: ContainerCreating Container is being created",
 		},
 		{
 			name:      "container missing",
@@ -325,6 +414,14 @@ func TestPodContainerHealthy(t *testing.T) {
 			container: "worker",
 			wantOk:    true,
 			wantErr:   false,
+		},
+		{
+			name:      "pod ImagePullBackOff",
+			pod:       podImagePullBackOff,
+			container: "worker",
+			wantOk:    false,
+			wantErr:   true,
+			wantError: "container worker is waiting: ImagePullBackOff Back-off pulling image",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request addresses concerns about the size and commit history of [PR #1332](https://github.com/ansible/receptor/pull/1332). We are consolidating these helper functions in this PR and moving the WaitForPodCompleted function to a separate pull request.

1. PodHealthy - Determine if the Pod and Container are both healthy. Eventually to be called after WaitForBodCompleted function determines the Pod has "settled" into a state that has diagnostic information.

1. PodContainerHealthy - Typically called by PodHealthy to make sure the "worker" container is healthy but can also be invoked externally.