### PR TITLE
Refactor Kubernetes client to use kubernetes.Interface for better tes…

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -52,7 +52,7 @@ type KubeUnit struct {
 	deletePodOnRestart     bool
 	namePrefix             string
 	config                 *rest.Config
-	clientset              *kubernetes.Clientset
+	clientset              kubernetes.Interface
 	Pod                    *corev1.Pod
 	podPendingTimeout      time.Duration
 }
@@ -71,14 +71,14 @@ type KubeExtraData struct {
 type KubeAPIer interface {
 	NewNotFound(schema.GroupResource, string) *apierrors.StatusError
 	OneTermEqualSelector(string, string) fields.Selector
-	NewForConfig(*rest.Config) (*kubernetes.Clientset, error)
-	GetLogs(*kubernetes.Clientset, string, string, *corev1.PodLogOptions) *rest.Request
-	Get(context.Context, *kubernetes.Clientset, string, string, metav1.GetOptions) (*corev1.Pod, error)
-	Create(context.Context, *kubernetes.Clientset, string, *corev1.Pod, metav1.CreateOptions) (*corev1.Pod, error)
-	List(context.Context, *kubernetes.Clientset, string, metav1.ListOptions) (*corev1.PodList, error)
-	Watch(context.Context, *kubernetes.Clientset, string, metav1.ListOptions) (watch.Interface, error)
-	Delete(context.Context, *kubernetes.Clientset, string, string, metav1.DeleteOptions) error
-	SubResource(*kubernetes.Clientset, string, string) *rest.Request
+	NewForConfig(*rest.Config) (kubernetes.Interface, error)
+	GetLogs(kubernetes.Interface, string, string, *corev1.PodLogOptions) *rest.Request
+	Get(context.Context, kubernetes.Interface, string, string, metav1.GetOptions) (*corev1.Pod, error)
+	Create(context.Context, kubernetes.Interface, string, *corev1.Pod, metav1.CreateOptions) (*corev1.Pod, error)
+	List(context.Context, kubernetes.Interface, string, metav1.ListOptions) (*corev1.PodList, error)
+	Watch(context.Context, kubernetes.Interface, string, metav1.ListOptions) (watch.Interface, error)
+	Delete(context.Context, kubernetes.Interface, string, string, metav1.DeleteOptions) error
+	SubResource(kubernetes.Interface, string, string) *rest.Request
 	InClusterConfig() (*rest.Config, error)
 	NewDefaultClientConfigLoadingRules() *clientcmd.ClientConfigLoadingRules
 	BuildConfigFromFlags(string, string) (*rest.Config, error)
@@ -100,35 +100,35 @@ func (ku KubeAPIWrapper) OneTermEqualSelector(k string, v string) fields.Selecto
 	return fields.OneTermEqualSelector(k, v)
 }
 
-func (ku KubeAPIWrapper) NewForConfig(c *rest.Config) (*kubernetes.Clientset, error) {
+func (ku KubeAPIWrapper) NewForConfig(c *rest.Config) (kubernetes.Interface, error) {
 	return kubernetes.NewForConfig(c)
 }
 
-func (ku KubeAPIWrapper) GetLogs(clientset *kubernetes.Clientset, namespace string, name string, opts *corev1.PodLogOptions) *rest.Request {
+func (ku KubeAPIWrapper) GetLogs(clientset kubernetes.Interface, namespace string, name string, opts *corev1.PodLogOptions) *rest.Request {
 	return clientset.CoreV1().Pods(namespace).GetLogs(name, opts)
 }
 
-func (ku KubeAPIWrapper) Get(ctx context.Context, clientset *kubernetes.Clientset, namespace string, name string, opts metav1.GetOptions) (*corev1.Pod, error) {
+func (ku KubeAPIWrapper) Get(ctx context.Context, clientset kubernetes.Interface, namespace string, name string, opts metav1.GetOptions) (*corev1.Pod, error) {
 	return clientset.CoreV1().Pods(namespace).Get(ctx, name, opts)
 }
 
-func (ku KubeAPIWrapper) Create(ctx context.Context, clientset *kubernetes.Clientset, namespace string, pod *corev1.Pod, opts metav1.CreateOptions) (*corev1.Pod, error) {
+func (ku KubeAPIWrapper) Create(ctx context.Context, clientset kubernetes.Interface, namespace string, pod *corev1.Pod, opts metav1.CreateOptions) (*corev1.Pod, error) {
 	return clientset.CoreV1().Pods(namespace).Create(ctx, pod, opts)
 }
 
-func (ku KubeAPIWrapper) List(ctx context.Context, clientset *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (*corev1.PodList, error) {
+func (ku KubeAPIWrapper) List(ctx context.Context, clientset kubernetes.Interface, namespace string, opts metav1.ListOptions) (*corev1.PodList, error) {
 	return clientset.CoreV1().Pods(namespace).List(ctx, opts)
 }
 
-func (ku KubeAPIWrapper) Watch(ctx context.Context, clientset *kubernetes.Clientset, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
+func (ku KubeAPIWrapper) Watch(ctx context.Context, clientset kubernetes.Interface, namespace string, opts metav1.ListOptions) (watch.Interface, error) {
 	return clientset.CoreV1().Pods(namespace).Watch(ctx, opts)
 }
 
-func (ku KubeAPIWrapper) Delete(ctx context.Context, clientset *kubernetes.Clientset, namespace string, name string, opts metav1.DeleteOptions) error {
+func (ku KubeAPIWrapper) Delete(ctx context.Context, clientset kubernetes.Interface, namespace string, name string, opts metav1.DeleteOptions) error {
 	return clientset.CoreV1().Pods(namespace).Delete(ctx, name, opts)
 }
 
-func (ku KubeAPIWrapper) SubResource(clientset *kubernetes.Clientset, podName string, podNamespace string) *rest.Request {
+func (ku KubeAPIWrapper) SubResource(clientset kubernetes.Interface, podName string, podNamespace string) *rest.Request {
 	return clientset.CoreV1().RESTClient().Post().Resource("pods").Name(podName).Namespace(podNamespace).SubResource("attach")
 }
 
@@ -1010,7 +1010,7 @@ func ShouldUseReconnect(kw *KubeUnit) bool {
 		}
 	}
 
-	serverVerInfo, err := kw.clientset.ServerVersion()
+	serverVerInfo, err := kw.clientset.Discovery().ServerVersion()
 	if err != nil {
 		kw.GetWorkceptor().nc.GetLogger().Warning("could not detect Kubernetes server version, will not use reconnect support")
 
@@ -1500,7 +1500,7 @@ func (kw *KubeUnit) Status() *StatusFileData {
 }
 
 // SetClientset sets the clientset for testing purposes.
-func (kw *KubeUnit) SetClientset(clientset *kubernetes.Clientset) {
+func (kw *KubeUnit) SetClientset(clientset kubernetes.Interface) {
 	kw.clientset = clientset
 }
 

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1021,7 +1021,7 @@ func TestKubeAPIWrapperExtended(t *testing.T) {
 	t.Run("NewForConfig", func(t *testing.T) {
 		// Verify NewForConfig method exists with correct signature
 		methodType := reflect.TypeOf(wrapper.NewForConfig)
-		assert.Equal(t, "func(*rest.Config) (*kubernetes.Clientset, error)", methodType.String())
+		assert.Equal(t, "func(*rest.Config) (kubernetes.Interface, error)", methodType.String())
 	})
 
 	// Test GetLogs

--- a/pkg/workceptor/mock_workceptor/kubernetes.go
+++ b/pkg/workceptor/mock_workceptor/kubernetes.go
@@ -71,7 +71,7 @@ func (mr *MockKubeAPIerMockRecorder) BuildConfigFromFlags(arg0, arg1 any) *gomoc
 }
 
 // Create mocks base method.
-func (m *MockKubeAPIer) Create(arg0 context.Context, arg1 *kubernetes.Clientset, arg2 string, arg3 *v1.Pod, arg4 v10.CreateOptions) (*v1.Pod, error) {
+func (m *MockKubeAPIer) Create(arg0 context.Context, arg1 kubernetes.Interface, arg2 string, arg3 *v1.Pod, arg4 v10.CreateOptions) (*v1.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1.Pod)
@@ -86,7 +86,7 @@ func (mr *MockKubeAPIerMockRecorder) Create(arg0, arg1, arg2, arg3, arg4 any) *g
 }
 
 // Delete mocks base method.
-func (m *MockKubeAPIer) Delete(arg0 context.Context, arg1 *kubernetes.Clientset, arg2, arg3 string, arg4 v10.DeleteOptions) error {
+func (m *MockKubeAPIer) Delete(arg0 context.Context, arg1 kubernetes.Interface, arg2, arg3 string, arg4 v10.DeleteOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
@@ -100,7 +100,7 @@ func (mr *MockKubeAPIerMockRecorder) Delete(arg0, arg1, arg2, arg3, arg4 any) *g
 }
 
 // Get mocks base method.
-func (m *MockKubeAPIer) Get(arg0 context.Context, arg1 *kubernetes.Clientset, arg2, arg3 string, arg4 v10.GetOptions) (*v1.Pod, error) {
+func (m *MockKubeAPIer) Get(arg0 context.Context, arg1 kubernetes.Interface, arg2, arg3 string, arg4 v10.GetOptions) (*v1.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(*v1.Pod)
@@ -115,7 +115,7 @@ func (mr *MockKubeAPIerMockRecorder) Get(arg0, arg1, arg2, arg3, arg4 any) *gomo
 }
 
 // GetLogs mocks base method.
-func (m *MockKubeAPIer) GetLogs(arg0 *kubernetes.Clientset, arg1, arg2 string, arg3 *v1.PodLogOptions) *rest.Request {
+func (m *MockKubeAPIer) GetLogs(arg0 kubernetes.Interface, arg1, arg2 string, arg3 *v1.PodLogOptions) *rest.Request {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogs", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*rest.Request)
@@ -144,7 +144,7 @@ func (mr *MockKubeAPIerMockRecorder) InClusterConfig() *gomock.Call {
 }
 
 // List mocks base method.
-func (m *MockKubeAPIer) List(arg0 context.Context, arg1 *kubernetes.Clientset, arg2 string, arg3 v10.ListOptions) (*v1.PodList, error) {
+func (m *MockKubeAPIer) List(arg0 context.Context, arg1 kubernetes.Interface, arg2 string, arg3 v10.ListOptions) (*v1.PodList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*v1.PodList)
@@ -216,10 +216,10 @@ func (mr *MockKubeAPIerMockRecorder) NewFakeNeverRateLimiter() *gomock.Call {
 }
 
 // NewForConfig mocks base method.
-func (m *MockKubeAPIer) NewForConfig(arg0 *rest.Config) (*kubernetes.Clientset, error) {
+func (m *MockKubeAPIer) NewForConfig(arg0 *rest.Config) (kubernetes.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewForConfig", arg0)
-	ret0, _ := ret[0].(*kubernetes.Clientset)
+	ret0, _ := ret[0].(kubernetes.Interface)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -288,7 +288,7 @@ func (mr *MockKubeAPIerMockRecorder) StreamWithContext(arg0, arg1, arg2 any) *go
 }
 
 // SubResource mocks base method.
-func (m *MockKubeAPIer) SubResource(arg0 *kubernetes.Clientset, arg1, arg2 string) *rest.Request {
+func (m *MockKubeAPIer) SubResource(arg0 kubernetes.Interface, arg1, arg2 string) *rest.Request {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubResource", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*rest.Request)
@@ -322,7 +322,7 @@ func (mr *MockKubeAPIerMockRecorder) UntilWithSync(arg0, arg1, arg2, arg3 any, a
 }
 
 // Watch mocks base method.
-func (m *MockKubeAPIer) Watch(arg0 context.Context, arg1 *kubernetes.Clientset, arg2 string, arg3 v10.ListOptions) (watch.Interface, error) {
+func (m *MockKubeAPIer) Watch(arg0 context.Context, arg1 kubernetes.Interface, arg2 string, arg3 v10.ListOptions) (watch.Interface, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Watch", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(watch.Interface)


### PR DESCRIPTION
…tability

  Replace concrete *kubernetes.Clientset with kubernetes.Interface
  throughout
  the Kubernetes workceptor implementation to improve testability and enable
  better dependency injection patterns.

  Changes:
  - Update KubeUnit struct to use kubernetes.Interface instead of *kubernetes.Clientset
  - Modify all KubeAPIer interface methods to accept kubernetes.Interface parameters
  - Regenerate mock implementations to reflect interface changes
  - Update test assertions to verify correct interface types
  - Fix test for logging reconnection scenarios

  This abstraction allows for easier unit testing and better separation of
  concerns by depending on interfaces rather than concrete implementations.

  Co-Authored-By: Matthew Sandoval <mat24c@gmail.com>
  Co-Authored-By: Dan Leehr <dleehr@users.noreply.github.com>
  Co-Authored-By: Lisa Ranjbar Miller <lranjbar@redhat.com>