### PR TITLE
Fix qlog tracing

### DIFF
--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -167,12 +167,6 @@ func (s *Netceptor) tracer(ctx context.Context, p logging.Perspective, connID qu
 
 			return nil
 		}
-		defer func() {
-			err := f.Close()
-			if err != nil {
-				s.GetLogger().Error("Error closing %s: %s", qlogPath+filename, err)
-			}
-		}()
 
 		return qlog.NewConnectionTracer(f, p, connID)
 	} else {

--- a/pkg/netceptor/conn.go
+++ b/pkg/netceptor/conn.go
@@ -12,6 +12,7 @@ import (
 	"math/big"
 	"net"
 	"os"
+	"path"
 	"sync"
 	"time"
 
@@ -159,7 +160,8 @@ func (s *Netceptor) tracer(ctx context.Context, p logging.Perspective, connID qu
 			role = "client"
 		}
 		filename := fmt.Sprintf("log_%x_%s.qlog", connID, role)
-		f, err := os.Create(qlogPath + filename)
+		fullPath := path.Join(qlogPath, filename)
+		f, err := os.Create(fullPath)
 		if err != nil {
 			s.Logger.Debug("failed to create qlog file at path: %s", qlogPath)
 

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -1,10 +1,12 @@
 package netceptor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -895,6 +897,8 @@ func TestTracerDoesNotReturnsNewConnectionTracer(t *testing.T) {
 	}
 }
 
+// TestTracerCreatesCorrectFilePath tests the Netceptor.tracer() function that sets up
+// QUIC tracing does not depend on the QLOGDIR having a trailing slash character.
 func TestTracerCreatesCorrectFilePath(t *testing.T) {
 	t.Parallel()
 
@@ -930,6 +934,73 @@ func TestTracerCreatesCorrectFilePath(t *testing.T) {
 				_ = os.Remove(expectedFilename)
 			}
 		})
+	}
+}
+
+// TestTracerCreatesNonEmptyFiles tests that qlog files are correctly written to
+// when QUIC tracing is enabled.
+func TestTracerCreatesNonEmptyFiles(t *testing.T) {
+	// Make temporary directory to hold qlog files
+	qlogDirectory, err := os.MkdirTemp("", "receptor-qlogs-*")
+	if err != nil {
+		t.Fatalf("Error creating temp directory: %v", err)
+	}
+	defer func() {
+		err := os.RemoveAll(qlogDirectory)
+		if err != nil {
+			t.Errorf("Error removing temp directory '%s': %v", qlogDirectory, err)
+		}
+	}()
+
+	// Set QLOGDIR environment variable to enable tracing
+	os.Setenv("QLOGDIR", qlogDirectory)
+	defer func() {
+		os.Unsetenv("QLOGDIR")
+	}()
+
+	// Capture Go's log output because quic-go calls log.Printf() when it logs the
+	// "exporting qlog failed" error message
+	var logBuffer bytes.Buffer
+	log.SetOutput(&logBuffer)
+	defer func() {
+		log.SetOutput(os.Stderr)
+	}()
+
+	// Create a netceptor instance and attempt to dial a service that does not exist
+	node1 := New(context.Background(), "node1")
+
+	conn, _ := node1.Dial("node1", "testsvc", nil)
+	if conn != nil {
+		conn.Close()
+	}
+
+	node1.Shutdown()
+
+	// Verify qlog trace files exist in the temp directory
+	foundAtLeastOneQlogFile := false
+	err = filepath.Walk(qlogDirectory, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		if info.Size() <= 0 {
+			foundAtLeastOneQlogFile = true
+			return fmt.Errorf("QLog trace file was empty: %s", path)
+		}
+		foundAtLeastOneQlogFile = true
+		return nil
+	})
+	if err != nil {
+		t.Errorf("Error verifying qlog trace files: %v", err)
+	}
+	if !foundAtLeastOneQlogFile {
+		t.Error("Did not find any trace files in QLOGDIR")
+	}
+
+	// Verify the "exporting qlog failed ... file already closed" error was not logged
+	logs := strings.Split(logBuffer.String(), "\n")
+	logCapture := &logCapture{messages: logs}
+	if checkLogForMessage(logCapture, "exporting qlog failed", "file already closed") {
+		t.Error("Node logs contained error about qlog file already closed")
 	}
 }
 

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -904,7 +904,7 @@ func TestTracerCreatesCorrectFilePath(t *testing.T) {
 
 	testNetcepter := New(context.Background(), "node1")
 	clientLoggingPerspective := logging.PerspectiveClient
-	connId := quic.ConnectionIDFromBytes([]byte{})
+	connID := quic.ConnectionIDFromBytes([]byte{})
 	expectedFilename := "/tmp/log_28656d70747929_client.qlog"
 
 	tests := []struct {
@@ -923,8 +923,9 @@ func TestTracerCreatesCorrectFilePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			os.Setenv("QLOGDIR", tt.qlogDirectory)
-			tracer := testNetcepter.tracer(testNetcepter.context, clientLoggingPerspective, connId)
+			tracer := testNetcepter.tracer(testNetcepter.context, clientLoggingPerspective, connID)
 			defer tracer.Close()
 
 			_, err := os.Stat(expectedFilename)
@@ -984,9 +985,11 @@ func TestTracerCreatesNonEmptyFiles(t *testing.T) {
 		}
 		if info.Size() <= 0 {
 			foundAtLeastOneQlogFile = true
+
 			return fmt.Errorf("QLog trace file was empty: %s", path)
 		}
 		foundAtLeastOneQlogFile = true
+
 		return nil
 	})
 	if err != nil {

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -895,6 +895,44 @@ func TestTracerDoesNotReturnsNewConnectionTracer(t *testing.T) {
 	}
 }
 
+func TestTracerCreatesCorrectFilePath(t *testing.T) {
+	t.Parallel()
+
+	testNetcepter := New(context.Background(), "node1")
+	clientLoggingPerspective := logging.PerspectiveClient
+	connId := quic.ConnectionIDFromBytes([]byte{})
+	expectedFilename := "/tmp/log_28656d70747929_client.qlog"
+
+	tests := []struct {
+		name          string
+		qlogDirectory string
+	}{
+		{
+			name:          "QLOGDIR without trailing slash character",
+			qlogDirectory: "/tmp",
+		},
+		{
+			name:          "QLOGDIR with trailing slash character",
+			qlogDirectory: "/tmp/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Setenv("QLOGDIR", tt.qlogDirectory)
+			tracer := testNetcepter.tracer(testNetcepter.context, clientLoggingPerspective, connId)
+			defer tracer.Close()
+
+			_, err := os.Stat(expectedFilename)
+			if os.IsNotExist(err) {
+				t.Errorf("tracer should create file but did not exist. Expected: %s, Got: %v", expectedFilename, err)
+			} else {
+				_ = os.Remove(expectedFilename)
+			}
+		})
+	}
+}
+
 // TestRunProtocolExistingConnWithCanceledContext tests the condition in runProtocol
 // where an existing connection has a canceled context by calling the real runProtocol function.
 func TestRunProtocolExistingConnWithCanceledContext(t *testing.T) {


### PR DESCRIPTION
This fixes QLOG tracing in two ways:

1. `path.Join()` is used to construct the qlog file path.
2. Fixed a bug where the qlog tracer's writer instance was closed prematurely resulting in empty `.qlog` files.

Fixes AAP-43793