### PR TITLE
add unable to upgrade connection test

### DIFF
--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/fake"
+	fakekubernetes "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	fakerest "k8s.io/client-go/rest/fake"
@@ -3269,6 +3269,10 @@ func TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection(t *testing.T
 
 	mockBaseWorkUnit.EXPECT().Init(w, "", "", workceptor.FileSystem{})
 	kubeUnit := kubeConfig.NewkubeWorker(mockBaseWorkUnit, w, "", "", mockKubeAPI).(*workceptor.KubeUnit)
+	
+	// Set up a fake clientset to avoid nil pointer dereference in ShouldUseReconnect
+	fakeClientset := fakekubernetes.NewSimpleClientset()
+	kubeUnit.SetClientset(fakeClientset)
 
 	// CRITICAL: Set up status to trigger NEW pod creation (empty PodName)
 	// This makes skipStdin = false, which triggers stdin streaming and SPDY executor
@@ -4216,7 +4220,7 @@ func TestKubeUnit_RunWorkUsingLogger_ExitCode1SetsFinished(t *testing.T) {
 					},
 				},
 			}
-			fakeClient := fake.NewSimpleClientset(existingPod)
+			fakeClient := fakekubernetes.NewSimpleClientset(existingPod)
 			kubeUnit.SetClientset(fakeClient)
 
 			mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), testNamespace, tc.podName, gomock.Any()).Return(existingPod, nil).AnyTimes()

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -3230,6 +3230,7 @@ func TestKubeUnit_RunWorkUsingLogger(t *testing.T) {
 // TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection specifically tests the scenario
 // where STDIN streaming fails with "unable to upgrade connection" when the worker container is not found.
 func TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection(t *testing.T) {
+	t.Parallel() // Run in parallel to isolate from other tests
 	// Create test directory with stdin file to trigger stdin streaming
 	testDir := "/tmp/test-stdin-upgrade-connection"
 	err := os.MkdirAll(testDir, 0o755)
@@ -3255,7 +3256,9 @@ func TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection(t *testing.T
 	mockNetceptor.EXPECT().NodeID().Return("test-node").AnyTimes()
 	mockNetceptor.EXPECT().GetLogger().Return(logger.NewReceptorLogger("test")).AnyTimes()
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // Ensure all goroutines are cancelled when test ends
+
 	w, err := workceptor.New(ctx, mockNetceptor, "/tmp")
 	if err != nil {
 		t.Fatalf("Error creating Workceptor: %v", err)
@@ -3292,6 +3295,7 @@ func TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection(t *testing.T
 	mockBaseWorkUnit.EXPECT().GetStatusWithoutExtraData().Return(statusData).AnyTimes()
 	mockBaseWorkUnit.EXPECT().GetStatusCopy().Return(statusCopy).AnyTimes()
 	mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetCancel().Return(cancel).AnyTimes()
 	mockBaseWorkUnit.EXPECT().UnitDir().Return(testDir).AnyTimes()
 	mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
 	mockBaseWorkUnit.EXPECT().ID().Return("test-unit-id").AnyTimes()

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -2982,7 +2982,7 @@ spec:
 	}
 }
 
-// mockSPDYExecutor is a simple mock implementation of remotecommand.Executor for testing
+// mockSPDYExecutor is a simple mock implementation of remotecommand.Executor for testing.
 type mockSPDYExecutor struct{}
 
 func (m *mockSPDYExecutor) Stream(options remotecommand.StreamOptions) error {
@@ -3227,16 +3227,23 @@ func TestKubeUnit_RunWorkUsingLogger(t *testing.T) {
 	}
 }
 
-// TestKubeUnit_RunWorkUsingLogger_UnableToUpgradeConnection specifically tests the scenario
-// where stdin streaming fails with "unable to upgrade connection" when the container hasn't started yet.
-func TestKubeUnit_RunWorkUsingLogger_UnableToUpgradeConnection(t *testing.T) {
-	// Create test directory
-	testDir := "/tmp/test-upgrade-connection"
-	err := os.MkdirAll(testDir, 0755)
+// TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection specifically tests the scenario
+// where STDIN streaming fails with "unable to upgrade connection" when the worker container is not found.
+func TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection(t *testing.T) {
+	// Create test directory with stdin file to trigger stdin streaming
+	testDir := "/tmp/test-stdin-upgrade-connection"
+	err := os.MkdirAll(testDir, 0o755)
 	if err != nil {
 		t.Fatalf("Failed to create test directory: %v", err)
 	}
 	defer os.RemoveAll(testDir)
+
+	// Create a stdin file so skipStdin will be false
+	stdinFile := filepath.Join(testDir, "stdin")
+	err = os.WriteFile(stdinFile, []byte("test input data\n"), 0o644)
+	if err != nil {
+		t.Fatalf("Failed to create stdin file: %v", err)
+	}
 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -3254,7 +3261,7 @@ func TestKubeUnit_RunWorkUsingLogger_UnableToUpgradeConnection(t *testing.T) {
 		t.Fatalf("Error creating Workceptor: %v", err)
 	}
 
-	// Create KubeUnit with logger stream method (this is where stdin streaming occurs)
+	// Create KubeUnit with logger stream method
 	kubeConfig := workceptor.KubeWorkerCfg{
 		AuthMethod:   "incluster",
 		StreamMethod: "logger",
@@ -3263,15 +3270,18 @@ func TestKubeUnit_RunWorkUsingLogger_UnableToUpgradeConnection(t *testing.T) {
 	mockBaseWorkUnit.EXPECT().Init(w, "", "", workceptor.FileSystem{})
 	kubeUnit := kubeConfig.NewkubeWorker(mockBaseWorkUnit, w, "", "", mockKubeAPI).(*workceptor.KubeUnit)
 
-	// Set up status to indicate an existing pod (so it doesn't try to create a new one)
+	// CRITICAL: Set up status to trigger NEW pod creation (empty PodName)
+	// This makes skipStdin = false, which triggers stdin streaming and SPDY executor
 	statusLock := &sync.RWMutex{}
 	statusData := &workceptor.StatusFileData{
-		State: workceptor.WorkStateRunning,
+		State:     workceptor.WorkStateRunning,
 		ExtraData: &workceptor.KubeExtraData{},
 	}
 	statusCopy := workceptor.StatusFileData{ExtraData: &workceptor.KubeExtraData{
+		Image:         "busybox:latest",
+		Command:       "cat",
 		KubeNamespace: "default",
-		PodName:       "container-not-ready-pod", // Non-empty triggers existing pod retrieval
+		PodName:       "", // EMPTY to trigger new pod creation and stdin streaming
 	}}
 
 	mockBaseWorkUnit.EXPECT().GetStatusLock().Return(statusLock).AnyTimes()
@@ -3280,65 +3290,82 @@ func TestKubeUnit_RunWorkUsingLogger_UnableToUpgradeConnection(t *testing.T) {
 	mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
 	mockBaseWorkUnit.EXPECT().UnitDir().Return(testDir).AnyTimes()
 	mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
+	mockBaseWorkUnit.EXPECT().ID().Return("test-unit-id").AnyTimes()
 
-	// Mock a pod that exists but doesn't have the expected "worker" container yet
-	// This simulates a pod that's still being created and the worker container hasn't been added
+	// Mock CreatePod to create a pod without the worker container
 	podWithoutWorkerContainer := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "container-not-ready-pod",
+			Name:      "test-pod-without-worker",
 			Namespace: "default",
 		},
 		Status: corev1.PodStatus{
 			Phase: corev1.PodPending,
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: "init-container", // Different container name - NOT "worker"
+					Name: "init-container", // NOT "worker" container
 					State: corev1.ContainerState{
-						Running: &corev1.ContainerStateRunning{},
+						Waiting: &corev1.ContainerStateWaiting{
+							Reason: "ContainerCreating",
+						},
 					},
-					Ready: true,
+					Ready: false,
 				},
 			},
 		},
 	}
 
-	// Mock successful pod retrieval - called multiple times during logger-based streaming
-	mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), "default", "container-not-ready-pod", gomock.Any()).Return(podWithoutWorkerContainer, nil).AnyTimes()
+	// Mock pod creation that succeeds but creates pod without worker container
+	mockKubeAPI.EXPECT().Create(gomock.Any(), gomock.Any(), "default", gomock.Any(), gomock.Any()).Return(podWithoutWorkerContainer, nil)
 
-	// Mock status updates
-	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	// Mock additional Get calls that happen during logger streaming
+	mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), "default", "test-pod-without-worker", gomock.Any()).Return(podWithoutWorkerContainer, nil).AnyTimes()
+
+	// Mock status updates during pod creation
 	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).AnyTimes()
+	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 
-	// The key part - mock the stdin streaming attempt that will fail with "unable to upgrade connection"
-	// This happens when trying to stream to a container that isn't ready yet
-	
-	// Mock SubResource call for stdin streaming
-	mockKubeAPI.EXPECT().SubResource(gomock.Any(), "container-not-ready-pod", "default").Return(&rest.Request{}).AnyTimes()
-	
+	// Mock pod waiting/watching during CreatePod
+	selector := &hasTerm{field: "metadata.name", value: "test-pod-without-worker"}
+	mockKubeAPI.EXPECT().OneTermEqualSelector("metadata.name", "test-pod-without-worker").Return(selector)
+	mockKubeAPI.EXPECT().List(gomock.Any(), gomock.Any(), "default", gomock.Any()).Return(&corev1.PodList{}, nil).AnyTimes()
+	mockKubeAPI.EXPECT().Watch(gomock.Any(), gomock.Any(), "default", gomock.Any()).Return(nil, nil).AnyTimes()
+	watchEvent := &watch.Event{Type: watch.Modified, Object: podWithoutWorkerContainer}
+	mockKubeAPI.EXPECT().UntilWithSync(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(watchEvent, nil)
+
+	// NOW THE KEY PART: Mock stdin streaming that fails with "unable to upgrade connection"
+
+	// Mock SubResource call for stdin streaming to the worker container
+	// Create a proper rest.Request with required URL
+	testURL, _ := url.Parse("https://localhost/api/v1/namespaces/default/pods/test-pod-without-worker/exec")
+	req := rest.NewRequestWithClient(testURL, "", rest.ClientContentConfig{}, nil).
+		VersionedParams(&corev1.PodExecOptions{}, scheme.ParameterCodec)
+	mockKubeAPI.EXPECT().SubResource(gomock.Any(), "test-pod-without-worker", "default").Return(req).AnyTimes()
+
 	// Mock SPDY executor creation
 	mockExecutor := &mockSPDYExecutor{}
 	mockKubeAPI.EXPECT().NewSPDYExecutor(gomock.Any(), "POST", gomock.Any()).Return(mockExecutor, nil).AnyTimes()
-	
-	// Mock log streaming that will also fail when worker container is not found
-	req := fakerest.RESTClient{
+
+	// Mock the StreamWithContext call that fails with "unable to upgrade connection"
+	// This is the specific error when trying to stream stdin to a non-existent worker container
+	stdinUpgradeError := fmt.Errorf("unable to upgrade connection: container worker not found in pod test-pod-without-worker")
+	mockKubeAPI.EXPECT().StreamWithContext(gomock.Any(), mockExecutor, gomock.Any()).Return(stdinUpgradeError).Times(5) // Will retry 5 times
+
+	// Mock log streaming (this runs in parallel with stdin streaming)
+	logReq := fakerest.RESTClient{
 		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
-			// Simulate the "unable to upgrade connection" error during log streaming when worker container not found
-			return nil, fmt.Errorf("unable to upgrade connection: container worker not found in pod container-not-ready-pod")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("test log output")),
+			}, nil
 		}),
 		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
 	}
-	mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+	mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(logReq.Request()).AnyTimes()
 
-	// Mock the StreamWithContext call that fails with the specific "worker not found" error
-	// This error occurs because the pod doesn't have the expected "worker" container yet
-	upgradeError := fmt.Errorf("unable to upgrade connection: container worker not found in pod container-not-ready-pod")
-	mockKubeAPI.EXPECT().StreamWithContext(gomock.Any(), mockExecutor, gomock.Any()).Return(upgradeError).AnyTimes()
-
-	// Test that RunWorkUsingLogger handles the upgrade failure gracefully
-	// This reproduces the real scenario where a pod exists but doesn't have the worker container yet
-	t.Log("Testing unable to upgrade connection error: container worker not found in pod")
+	// Test that RunWorkUsingLogger handles the stdin upgrade failure gracefully
+	t.Log("Testing stdin streaming unable to upgrade connection error: container worker not found in pod")
 	kubeUnit.RunWorkUsingLogger()
-	t.Log("RunWorkUsingLogger completed - successfully handled unable to upgrade connection error")
+	t.Log("RunWorkUsingLogger completed - successfully handled stdin streaming unable to upgrade connection error")
 }
 
 // TestKubeAPIWrapper_StreamWithContext tests the StreamWithContext method.

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -2982,6 +2982,17 @@ spec:
 	}
 }
 
+// mockSPDYExecutor is a simple mock implementation of remotecommand.Executor for testing
+type mockSPDYExecutor struct{}
+
+func (m *mockSPDYExecutor) Stream(options remotecommand.StreamOptions) error {
+	return nil
+}
+
+func (m *mockSPDYExecutor) StreamWithContext(ctx context.Context, options remotecommand.StreamOptions) error {
+	return nil
+}
+
 func TestKubeUnit_RunWorkUsingLogger(t *testing.T) {
 	// Test basic execution paths that are feasible to test with focused mocking
 	tests := []struct {
@@ -3214,6 +3225,120 @@ func TestKubeUnit_RunWorkUsingLogger(t *testing.T) {
 			t.Logf("Function completed successfully for error path test")
 		})
 	}
+}
+
+// TestKubeUnit_RunWorkUsingLogger_UnableToUpgradeConnection specifically tests the scenario
+// where stdin streaming fails with "unable to upgrade connection" when the container hasn't started yet.
+func TestKubeUnit_RunWorkUsingLogger_UnableToUpgradeConnection(t *testing.T) {
+	// Create test directory
+	testDir := "/tmp/test-upgrade-connection"
+	err := os.MkdirAll(testDir, 0755)
+	if err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+	defer os.RemoveAll(testDir)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBaseWorkUnit := mock_workceptor.NewMockBaseWorkUnitForWorkUnit(ctrl)
+	mockNetceptor := mock_workceptor.NewMockNetceptorForWorkceptor(ctrl)
+	mockKubeAPI := mock_workceptor.NewMockKubeAPIer(ctrl)
+
+	mockNetceptor.EXPECT().NodeID().Return("test-node").AnyTimes()
+	mockNetceptor.EXPECT().GetLogger().Return(logger.NewReceptorLogger("test")).AnyTimes()
+
+	ctx := context.Background()
+	w, err := workceptor.New(ctx, mockNetceptor, "/tmp")
+	if err != nil {
+		t.Fatalf("Error creating Workceptor: %v", err)
+	}
+
+	// Create KubeUnit with logger stream method (this is where stdin streaming occurs)
+	kubeConfig := workceptor.KubeWorkerCfg{
+		AuthMethod:   "incluster",
+		StreamMethod: "logger",
+	}
+
+	mockBaseWorkUnit.EXPECT().Init(w, "", "", workceptor.FileSystem{})
+	kubeUnit := kubeConfig.NewkubeWorker(mockBaseWorkUnit, w, "", "", mockKubeAPI).(*workceptor.KubeUnit)
+
+	// Set up status to indicate an existing pod (so it doesn't try to create a new one)
+	statusLock := &sync.RWMutex{}
+	statusData := &workceptor.StatusFileData{
+		State: workceptor.WorkStateRunning,
+		ExtraData: &workceptor.KubeExtraData{},
+	}
+	statusCopy := workceptor.StatusFileData{ExtraData: &workceptor.KubeExtraData{
+		KubeNamespace: "default",
+		PodName:       "container-not-ready-pod", // Non-empty triggers existing pod retrieval
+	}}
+
+	mockBaseWorkUnit.EXPECT().GetStatusLock().Return(statusLock).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetStatusWithoutExtraData().Return(statusData).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetStatusCopy().Return(statusCopy).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
+	mockBaseWorkUnit.EXPECT().UnitDir().Return(testDir).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
+
+	// Mock a pod that exists but doesn't have the expected "worker" container yet
+	// This simulates a pod that's still being created and the worker container hasn't been added
+	podWithoutWorkerContainer := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "container-not-ready-pod",
+			Namespace: "default",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "init-container", // Different container name - NOT "worker"
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{},
+					},
+					Ready: true,
+				},
+			},
+		},
+	}
+
+	// Mock successful pod retrieval - called multiple times during logger-based streaming
+	mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), "default", "container-not-ready-pod", gomock.Any()).Return(podWithoutWorkerContainer, nil).AnyTimes()
+
+	// Mock status updates
+	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).AnyTimes()
+
+	// The key part - mock the stdin streaming attempt that will fail with "unable to upgrade connection"
+	// This happens when trying to stream to a container that isn't ready yet
+	
+	// Mock SubResource call for stdin streaming
+	mockKubeAPI.EXPECT().SubResource(gomock.Any(), "container-not-ready-pod", "default").Return(&rest.Request{}).AnyTimes()
+	
+	// Mock SPDY executor creation
+	mockExecutor := &mockSPDYExecutor{}
+	mockKubeAPI.EXPECT().NewSPDYExecutor(gomock.Any(), "POST", gomock.Any()).Return(mockExecutor, nil).AnyTimes()
+	
+	// Mock log streaming that will also fail when worker container is not found
+	req := fakerest.RESTClient{
+		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			// Simulate the "unable to upgrade connection" error during log streaming when worker container not found
+			return nil, fmt.Errorf("unable to upgrade connection: container worker not found in pod container-not-ready-pod")
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+	mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+
+	// Mock the StreamWithContext call that fails with the specific "worker not found" error
+	// This error occurs because the pod doesn't have the expected "worker" container yet
+	upgradeError := fmt.Errorf("unable to upgrade connection: container worker not found in pod container-not-ready-pod")
+	mockKubeAPI.EXPECT().StreamWithContext(gomock.Any(), mockExecutor, gomock.Any()).Return(upgradeError).AnyTimes()
+
+	// Test that RunWorkUsingLogger handles the upgrade failure gracefully
+	// This reproduces the real scenario where a pod exists but doesn't have the worker container yet
+	t.Log("Testing unable to upgrade connection error: container worker not found in pod")
+	kubeUnit.RunWorkUsingLogger()
+	t.Log("RunWorkUsingLogger completed - successfully handled unable to upgrade connection error")
 }
 
 // TestKubeAPIWrapper_StreamWithContext tests the StreamWithContext method.

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -3269,7 +3269,7 @@ func TestKubeUnit_RunWorkUsingLogger_StdinUnableToUpgradeConnection(t *testing.T
 
 	mockBaseWorkUnit.EXPECT().Init(w, "", "", workceptor.FileSystem{})
 	kubeUnit := kubeConfig.NewkubeWorker(mockBaseWorkUnit, w, "", "", mockKubeAPI).(*workceptor.KubeUnit)
-	
+
 	// Set up a fake clientset to avoid nil pointer dereference in ShouldUseReconnect
 	fakeClientset := fakekubernetes.NewSimpleClientset()
 	kubeUnit.SetClientset(fakeClientset)


### PR DESCRIPTION
add unable to upgrade connection test

Test output:
```
test ERROR 2025/08/19 14:11:12 Error streaming stdin to pod default/test-pod-without-worker. Will retry 5 more times. Error: unable to upgrade connection: container worker not found in pod test-pod-without-worker
test ERROR 2025/08/19 14:11:12 Unable to find the container worker for pod test-pod-without-worker. This is unrecoverable. Marking the job as failed and exiting
test WARNING 2025/08/19 14:11:12 Error streaming stdin to pod default/test-pod-without-worker. Will retry 4 more times. Error: unable to upgrade connection: container worker not found in pod test-pod-without-worker
test WARNING 2025/08/19 14:11:13 Error streaming stdin to pod default/test-pod-without-worker. Will retry 3 more times. Error: unable to upgrade connection: container worker not found in pod test-pod-without-worker
test WARNING 2025/08/19 14:11:13 Error streaming stdin to pod default/test-pod-without-worker. Will retry 2 more times. Error: unable to upgrade connection: container worker not found in pod test-pod-without-worker
test WARNING 2025/08/19 14:11:13 Error streaming stdin to pod default/test-pod-without-worker. Will retry 1 more times. Error: unable to upgrade connection: container worker not found in pod test-pod-without-worker
test ERROR 2025/08/19 14:11:13 Error streaming stdin to pod default/test-pod-without-worker. Error: unable to upgrade connection: container worker not found in pod test-pod-without-worker
```