### PR TITLE
Fix data race in workunitbase test setUp function

### DIFF
--- a/pkg/workceptor/workunitbase_test.go
+++ b/pkg/workceptor/workunitbase_test.go
@@ -86,11 +86,7 @@ func TestIsPending(t *testing.T) {
 
 func setUp(t *testing.T) (*gomock.Controller, workceptor.BaseWorkUnit, *workceptor.Workceptor, *mock_workceptor.MockNetceptorForWorkceptor, *logger.ReceptorLogger) {
 	ctrl := gomock.NewController(t)
-
 	mockNetceptor := mock_workceptor.NewMockNetceptorForWorkceptor(ctrl)
-
-	// attach logger to the mock netceptor and return any number of times
-	logger.SetGlobalLogLevel(4)
 	logger := logger.NewReceptorLogger("")
 	mockNetceptor.EXPECT().GetLogger().AnyTimes().Return(logger)
 	mockNetceptor.EXPECT().NodeID().Return("NodeID")


### PR DESCRIPTION
Clean up test setup by removing unnecessary code and blank lines that could contribute to data race conditions in workceptor tests.