### PR TITLE
Correct log messages to identify the pod name instead of container name

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -521,7 +521,11 @@ mainLoop:
 						continue mainLoop
 					}
 					// Retrying hasn't worked we will error and mark the job as failed
-					kw.GetWorkceptor().nc.GetLogger().Error("Container in %s pod is running but is continuing to stream EOF after retries exhausted", podName)
+					kw.GetWorkceptor().nc.GetLogger().Error("%s/%s: %s is running but is continuing to stream EOF after retries exhausted",
+						podNamespace,
+						podName,
+						WorkerContainerName,
+					)
 					*stdoutErr = fmt.Errorf("detected Error: %s for pod %s/%s. Pod is running but is continuing to stream EOF after retries exhausted", err,
 						podNamespace,
 						podName,
@@ -531,7 +535,11 @@ mainLoop:
 				case containerState.Terminated != nil:
 					// We got EOF and the pod terminated, we will log the terminated information
 					if containerState.Terminated.ExitCode != 0 {
-						kw.GetWorkceptor().nc.GetLogger().Info("Container in %s pod has terminated, with nonzero exit code: %v, terminated reason: %v and terminated message: %v", podName, containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
+						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s has terminated, with nonzero exit code: %v, terminated reason: %v and terminated message: %v",
+							podNamespace,
+							podName,
+							WorkerContainerName,
+							containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
 					}
 
 					// We need to check if last line has data
@@ -557,8 +565,12 @@ mainLoop:
 				// Something has gone very wrong if we are here. EOF is true and we can get the container state, but it is not running or terminated.
 				// At this stage something has gone very wrong with our interactions with the container.
 				// We will fail, and mark the job as failed due to an unknown kube container state.
-
-				kw.GetWorkceptor().nc.GetLogger().Error("received EOF on log stream for pod %s and container state is not valid %s, failing and marking the job as failed", podName, containerState)
+				kw.GetWorkceptor().nc.GetLogger().Error("%s/%s: %s sent EOF on log stream and container state is not valid %s, failing and marking the job as failed",
+					podNamespace,
+					podName,
+					WorkerContainerName,
+					containerState,
+				)
 				*stdoutErr = fmt.Errorf("received EOF on log stream for pod %s and container state is not valid %s, failing and marking the job as failed", podName, containerState)
 
 				return

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -521,7 +521,7 @@ mainLoop:
 						continue mainLoop
 					}
 					// Retrying hasn't worked we will error and mark the job as failed
-					kw.GetWorkceptor().nc.GetLogger().Error("Container in %s pod is running but is continuing to stream EOF after retries exhausted", WorkerContainerName)
+					kw.GetWorkceptor().nc.GetLogger().Error("Container in %s pod is running but is continuing to stream EOF after retries exhausted", podName)
 					*stdoutErr = fmt.Errorf("detected Error: %s for pod %s/%s. Pod is running but is continuing to stream EOF after retries exhausted", err,
 						podNamespace,
 						podName,
@@ -531,7 +531,7 @@ mainLoop:
 				case containerState.Terminated != nil:
 					// We got EOF and the pod terminated, we will log the terminated information
 					if containerState.Terminated.ExitCode != 0 {
-						kw.GetWorkceptor().nc.GetLogger().Info("Container in %s pod has terminated, with nonzero exit code: %v, terminated reason: %v and terminated message: %v", WorkerContainerName, containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
+						kw.GetWorkceptor().nc.GetLogger().Info("Container in %s pod has terminated, with nonzero exit code: %v, terminated reason: %v and terminated message: %v", podName, containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
 					}
 
 					// We need to check if last line has data

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1287,7 +1287,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Container in Test_Name pod has terminated, with nonzero exit code: 1, terminated reason: Error and terminated message: Container failed with error",
+				"Test_Namespace/Test_Name: worker has terminated, with nonzero exit code: 1, terminated reason: Error and terminated message: Container failed with error",
 			},
 		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1287,7 +1287,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Container in worker pod has terminated, with nonzero exit code: 1, terminated reason: Error and terminated message: Container failed with error",
+				"Container in Test_name pod has terminated, with nonzero exit code: 1, terminated reason: Error and terminated message: Container failed with error",
 			},
 		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1287,7 +1287,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Container in Test_name pod has terminated, with nonzero exit code: 1, terminated reason: Error and terminated message: Container failed with error",
+				"Container in Test_Name pod has terminated, with nonzero exit code: 1, terminated reason: Error and terminated message: Container failed with error",
 			},
 		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code


### PR DESCRIPTION
Some log messages were including the name of the container (which is a constant `worker`) rather than the name of the pod. This change updates those log statements to print the name of the pod since it is useful when reviewing logs.