### PR TITLE
Add unit tests for netceptor.Listener and removes panic from Listener.Accept()

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -38,6 +38,12 @@ type QuicConnectionForConn interface {
 	quic.Connection
 }
 
+type QuicListenerForListener interface {
+	Accept(ctx context.Context) (quic.Connection, error)
+	Addr() net.Addr
+	Close() error
+}
+
 type AcceptResult struct {
 	Conn net.Conn
 	Err  error
@@ -47,10 +53,21 @@ type AcceptResult struct {
 type Listener struct {
 	s          *Netceptor
 	pc         PacketConner
-	ql         *quic.Listener
+	ql         QuicListenerForListener
 	AcceptChan chan *AcceptResult
 	DoneChan   chan struct{}
 	doneOnce   *sync.Once
+}
+
+func NewListener(s *Netceptor, pc PacketConner, ql QuicListenerForListener, acceptChan chan *AcceptResult, doneChan chan struct{}, doneOnce *sync.Once) *Listener {
+	return &Listener{
+		s:          s,
+		pc:         pc,
+		ql:         ql,
+		AcceptChan: acceptChan,
+		DoneChan:   doneChan,
+		doneOnce:   doneOnce,
+	}
 }
 
 // Internal implementation of Listen and ListenAndAdvertise.
@@ -292,7 +309,11 @@ func (li *Listener) acceptLoop(ctx context.Context) {
 func (li *Listener) Accept() (net.Conn, error) {
 	select {
 	case ar := <-li.AcceptChan:
-		return ar.Conn, ar.Err
+		if ar == nil {
+			return nil, fmt.Errorf("listener closed")
+		} else {
+			return ar.Conn, ar.Err
+		}
 	case <-li.DoneChan:
 		return nil, fmt.Errorf("listener closed")
 	}

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -305,12 +305,12 @@ func (li *Listener) Accept() (net.Conn, error) {
 	select {
 	case ar := <-li.AcceptChan:
 		if ar == nil {
-			return nil, fmt.Errorf("listener closed")
+			return nil, fmt.Errorf("listener accept channel closed")
 		} else {
 			return ar.Conn, ar.Err
 		}
 	case <-li.DoneChan:
-		return nil, fmt.Errorf("listener closed")
+		return nil, fmt.Errorf("listener done channel closed")
 	}
 }
 

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -71,7 +71,7 @@ func NewListener(s *Netceptor, pc PacketConner, ql QuicListenerForListener, acce
 }
 
 // Internal implementation of Listen and ListenAndAdvertise.
-func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Config, advertise bool, adTags map[string]string) (*Listener, error) {
+func (s *Netceptor) listen(service string, tlscfg *tls.Config, advertise bool, adTags map[string]string) (*Listener, error) {
 	if len(service) > 8 {
 		return nil, fmt.Errorf("service name %s too long", service)
 	}
@@ -136,22 +136,15 @@ func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Conf
 		select {
 		case <-s.context.Done():
 			_ = ql.Close()
-		case <-ctx.Done():
-			_ = ql.Close()
 		case <-doneChan:
 			return
 		}
 	}()
-	li := &Listener{
-		s:          s,
-		pc:         pc,
-		ql:         ql,
-		AcceptChan: make(chan *AcceptResult),
-		DoneChan:   doneChan,
-		doneOnce:   &sync.Once{},
-	}
+	acceptChan := make(chan *AcceptResult)
+	syncOnce := &sync.Once{}
+	li := NewListener(s, pc, ql, acceptChan, doneChan, syncOnce)
 
-	go li.acceptLoop(ctx)
+	go li.acceptLoop(s.context)
 
 	return li, nil
 }
@@ -200,12 +193,12 @@ func (s *Netceptor) tracer(ctx context.Context, p logging.Perspective, connID qu
 // Listen returns a stream listener compatible with Go's net.Listener.
 // If service is blank, generates and uses an ephemeral service name.
 func (s *Netceptor) Listen(service string, tlscfg *tls.Config) (*Listener, error) {
-	return s.listen(s.context, service, tlscfg, false, nil)
+	return s.listen(service, tlscfg, false, nil)
 }
 
 // ListenAndAdvertise listens for stream connections on a service and also advertises it via broadcasts.
 func (s *Netceptor) ListenAndAdvertise(service string, tlscfg *tls.Config, tags map[string]string) (*Listener, error) {
-	return s.listen(s.context, service, tlscfg, true, tags)
+	return s.listen(service, tlscfg, true, tags)
 }
 
 func (li *Listener) sendResult(ctx context.Context, conn net.Conn, err error) {

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -71,7 +71,7 @@ func NewListener(s *Netceptor, pc PacketConner, ql QuicListenerForListener, acce
 }
 
 // Internal implementation of Listen and ListenAndAdvertise.
-func (s *Netceptor) listen(service string, tlscfg *tls.Config, advertise bool, adTags map[string]string) (*Listener, error) {
+func (s *Netceptor) listen(ctx context.Context, service string, tlscfg *tls.Config, advertise bool, adTags map[string]string) (*Listener, error) {
 	if len(service) > 8 {
 		return nil, fmt.Errorf("service name %s too long", service)
 	}
@@ -136,6 +136,8 @@ func (s *Netceptor) listen(service string, tlscfg *tls.Config, advertise bool, a
 		select {
 		case <-s.context.Done():
 			_ = ql.Close()
+		case <-ctx.Done():
+			_ = ql.Close()
 		case <-doneChan:
 			return
 		}
@@ -144,7 +146,7 @@ func (s *Netceptor) listen(service string, tlscfg *tls.Config, advertise bool, a
 	syncOnce := &sync.Once{}
 	li := NewListener(s, pc, ql, acceptChan, doneChan, syncOnce)
 
-	go li.acceptLoop(s.context)
+	go li.acceptLoop(ctx)
 
 	return li, nil
 }
@@ -193,12 +195,12 @@ func (s *Netceptor) tracer(ctx context.Context, p logging.Perspective, connID qu
 // Listen returns a stream listener compatible with Go's net.Listener.
 // If service is blank, generates and uses an ephemeral service name.
 func (s *Netceptor) Listen(service string, tlscfg *tls.Config) (*Listener, error) {
-	return s.listen(service, tlscfg, false, nil)
+	return s.listen(s.context, service, tlscfg, false, nil)
 }
 
 // ListenAndAdvertise listens for stream connections on a service and also advertises it via broadcasts.
 func (s *Netceptor) ListenAndAdvertise(service string, tlscfg *tls.Config, tags map[string]string) (*Listener, error) {
-	return s.listen(service, tlscfg, true, tags)
+	return s.listen(s.context, service, tlscfg, true, tags)
 }
 
 func (li *Listener) sendResult(ctx context.Context, conn net.Conn, err error) {

--- a/pkg/netceptor/conn_test.go
+++ b/pkg/netceptor/conn_test.go
@@ -232,3 +232,101 @@ func TestSetWriteDeadline(t *testing.T) {
 		}
 	})
 }
+
+func TestListenerAddr(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+	mockNetC := &netceptor.Netceptor{}
+	ql := &quic.Listener{}
+	doneChan := make(chan struct{})
+	acceptChan := make(chan *netceptor.AcceptResult)
+	syncOnce := &sync.Once{}
+	listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
+
+	mockPacketConner.EXPECT().LocalAddr().Return(nil)
+	got := listener.Addr()
+	if got != nil {
+		t.Errorf("Wanted %v, got %v", nil, got)
+	}
+}
+
+func TestListenerAccept(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+	mockNetC := &netceptor.Netceptor{}
+	ql := &quic.Listener{}
+	syncOnce := &sync.Once{}
+
+	t.Run("accept channel error", func(t *testing.T) {
+		doneChan := make(chan struct{})
+		acceptChan := make(chan *netceptor.AcceptResult)
+		listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
+		wantErr := errors.New("accept channel error")
+		go func() {
+			_, gotErr := listener.Accept()
+			if gotErr.Error() != wantErr.Error() {
+				t.Errorf("Wanted %v, got %v", wantErr, gotErr)
+			}
+		}()
+		ar := &netceptor.AcceptResult{
+			Conn: nil,
+			Err:  wantErr,
+		}
+		listener.AcceptChan <- ar
+	})
+
+	t.Run("accept channel closed", func(t *testing.T) {
+		doneChan := make(chan struct{})
+		acceptChan := make(chan *netceptor.AcceptResult)
+		listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
+		wantErr := errors.New("listener closed")
+		close(listener.AcceptChan)
+		_, gotErr := listener.Accept()
+		if gotErr.Error() != wantErr.Error() {
+			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
+		}
+	})
+
+	t.Run("done channel closed", func(t *testing.T) {
+		doneChan := make(chan struct{})
+		acceptChan := make(chan *netceptor.AcceptResult)
+		listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
+		close(listener.DoneChan)
+		_, gotErr := listener.Accept()
+		wantErr := errors.New("listener closed")
+		if gotErr.Error() != wantErr.Error() {
+			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
+		}
+	})
+}
+
+func TestListenerClose(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+	mockNetC := &netceptor.Netceptor{}
+	mockListener := mock_netceptor.NewMockQuicListenerForListener(ctrl)
+	syncOnce := &sync.Once{}
+	doneChan := make(chan struct{})
+	acceptChan := make(chan *netceptor.AcceptResult)
+
+	t.Run("packetconner error", func(t *testing.T) {
+		listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
+		wantErr := errors.New("packetconner error")
+		mockListener.EXPECT().Close()
+		mockPacketConner.EXPECT().Close().Return(wantErr)
+		gotErr := listener.Close()
+		if gotErr.Error() != wantErr.Error() {
+			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
+		}
+	})
+	t.Run("quiclistener error", func(t *testing.T) {
+		listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
+		wantErr := errors.New("quiclistener error")
+		mockPacketConner.EXPECT().Close()
+		mockListener.EXPECT().Close().Return(wantErr)
+		gotErr := listener.Close()
+		if gotErr.Error() != wantErr.Error() {
+			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
+		}
+	})
+}

--- a/pkg/netceptor/conn_test.go
+++ b/pkg/netceptor/conn_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"net"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -235,102 +237,481 @@ func TestSetWriteDeadline(t *testing.T) {
 	})
 }
 
-func TestListenerAddr(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
-	mockNetC := &netceptor.Netceptor{}
-	ql := &quic.Listener{}
-	doneChan := make(chan struct{})
-	acceptChan := make(chan *netceptor.AcceptResult)
-	syncOnce := &sync.Once{}
-	listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
+func TestListenerAccept(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupAction   func(*netceptor.Listener)
+		expectedError string
+		expectedConn  bool
+	}{
+		{
+			name: "accept channel error",
+			setupAction: func(listener *netceptor.Listener) {
+				go func() {
+					listener.AcceptChan <- &netceptor.AcceptResult{
+						Conn: nil,
+						Err:  errors.New("accept channel error"),
+					}
+				}()
+			},
+			expectedError: "accept channel error",
+		},
+		{
+			name: "accept channel closed",
+			setupAction: func(listener *netceptor.Listener) {
+				close(listener.AcceptChan)
+			},
+			expectedError: "listener closed",
+		},
+		{
+			name: "done channel closed",
+			setupAction: func(listener *netceptor.Listener) {
+				close(listener.DoneChan)
+			},
+			expectedError: "listener closed",
+		},
+		{
+			name: "successful accept",
+			setupAction: func(listener *netceptor.Listener) {
+				go func() {
+					listener.AcceptChan <- &netceptor.AcceptResult{
+						Conn: &netceptor.Conn{},
+						Err:  nil,
+					}
+				}()
+			},
+			expectedConn: true,
+		},
+	}
 
-	mockPacketConner.EXPECT().LocalAddr().Return(nil)
-	got := listener.Addr()
-	if got != nil {
-		t.Errorf("Wanted %v, got %v", nil, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Common listener setup moved outside the table
+			mockNetC := &netceptor.Netceptor{}
+			ql := &quic.Listener{}
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult)
+			syncOnce := &sync.Once{}
+			listener := netceptor.NewListener(mockNetC, nil, ql, acceptChan, doneChan, syncOnce)
+
+			tt.setupAction(listener)
+
+			conn, err := listener.Accept()
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("Expected error %q, got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("Expected error %q, got %q", tt.expectedError, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+
+			if tt.expectedConn {
+				if conn == nil {
+					t.Error("Expected connection, got nil")
+				}
+			} else if conn != nil {
+				t.Errorf("Expected no connection, got %v", conn)
+			}
+		})
 	}
 }
 
-func TestListenerAccept(t *testing.T) {
+func TestListenerClose(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupMocks       func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener)
+		expectedError    string
+		multipleClose    bool
+		validateDoneChan bool
+	}{
+		{
+			name: "packetconner error",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockQL.EXPECT().Close().Return(nil)
+				mockPC.EXPECT().Close().Return(errors.New("packetconner error"))
+			},
+			expectedError: "packetconner error",
+		},
+		{
+			name: "quiclistener error",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockPC.EXPECT().Close().Return(nil)
+				mockQL.EXPECT().Close().Return(errors.New("quiclistener error"))
+			},
+			expectedError: "quiclistener error",
+		},
+		{
+			name: "successful close",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockPC.EXPECT().Close().Return(nil)
+				mockQL.EXPECT().Close().Return(nil)
+			},
+			validateDoneChan: true,
+		},
+		{
+			name: "multiple close calls are safe",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockPC.EXPECT().Close().Return(nil).Times(2)
+				mockQL.EXPECT().Close().Return(nil).Times(2)
+			},
+			multipleClose:    true,
+			validateDoneChan: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+			mockListener := mock_netceptor.NewMockQuicListenerForListener(ctrl)
+			mockNetC := &netceptor.Netceptor{}
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult)
+			syncOnce := &sync.Once{}
+
+			listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
+
+			tt.setupMocks(mockPacketConner, mockListener)
+
+			// First close
+			err1 := listener.Close()
+			if tt.expectedError != "" {
+				if err1 == nil {
+					t.Errorf("Expected error %q, got nil", tt.expectedError)
+				} else if err1.Error() != tt.expectedError {
+					t.Errorf("Expected error %q, got %q", tt.expectedError, err1.Error())
+				}
+			} else if err1 != nil {
+				t.Errorf("Expected no error, got %v", err1)
+			}
+
+			// Test multiple close if requested
+			if tt.multipleClose {
+				err2 := listener.Close()
+				if err2 != nil {
+					t.Errorf("Second close should not error, got %v", err2)
+				}
+			}
+
+			// Validate DoneChan is closed if requested
+			if tt.validateDoneChan {
+				select {
+				case <-listener.DoneChan:
+					// Expected - channel should be closed
+				default:
+					t.Error("DoneChan should be closed after Close()")
+				}
+			}
+		})
+	}
+}
+
+func TestListenerAddr(t *testing.T) {
+	tests := []struct {
+		name         string
+		setupMock    func(*mock_netceptor.MockPacketConner)
+		expectedAddr net.Addr
+	}{
+		{
+			name: "returns non-nil addr",
+			setupMock: func(mockPC *mock_netceptor.MockPacketConner) {
+				testAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}
+				mockPC.EXPECT().LocalAddr().Return(testAddr)
+			},
+			expectedAddr: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080},
+		},
+		{
+			name: "handles nil addr from PacketConner",
+			setupMock: func(mockPC *mock_netceptor.MockPacketConner) {
+				mockPC.EXPECT().LocalAddr().Return(nil)
+			},
+			expectedAddr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+			mockNetC := &netceptor.Netceptor{}
+			ql := &quic.Listener{}
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult)
+			syncOnce := &sync.Once{}
+
+			listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
+
+			tt.setupMock(mockPacketConner)
+
+			got := listener.Addr()
+			if !reflect.DeepEqual(got, tt.expectedAddr) {
+				t.Errorf("Expected %v, got %v", tt.expectedAddr, got)
+			}
+		})
+	}
+}
+
+func TestListenerAcceptEdgeCases(t *testing.T) {
+	tests := []struct {
+		name              string
+		setupAction       func(*netceptor.Listener)
+		expectedError     string
+		expectedConnCount int
+		concurrent        bool
+	}{
+		{
+			name: "accept returns nil AcceptResult",
+			setupAction: func(listener *netceptor.Listener) {
+				go func() {
+					listener.AcceptChan <- nil
+				}()
+			},
+			expectedError: "listener closed",
+		},
+		{
+			name: "accept with successful connection",
+			setupAction: func(listener *netceptor.Listener) {
+				conn := &netceptor.Conn{}
+				go func() {
+					listener.AcceptChan <- &netceptor.AcceptResult{
+						Conn: conn,
+						Err:  nil,
+					}
+				}()
+			},
+			expectedConnCount: 1,
+		},
+		{
+			name: "concurrent accepts",
+			setupAction: func(listener *netceptor.Listener) {
+				conn1 := &netceptor.Conn{}
+				conn2 := &netceptor.Conn{}
+				// Send two connections
+				go func() {
+					listener.AcceptChan <- &netceptor.AcceptResult{Conn: conn1, Err: nil}
+					listener.AcceptChan <- &netceptor.AcceptResult{Conn: conn2, Err: nil}
+				}()
+			},
+			expectedConnCount: 2,
+			concurrent:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockNetC := &netceptor.Netceptor{}
+			ql := &quic.Listener{}
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult, 2)
+			syncOnce := &sync.Once{}
+
+			listener := netceptor.NewListener(mockNetC, nil, ql, acceptChan, doneChan, syncOnce)
+
+			tt.setupAction(listener)
+
+			if tt.concurrent {
+				// Handle concurrent accepts
+				results := make(chan net.Conn, 2)
+				errors := make(chan error, 2)
+
+				for i := 0; i < tt.expectedConnCount; i++ {
+					go func() {
+						conn, err := listener.Accept()
+						results <- conn
+						errors <- err
+					}()
+				}
+
+				// Collect results
+				var conns []net.Conn
+				for i := 0; i < tt.expectedConnCount; i++ {
+					conn := <-results
+					err := <-errors
+					if err != nil {
+						t.Errorf("Accept %d failed: %v", i, err)
+					}
+					conns = append(conns, conn)
+				}
+
+				if len(conns) != tt.expectedConnCount {
+					t.Errorf("Expected %d connections, got %d", tt.expectedConnCount, len(conns))
+				}
+			} else {
+				// Handle single accept
+				conn, err := listener.Accept()
+
+				if tt.expectedError != "" {
+					if err == nil {
+						t.Errorf("Expected error %q, got nil", tt.expectedError)
+					} else if err.Error() != tt.expectedError {
+						t.Errorf("Expected error %q, got %q", tt.expectedError, err.Error())
+					}
+				} else if err != nil {
+					t.Errorf("Expected no error, got %v", err)
+				}
+
+				if tt.expectedConnCount > 0 {
+					if conn == nil {
+						t.Error("Expected connection, got nil")
+					}
+				} else if conn != nil {
+					t.Errorf("Expected no connection, got %v", conn)
+				}
+			}
+		})
+	}
+}
+
+func TestNewListener(t *testing.T) {
+	tests := []struct {
+		name             string
+		netceptor        *netceptor.Netceptor
+		validateChannels bool
+		shouldNotBeNil   bool
+	}{
+		{
+			name:             "creates listener with all fields set",
+			netceptor:        &netceptor.Netceptor{},
+			validateChannels: true,
+			shouldNotBeNil:   true,
+		},
+		{
+			name:           "creates listener with nil netceptor",
+			netceptor:      nil,
+			shouldNotBeNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+			mockQL := mock_netceptor.NewMockQuicListenerForListener(ctrl)
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult)
+			syncOnce := &sync.Once{}
+
+			listener := netceptor.NewListener(tt.netceptor, mockPacketConner, mockQL, acceptChan, doneChan, syncOnce)
+
+			if tt.shouldNotBeNil {
+				if listener == nil {
+					t.Error("NewListener should not return nil")
+				}
+			}
+
+			if tt.validateChannels && listener != nil {
+				if listener.AcceptChan != acceptChan {
+					t.Error("AcceptChan not properly assigned")
+				}
+				if listener.DoneChan != doneChan {
+					t.Error("DoneChan not properly assigned")
+				}
+			}
+		})
+	}
+}
+
+func TestListenerAcceptWithContextCancellation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
 	mockNetC := &netceptor.Netceptor{}
 	ql := &quic.Listener{}
-	syncOnce := &sync.Once{}
 
-	t.Run("accept channel error", func(t *testing.T) {
+	t.Run("accept blocks and then receives done signal", func(t *testing.T) {
 		doneChan := make(chan struct{})
 		acceptChan := make(chan *netceptor.AcceptResult)
+		syncOnce := &sync.Once{}
 		listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
-		wantErr := errors.New("accept channel error")
+
+		resultChan := make(chan error, 1)
+
+		// Start accept in goroutine
 		go func() {
-			_, gotErr := listener.Accept()
-			if gotErr.Error() != wantErr.Error() {
-				t.Errorf("Wanted %v, got %v", wantErr, gotErr)
-			}
+			_, err := listener.Accept()
+			resultChan <- err
 		}()
-		ar := &netceptor.AcceptResult{
-			Conn: nil,
-			Err:  wantErr,
-		}
-		listener.AcceptChan <- ar
-	})
 
-	t.Run("accept channel closed", func(t *testing.T) {
-		doneChan := make(chan struct{})
-		acceptChan := make(chan *netceptor.AcceptResult)
-		listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
-		wantErr := errors.New("listener closed")
-		close(listener.AcceptChan)
-		_, gotErr := listener.Accept()
-		if gotErr.Error() != wantErr.Error() {
-			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
-		}
-	})
+		// Give Accept time to start blocking
+		time.Sleep(10 * time.Millisecond)
 
-	t.Run("done channel closed", func(t *testing.T) {
-		doneChan := make(chan struct{})
-		acceptChan := make(chan *netceptor.AcceptResult)
-		listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
-		close(listener.DoneChan)
-		_, gotErr := listener.Accept()
-		wantErr := errors.New("listener closed")
-		if gotErr.Error() != wantErr.Error() {
-			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
+		// Close done channel to signal shutdown
+		close(doneChan)
+
+		// Should receive error quickly
+		select {
+		case err := <-resultChan:
+			if err == nil {
+				t.Error("Expected error when done channel closed")
+			}
+			if err.Error() != "listener closed" {
+				t.Errorf("Expected 'listener closed', got %v", err)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Accept should have returned quickly after done channel closed")
 		}
 	})
 }
 
-func TestListenerClose(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
-	mockNetC := &netceptor.Netceptor{}
-	mockListener := mock_netceptor.NewMockQuicListenerForListener(ctrl)
-	syncOnce := &sync.Once{}
-	doneChan := make(chan struct{})
-	acceptChan := make(chan *netceptor.AcceptResult)
+func TestListenerCloseErrorPrecedence(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMocks    func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener)
+		expectedError string
+	}{
+		{
+			name: "quic listener error takes precedence over packet conner error",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				pcErr := errors.New("packet conner error")
+				qlErr := errors.New("quic listener error")
+				mockPC.EXPECT().Close().Return(pcErr)
+				mockQL.EXPECT().Close().Return(qlErr)
+			},
+			expectedError: "quic listener error",
+		},
+		{
+			name: "packet conner error returned when quic listener succeeds",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				pcErr := errors.New("packet conner error")
+				mockPC.EXPECT().Close().Return(pcErr)
+				mockQL.EXPECT().Close().Return(nil)
+			},
+			expectedError: "packet conner error",
+		},
+	}
 
-	t.Run("packetconner error", func(t *testing.T) {
-		listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
-		wantErr := errors.New("packetconner error")
-		mockListener.EXPECT().Close()
-		mockPacketConner.EXPECT().Close().Return(wantErr)
-		gotErr := listener.Close()
-		if gotErr.Error() != wantErr.Error() {
-			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
-		}
-	})
-	t.Run("quiclistener error", func(t *testing.T) {
-		listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
-		wantErr := errors.New("quiclistener error")
-		mockPacketConner.EXPECT().Close()
-		mockListener.EXPECT().Close().Return(wantErr)
-		gotErr := listener.Close()
-		if gotErr.Error() != wantErr.Error() {
-			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+			mockListener := mock_netceptor.NewMockQuicListenerForListener(ctrl)
+			mockNetC := &netceptor.Netceptor{}
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult)
+			syncOnce := &sync.Once{}
+
+			listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
+
+			tt.setupMocks(mockPacketConner, mockListener)
+
+			gotErr := listener.Close()
+			if gotErr == nil {
+				t.Errorf("Expected error %q, got nil", tt.expectedError)
+			} else if gotErr.Error() != tt.expectedError {
+				t.Errorf("Expected error %q, got %q", tt.expectedError, gotErr.Error())
+			}
+		})
+	}
 }
 
 func TestNeceptorListen(t *testing.T) {

--- a/pkg/netceptor/conn_test.go
+++ b/pkg/netceptor/conn_test.go
@@ -2,6 +2,7 @@ package netceptor_test
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"sync"
 	"testing"
@@ -10,6 +11,7 @@ import (
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/netceptor/mock_netceptor"
 	"github.com/quic-go/quic-go"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
 
@@ -328,5 +330,30 @@ func TestListenerClose(t *testing.T) {
 		if gotErr.Error() != wantErr.Error() {
 			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
 		}
+	})
+}
+
+func TestNeceptorListen(t *testing.T) {
+	t.Parallel()
+	t.Run("service is already listening", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		mockNetC := netceptor.New(ctx, "node1")
+		wantErr := errors.New("service node1 is already listening")
+		_, _ = mockNetC.Listen("node1", &tls.Config{})
+		_, gotErr := mockNetC.Listen("node1", &tls.Config{})
+		if gotErr.Error() != wantErr.Error() {
+			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
+		}
+	})
+
+	t.Run("context cancelled does not panic", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		mockNetC := netceptor.New(ctx, "nodecc")
+		_, _ = mockNetC.Listen("nodecc", &tls.Config{})
+		// Assert cancelling netceptor context doesn't create panic
+		assert.NotPanics(t, func() { time.AfterFunc(500*time.Millisecond, cancel) })
 	})
 }

--- a/pkg/netceptor/conn_test.go
+++ b/pkg/netceptor/conn_test.go
@@ -237,128 +237,23 @@ func TestSetWriteDeadline(t *testing.T) {
 	})
 }
 
-func TestListenerAccept(t *testing.T) {
-	tests := []struct {
-		name          string
-		setupAction   func(*netceptor.Listener)
-		expectedError string
-		expectedConn  bool
-	}{
-		{
-			name: "accept channel error",
-			setupAction: func(listener *netceptor.Listener) {
-				go func() {
-					listener.AcceptChan <- &netceptor.AcceptResult{
-						Conn: nil,
-						Err:  errors.New("accept channel error"),
-					}
-				}()
-			},
-			expectedError: "accept channel error",
-		},
-		{
-			name: "accept channel closed",
-			setupAction: func(listener *netceptor.Listener) {
-				close(listener.AcceptChan)
-			},
-			expectedError: "listener closed",
-		},
-		{
-			name: "done channel closed",
-			setupAction: func(listener *netceptor.Listener) {
-				close(listener.DoneChan)
-			},
-			expectedError: "listener closed",
-		},
-		{
-			name: "successful accept",
-			setupAction: func(listener *netceptor.Listener) {
-				go func() {
-					listener.AcceptChan <- &netceptor.AcceptResult{
-						Conn: &netceptor.Conn{},
-						Err:  nil,
-					}
-				}()
-			},
-			expectedConn: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Common listener setup moved outside the table
-			mockNetC := &netceptor.Netceptor{}
-			ql := &quic.Listener{}
-			doneChan := make(chan struct{})
-			acceptChan := make(chan *netceptor.AcceptResult)
-			syncOnce := &sync.Once{}
-			listener := netceptor.NewListener(mockNetC, nil, ql, acceptChan, doneChan, syncOnce)
-
-			tt.setupAction(listener)
-
-			conn, err := listener.Accept()
-
-			if tt.expectedError != "" {
-				if err == nil {
-					t.Errorf("Expected error %q, got nil", tt.expectedError)
-				} else if err.Error() != tt.expectedError {
-					t.Errorf("Expected error %q, got %q", tt.expectedError, err.Error())
-				}
-			} else if err != nil {
-				t.Errorf("Expected no error, got %v", err)
-			}
-
-			if tt.expectedConn {
-				if conn == nil {
-					t.Error("Expected connection, got nil")
-				}
-			} else if conn != nil {
-				t.Errorf("Expected no connection, got %v", conn)
-			}
-		})
-	}
-}
-
-func TestListenerClose(t *testing.T) {
+func TestNewListener(t *testing.T) {
 	tests := []struct {
 		name             string
-		setupMocks       func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener)
-		expectedError    string
-		multipleClose    bool
-		validateDoneChan bool
+		netceptor        *netceptor.Netceptor
+		validateChannels bool
+		shouldNotBeNil   bool
 	}{
 		{
-			name: "packetconner error",
-			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
-				mockQL.EXPECT().Close().Return(nil)
-				mockPC.EXPECT().Close().Return(errors.New("packetconner error"))
-			},
-			expectedError: "packetconner error",
+			name:             "creates listener with all fields set",
+			netceptor:        &netceptor.Netceptor{},
+			validateChannels: true,
+			shouldNotBeNil:   true,
 		},
 		{
-			name: "quiclistener error",
-			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
-				mockPC.EXPECT().Close().Return(nil)
-				mockQL.EXPECT().Close().Return(errors.New("quiclistener error"))
-			},
-			expectedError: "quiclistener error",
-		},
-		{
-			name: "successful close",
-			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
-				mockPC.EXPECT().Close().Return(nil)
-				mockQL.EXPECT().Close().Return(nil)
-			},
-			validateDoneChan: true,
-		},
-		{
-			name: "multiple close calls are safe",
-			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
-				mockPC.EXPECT().Close().Return(nil).Times(2)
-				mockQL.EXPECT().Close().Return(nil).Times(2)
-			},
-			multipleClose:    true,
-			validateDoneChan: true,
+			name:           "creates listener with nil netceptor",
+			netceptor:      nil,
+			shouldNotBeNil: true,
 		},
 	}
 
@@ -368,43 +263,25 @@ func TestListenerClose(t *testing.T) {
 			defer ctrl.Finish()
 
 			mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
-			mockListener := mock_netceptor.NewMockQuicListenerForListener(ctrl)
-			mockNetC := &netceptor.Netceptor{}
+			mockQL := mock_netceptor.NewMockQuicListenerForListener(ctrl)
 			doneChan := make(chan struct{})
 			acceptChan := make(chan *netceptor.AcceptResult)
 			syncOnce := &sync.Once{}
 
-			listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
+			listener := netceptor.NewListener(tt.netceptor, mockPacketConner, mockQL, acceptChan, doneChan, syncOnce)
 
-			tt.setupMocks(mockPacketConner, mockListener)
-
-			// First close
-			err1 := listener.Close()
-			if tt.expectedError != "" {
-				if err1 == nil {
-					t.Errorf("Expected error %q, got nil", tt.expectedError)
-				} else if err1.Error() != tt.expectedError {
-					t.Errorf("Expected error %q, got %q", tt.expectedError, err1.Error())
-				}
-			} else if err1 != nil {
-				t.Errorf("Expected no error, got %v", err1)
-			}
-
-			// Test multiple close if requested
-			if tt.multipleClose {
-				err2 := listener.Close()
-				if err2 != nil {
-					t.Errorf("Second close should not error, got %v", err2)
+			if tt.shouldNotBeNil {
+				if listener == nil {
+					t.Error("NewListener should not return nil")
 				}
 			}
 
-			// Validate DoneChan is closed if requested
-			if tt.validateDoneChan {
-				select {
-				case <-listener.DoneChan:
-					// Expected - channel should be closed
-				default:
-					t.Error("DoneChan should be closed after Close()")
+			if tt.validateChannels && listener != nil {
+				if listener.AcceptChan != acceptChan {
+					t.Error("AcceptChan not properly assigned")
+				}
+				if listener.DoneChan != doneChan {
+					t.Error("DoneChan not properly assigned")
 				}
 			}
 		})
@@ -458,6 +335,88 @@ func TestListenerAddr(t *testing.T) {
 	}
 }
 
+func TestListenerAccept(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupAction   func(*netceptor.Listener)
+		expectedError string
+		expectedConn  bool
+	}{
+		{
+			name: "accept channel error",
+			setupAction: func(listener *netceptor.Listener) {
+				go func() {
+					listener.AcceptChan <- &netceptor.AcceptResult{
+						Conn: nil,
+						Err:  errors.New("accept channel error"),
+					}
+				}()
+			},
+			expectedError: "accept channel error",
+		},
+		{
+			name: "accept channel closed",
+			setupAction: func(listener *netceptor.Listener) {
+				close(listener.AcceptChan)
+			},
+			expectedError: "listener accept channel closed",
+		},
+		{
+			name: "done channel closed",
+			setupAction: func(listener *netceptor.Listener) {
+				close(listener.DoneChan)
+			},
+			expectedError: "listener done channel closed",
+		},
+		{
+			name: "successful accept",
+			setupAction: func(listener *netceptor.Listener) {
+				go func() {
+					listener.AcceptChan <- &netceptor.AcceptResult{
+						Conn: &netceptor.Conn{},
+						Err:  nil,
+					}
+				}()
+			},
+			expectedConn: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Common listener setup moved outside the table
+			mockNetC := &netceptor.Netceptor{}
+			ql := &quic.Listener{}
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult)
+			syncOnce := &sync.Once{}
+			listener := netceptor.NewListener(mockNetC, nil, ql, acceptChan, doneChan, syncOnce)
+
+			tt.setupAction(listener)
+
+			conn, err := listener.Accept()
+
+			if tt.expectedError != "" {
+				if err == nil {
+					t.Errorf("Expected error %q, got nil", tt.expectedError)
+				} else if err.Error() != tt.expectedError {
+					t.Errorf("Expected error %q, got %q", tt.expectedError, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+
+			if tt.expectedConn {
+				if conn == nil {
+					t.Error("Expected connection, got nil")
+				}
+			} else if conn != nil {
+				t.Errorf("Expected no connection, got %v", conn)
+			}
+		})
+	}
+}
+
 func TestListenerAcceptEdgeCases(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -473,7 +432,7 @@ func TestListenerAcceptEdgeCases(t *testing.T) {
 					listener.AcceptChan <- nil
 				}()
 			},
-			expectedError: "listener closed",
+			expectedError: "listener accept channel closed",
 		},
 		{
 			name: "accept with successful connection",
@@ -569,57 +528,6 @@ func TestListenerAcceptEdgeCases(t *testing.T) {
 	}
 }
 
-func TestNewListener(t *testing.T) {
-	tests := []struct {
-		name             string
-		netceptor        *netceptor.Netceptor
-		validateChannels bool
-		shouldNotBeNil   bool
-	}{
-		{
-			name:             "creates listener with all fields set",
-			netceptor:        &netceptor.Netceptor{},
-			validateChannels: true,
-			shouldNotBeNil:   true,
-		},
-		{
-			name:           "creates listener with nil netceptor",
-			netceptor:      nil,
-			shouldNotBeNil: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
-
-			mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
-			mockQL := mock_netceptor.NewMockQuicListenerForListener(ctrl)
-			doneChan := make(chan struct{})
-			acceptChan := make(chan *netceptor.AcceptResult)
-			syncOnce := &sync.Once{}
-
-			listener := netceptor.NewListener(tt.netceptor, mockPacketConner, mockQL, acceptChan, doneChan, syncOnce)
-
-			if tt.shouldNotBeNil {
-				if listener == nil {
-					t.Error("NewListener should not return nil")
-				}
-			}
-
-			if tt.validateChannels && listener != nil {
-				if listener.AcceptChan != acceptChan {
-					t.Error("AcceptChan not properly assigned")
-				}
-				if listener.DoneChan != doneChan {
-					t.Error("DoneChan not properly assigned")
-				}
-			}
-		})
-	}
-}
-
 func TestListenerAcceptWithContextCancellation(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
@@ -631,8 +539,8 @@ func TestListenerAcceptWithContextCancellation(t *testing.T) {
 		acceptChan := make(chan *netceptor.AcceptResult)
 		syncOnce := &sync.Once{}
 		listener := netceptor.NewListener(mockNetC, mockPacketConner, ql, acceptChan, doneChan, syncOnce)
-
 		resultChan := make(chan error, 1)
+		expectErrMsg := "listener done channel closed"
 
 		// Start accept in goroutine
 		go func() {
@@ -652,13 +560,105 @@ func TestListenerAcceptWithContextCancellation(t *testing.T) {
 			if err == nil {
 				t.Error("Expected error when done channel closed")
 			}
-			if err.Error() != "listener closed" {
-				t.Errorf("Expected 'listener closed', got %v", err)
+			if err.Error() != expectErrMsg {
+				t.Errorf("Expected '%s', got %v", expectErrMsg, err)
 			}
 		case <-time.After(100 * time.Millisecond):
 			t.Error("Accept should have returned quickly after done channel closed")
 		}
 	})
+}
+
+func TestListenerClose(t *testing.T) {
+	tests := []struct {
+		name             string
+		setupMocks       func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener)
+		expectedError    string
+		multipleClose    bool
+		validateDoneChan bool
+	}{
+		{
+			name: "packetconner error",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockQL.EXPECT().Close().Return(nil)
+				mockPC.EXPECT().Close().Return(errors.New("packetconner error"))
+			},
+			expectedError: "packetconner error",
+		},
+		{
+			name: "quiclistener error",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockPC.EXPECT().Close().Return(nil)
+				mockQL.EXPECT().Close().Return(errors.New("quiclistener error"))
+			},
+			expectedError: "quiclistener error",
+		},
+		{
+			name: "successful close",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockPC.EXPECT().Close().Return(nil)
+				mockQL.EXPECT().Close().Return(nil)
+			},
+			validateDoneChan: true,
+		},
+		{
+			name: "multiple close calls are safe",
+			setupMocks: func(mockPC *mock_netceptor.MockPacketConner, mockQL *mock_netceptor.MockQuicListenerForListener) {
+				mockPC.EXPECT().Close().Return(nil).Times(2)
+				mockQL.EXPECT().Close().Return(nil).Times(2)
+			},
+			multipleClose:    true,
+			validateDoneChan: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockPacketConner := mock_netceptor.NewMockPacketConner(ctrl)
+			mockListener := mock_netceptor.NewMockQuicListenerForListener(ctrl)
+			mockNetC := &netceptor.Netceptor{}
+			doneChan := make(chan struct{})
+			acceptChan := make(chan *netceptor.AcceptResult)
+			syncOnce := &sync.Once{}
+
+			listener := netceptor.NewListener(mockNetC, mockPacketConner, mockListener, acceptChan, doneChan, syncOnce)
+
+			tt.setupMocks(mockPacketConner, mockListener)
+
+			// First close
+			err1 := listener.Close()
+			if tt.expectedError != "" {
+				if err1 == nil {
+					t.Errorf("Expected error %q, got nil", tt.expectedError)
+				} else if err1.Error() != tt.expectedError {
+					t.Errorf("Expected error %q, got %q", tt.expectedError, err1.Error())
+				}
+			} else if err1 != nil {
+				t.Errorf("Expected no error, got %v", err1)
+			}
+
+			// Test multiple close if requested
+			if tt.multipleClose {
+				err2 := listener.Close()
+				if err2 != nil {
+					t.Errorf("Second close should not error, got %v", err2)
+				}
+			}
+
+			// Validate DoneChan is closed if requested
+			if tt.validateDoneChan {
+				select {
+				case <-listener.DoneChan:
+					// Expected - channel should be closed
+				default:
+					t.Error("DoneChan should be closed after Close()")
+				}
+			}
+		})
+	}
 }
 
 func TestListenerCloseErrorPrecedence(t *testing.T) {

--- a/pkg/netceptor/mock_netceptor/conn.go
+++ b/pkg/netceptor/mock_netceptor/conn.go
@@ -393,3 +393,70 @@ func (mr *MockQuicConnectionForConnMockRecorder) SendDatagram(payload any) *gomo
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendDatagram", reflect.TypeOf((*MockQuicConnectionForConn)(nil).SendDatagram), payload)
 }
+
+// MockQuicListenerForListener is a mock of QuicListenerForListener interface.
+type MockQuicListenerForListener struct {
+	ctrl     *gomock.Controller
+	recorder *MockQuicListenerForListenerMockRecorder
+	isgomock struct{}
+}
+
+// MockQuicListenerForListenerMockRecorder is the mock recorder for MockQuicListenerForListener.
+type MockQuicListenerForListenerMockRecorder struct {
+	mock *MockQuicListenerForListener
+}
+
+// NewMockQuicListenerForListener creates a new mock instance.
+func NewMockQuicListenerForListener(ctrl *gomock.Controller) *MockQuicListenerForListener {
+	mock := &MockQuicListenerForListener{ctrl: ctrl}
+	mock.recorder = &MockQuicListenerForListenerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockQuicListenerForListener) EXPECT() *MockQuicListenerForListenerMockRecorder {
+	return m.recorder
+}
+
+// Accept mocks base method.
+func (m *MockQuicListenerForListener) Accept(ctx context.Context) (quic.Connection, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Accept", ctx)
+	ret0, _ := ret[0].(quic.Connection)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Accept indicates an expected call of Accept.
+func (mr *MockQuicListenerForListenerMockRecorder) Accept(ctx any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Accept", reflect.TypeOf((*MockQuicListenerForListener)(nil).Accept), ctx)
+}
+
+// Addr mocks base method.
+func (m *MockQuicListenerForListener) Addr() net.Addr {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Addr")
+	ret0, _ := ret[0].(net.Addr)
+	return ret0
+}
+
+// Addr indicates an expected call of Addr.
+func (mr *MockQuicListenerForListenerMockRecorder) Addr() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Addr", reflect.TypeOf((*MockQuicListenerForListener)(nil).Addr))
+}
+
+// Close mocks base method.
+func (m *MockQuicListenerForListener) Close() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Close")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Close indicates an expected call of Close.
+func (mr *MockQuicListenerForListenerMockRecorder) Close() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockQuicListenerForListener)(nil).Close))
+}


### PR DESCRIPTION
Partial completion of AAP-47012. 
Since #1376 is getting quite big I'm breaking these changes out.

Adds unit tests for `netceptor.Listener`.
- `Listener.Addr()`
- `Listener.Accept()`
- `Listener.Close()`

`Listener.Accept()` would panic if the accept channel was closed. This is because `AcceptChan` uses pointers for AcceptResult (ie: `AcceptChan: make(chan *AcceptResult)`). When the `AcceptChan` is closed the pointer for the `AcceptResult` becomes `nil`.