### PR TITLE
Fix: Prevent race condition in job status updates

### DIFF
--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -1155,8 +1155,15 @@ func (kw *KubeUnit) RunWorkUsingLogger() {
 	}
 
 	// only transition from WorkStateRunning to WorkStateSucceeded if WorkStateFailed is set we do not override
-	if kw.GetContext().Err() != context.Canceled && kw.Status().State == WorkStateRunning {
-		kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", stdout.Size())
+	if kw.GetContext().Err() != context.Canceled {
+		kw.UpdateFullStatus(func(status *StatusFileData) {
+			// Atomically check and update within single lock to prevent race condition
+			if status.State == WorkStateRunning {
+				status.State = WorkStateSucceeded
+				status.Detail = "Finished"
+				status.StdoutSize = stdout.Size()
+			}
+		})
 	}
 }
 

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -566,6 +566,30 @@ func (e *errorReadCloser) Close() error {
 	return nil
 }
 
+// errorStreamExecutor is used to simulate stdin streaming errors in tests.
+// This helps reproduce the race condition where the stdin goroutine sets
+// WorkStateFailed, but the main thread's status check sees stale state.
+type errorStreamExecutor struct {
+	returnErrorAfter int
+	callCount        int
+}
+
+func (e *errorStreamExecutor) Stream(options remotecommand.StreamOptions) error {
+	return e.StreamWithContext(context.Background(), options)
+}
+
+func (e *errorStreamExecutor) StreamWithContext(ctx context.Context, options remotecommand.StreamOptions) error {
+	e.callCount++
+	if e.callCount > e.returnErrorAfter {
+		// Return an error to trigger line 1100 in kubernetes.go:
+		// stdinErr = err
+		// And then line 1108:
+		// kw.UpdateBasicStatus(WorkStateFailed, errMsg, stdout.Size())
+		return errors.New("simulated stdin stream error")
+	}
+	return nil
+}
+
 func TestKubeLoggingWithReconnect(t *testing.T) {
 	// Set fast timeout and retry values for testing
 	os.Setenv("RECEPTOR_KUBE_TIMEOUT_START", "10ms")
@@ -5552,6 +5576,118 @@ func TestKubeUnit_RunWorkUsingTCP_ExtensiveErrorPaths(t *testing.T) {
 
 			t.Logf("Successfully completed test: %s", tc.name)
 		})
+	}
+}
+
+// TestKubeUnit_StatusCheckRaceCondition reproduces a TOCTOU (Time-Of-Check to Time-Of-Use)
+// race condition in RunWorkUsingLogger where a job can have both an error state and a
+// "Finished" status.
+//
+// The race occurs in the final status check and update logic:
+//   CHECK: if kw.Status().State == WorkStateRunning
+//   UPDATE: kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", ...)
+//
+// The race sequence:
+// 1. Goroutine A: Sets status to WorkStateFailed due to an error
+// 2. Main thread: Reads Status().State, sees WorkStateRunning (stale read)
+// 3. Main thread: Calls UpdateBasicStatus(WorkStateSucceeded, "Finished"), overwriting Failed
+//
+// This results in a job that has both error and finished states, which is incorrect.
+func TestKubeUnit_StatusCheckRaceCondition(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockBaseWorkUnit := mock_workceptor.NewMockBaseWorkUnitForWorkUnit(ctrl)
+
+	// Track all UpdateBasicStatus calls
+	var statusUpdates []struct {
+		state  int
+		detail string
+	}
+	var mu sync.Mutex
+
+	// Mock Status() to ALWAYS return WorkStateRunning
+	// This simulates the stale read in the race condition
+	mockBaseWorkUnit.EXPECT().Status().DoAndReturn(func() *workceptor.StatusFileData {
+		return &workceptor.StatusFileData{
+			State:     workceptor.WorkStateRunning, // Always Running!
+			ExtraData: &workceptor.KubeExtraData{},
+		}
+	}).AnyTimes()
+
+	// Capture UpdateBasicStatus calls
+	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(state int, detail string, size int64) {
+			mu.Lock()
+			defer mu.Unlock()
+			statusUpdates = append(statusUpdates, struct {
+				state  int
+				detail string
+			}{state, detail})
+			t.Logf("UpdateBasicStatus called: state=%s, detail=%q",
+				getStateName(state), detail)
+		}).AnyTimes()
+
+	// Simulate the race:
+	// 1. Goroutine A sets WorkStateFailed
+	// 2. Main thread checks Status().State - sees Running (stale)
+	// 3. Main thread calls UpdateBasicStatus(Succeeded, "Finished")
+
+	// Simulating goroutine A setting Failed
+	mockBaseWorkUnit.UpdateBasicStatus(workceptor.WorkStateFailed, "Error with pod's stdout: simulated error", 0)
+
+	// Simulating the check-then-update pattern in the main thread
+	// This mimics what happens after waiting for stdin/stdout goroutines
+	ctx := context.Background()
+	if ctx.Err() != context.Canceled && mockBaseWorkUnit.Status().State == workceptor.WorkStateRunning {
+		mockBaseWorkUnit.UpdateBasicStatus(workceptor.WorkStateSucceeded, "Finished", 100)
+	}
+
+	// Analyze the results
+	mu.Lock()
+	defer mu.Unlock()
+
+	t.Logf("\n=== STATUS UPDATE SEQUENCE ===")
+	for i, update := range statusUpdates {
+		t.Logf("  %d. State=%s, Detail=%q", i+1, getStateName(update.state), update.detail)
+	}
+
+	if len(statusUpdates) != 2 {
+		t.Fatalf("Expected 2 status updates, got %d", len(statusUpdates))
+	}
+
+	if statusUpdates[0].state != workceptor.WorkStateFailed {
+		t.Errorf("First update should be WorkStateFailed, got %s", getStateName(statusUpdates[0].state))
+	}
+
+	if statusUpdates[1].state != workceptor.WorkStateSucceeded || statusUpdates[1].detail != "Finished" {
+		t.Errorf("Second update should be WorkStateSucceeded/'Finished', got %s/%q",
+			getStateName(statusUpdates[1].state), statusUpdates[1].detail)
+	}
+
+	// THE BUG IS PROVEN:
+	t.Errorf("RACE CONDITION REPRODUCED: WorkStateFailed was overwritten by WorkStateSucceeded/'Finished'")
+	t.Errorf("\nRoot cause: The status check and update in RunWorkUsingLogger are not atomic:")
+	t.Errorf("  CHECK: if kw.Status().State == WorkStateRunning  // Stale read possible")
+	t.Errorf("  UPDATE: kw.UpdateBasicStatus(WorkStateSucceeded, \"Finished\", ...)  // Overwrites Failed!")
+	t.Errorf("\nFix: Use UpdateFullStatus with callback for atomic check-and-update within single lock")
+}
+
+// Helper function to convert state int to string for logging
+func getStateName(state int) string {
+	switch state {
+	case workceptor.WorkStatePending:
+		return "Pending"
+	case workceptor.WorkStateRunning:
+		return "Running"
+	case workceptor.WorkStateSucceeded:
+		return "Succeeded"
+	case workceptor.WorkStateFailed:
+		return "Failed"
+	case workceptor.WorkStateCanceled:
+		return "Canceled"
+	default:
+		return fmt.Sprintf("Unknown(%d)", state)
 	}
 }
 

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -5571,18 +5571,22 @@ func TestKubeUnit_RunWorkUsingTCP_ExtensiveErrorPaths(t *testing.T) {
 // 3. Without atomic check-and-update, Failed state gets overwritten by Succeeded
 //
 // The BROKEN code pattern (before fix):
-//   if kw.Status().State == WorkStateRunning {
-//       kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", ...)
-//   }
+//
+//	if kw.Status().State == WorkStateRunning {
+//	    kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", ...)
+//	}
+//
 // This has a TOCTOU race: Status() and UpdateBasicStatus() are separate operations.
 //
 // The FIXED code pattern (after fix in kubernetes.go:1158-1167):
-//   kw.UpdateFullStatus(func(status *StatusFileData) {
-//       if status.State == WorkStateRunning {
-//           status.State = WorkStateSucceeded
-//           ...
-//       }
-//   })
+//
+//	kw.UpdateFullStatus(func(status *StatusFileData) {
+//	    if status.State == WorkStateRunning {
+//	        status.State = WorkStateSucceeded
+//	        ...
+//	    }
+//	})
+//
 // This is atomic: check and update happen within a single lock acquisition.
 //
 // This test simulates the race by having UpdateFullStatus inject a Failed state
@@ -5641,6 +5645,7 @@ func TestKubeUnit_StatusTransitionToFinished(t *testing.T) {
 	mockBaseWorkUnit.EXPECT().Status().DoAndReturn(func() *workceptor.StatusFileData {
 		statusLock.RLock()
 		defer statusLock.RUnlock()
+
 		return statusData
 	}).AnyTimes()
 

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -4571,7 +4571,14 @@ func TestKubeUnit_RunWorkUsingLogger_ExitCode1SetsFinished(t *testing.T) {
 			mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
 			mockBaseWorkUnit.EXPECT().UpdateBasicStatus(workceptor.WorkStateRunning, gomock.Any(), gomock.Any())
 			mockBaseWorkUnit.EXPECT().Init(w, "", "", workceptor.FileSystem{})
-			mockBaseWorkUnit.EXPECT().UpdateBasicStatus(workceptor.WorkStateSucceeded, gomock.Any(), gomock.Any())
+			mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).Do(func(updateFunc func(*workceptor.StatusFileData)) {
+				// Simulate the atomic check-and-update in UpdateFullStatus
+				status := &workceptor.StatusFileData{
+					State:     workceptor.WorkStateRunning,
+					ExtraData: &workceptor.KubeExtraData{},
+				}
+				updateFunc(status)
+			})
 
 			err = os.MkdirAll(testUnitDir, 0o700)
 			if err != nil {
@@ -5579,98 +5586,112 @@ func TestKubeUnit_RunWorkUsingTCP_ExtensiveErrorPaths(t *testing.T) {
 	}
 }
 
-// TestKubeUnit_StatusCheckRaceCondition reproduces a TOCTOU (Time-Of-Check to Time-Of-Use)
-// race condition in RunWorkUsingLogger where a job can have both an error state and a
-// "Finished" status.
+// TestKubeUnit_StatusTransitionToFinished verifies that the final status transition
+// to "Finished" does not overwrite a failed state that was set by a concurrent operation.
 //
-// The race occurs in the final status check and update logic:
-//   CHECK: if kw.Status().State == WorkStateRunning
-//   UPDATE: kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", ...)
+// This test prevents regression of a race condition where:
+// 1. A goroutine sets status to WorkStateFailed
+// 2. Main thread attempts to transition to WorkStateSucceeded/"Finished"
+// 3. The failed state must be preserved (not overwritten)
 //
-// The race sequence:
-// 1. Goroutine A: Sets status to WorkStateFailed due to an error
-// 2. Main thread: Reads Status().State, sees WorkStateRunning (stale read)
-// 3. Main thread: Calls UpdateBasicStatus(WorkStateSucceeded, "Finished"), overwriting Failed
-//
-// This results in a job that has both error and finished states, which is incorrect.
-func TestKubeUnit_StatusCheckRaceCondition(t *testing.T) {
+// The fix uses UpdateFullStatus to atomically check and update the status within
+// a single lock acquisition, preventing the race.
+func TestKubeUnit_StatusTransitionToFinished(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
 	mockBaseWorkUnit := mock_workceptor.NewMockBaseWorkUnitForWorkUnit(ctrl)
 
-	// Track all UpdateBasicStatus calls
-	var statusUpdates []struct {
-		state  int
-		detail string
-	}
-	var mu sync.Mutex
+	// Track the actual status state and transitions
+	currentState := workceptor.WorkStateRunning
+	var statusTransitions []string
+	var mu sync.RWMutex
 
-	// Mock Status() to ALWAYS return WorkStateRunning
-	// This simulates the stale read in the race condition
-	mockBaseWorkUnit.EXPECT().Status().DoAndReturn(func() *workceptor.StatusFileData {
-		return &workceptor.StatusFileData{
-			State:     workceptor.WorkStateRunning, // Always Running!
-			ExtraData: &workceptor.KubeExtraData{},
-		}
-	}).AnyTimes()
+	// Mock UpdateFullStatus to simulate atomic check-and-update behavior
+	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).DoAndReturn(
+		func(updateFunc func(*workceptor.StatusFileData)) {
+			mu.Lock()
+			defer mu.Unlock()
 
-	// Capture UpdateBasicStatus calls
+			status := &workceptor.StatusFileData{
+				State:     currentState,
+				ExtraData: &workceptor.KubeExtraData{},
+			}
+			oldState := currentState
+
+			// Execute the update function atomically within the lock
+			updateFunc(status)
+
+			if status.State != oldState {
+				currentState = status.State
+				statusTransitions = append(statusTransitions,
+					fmt.Sprintf("UpdateFullStatus: %s → %s", getStateName(oldState), getStateName(status.State)))
+			} else {
+				statusTransitions = append(statusTransitions,
+					fmt.Sprintf("UpdateFullStatus: Check failed, kept %s", getStateName(oldState)))
+			}
+		}).AnyTimes()
+
 	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(state int, detail string, size int64) {
 			mu.Lock()
 			defer mu.Unlock()
-			statusUpdates = append(statusUpdates, struct {
-				state  int
-				detail string
-			}{state, detail})
-			t.Logf("UpdateBasicStatus called: state=%s, detail=%q",
-				getStateName(state), detail)
+			oldState := currentState
+			currentState = state
+			statusTransitions = append(statusTransitions,
+				fmt.Sprintf("UpdateBasicStatus: %s → %s (%s)", getStateName(oldState), getStateName(state), detail))
 		}).AnyTimes()
 
-	// Simulate the race:
-	// 1. Goroutine A sets WorkStateFailed
-	// 2. Main thread checks Status().State - sees Running (stale)
-	// 3. Main thread calls UpdateBasicStatus(Succeeded, "Finished")
-
-	// Simulating goroutine A setting Failed
+	// Simulate the scenario:
+	// 1. A goroutine sets the status to Failed
 	mockBaseWorkUnit.UpdateBasicStatus(workceptor.WorkStateFailed, "Error with pod's stdout: simulated error", 0)
 
-	// Simulating the check-then-update pattern in the main thread
-	// This mimics what happens after waiting for stdin/stdout goroutines
+	// 2. Main thread attempts to transition to Finished using atomic check-and-update
+	//    This should NOT overwrite the Failed state
 	ctx := context.Background()
-	if ctx.Err() != context.Canceled && mockBaseWorkUnit.Status().State == workceptor.WorkStateRunning {
-		mockBaseWorkUnit.UpdateBasicStatus(workceptor.WorkStateSucceeded, "Finished", 100)
+	if ctx.Err() != context.Canceled {
+		mockBaseWorkUnit.UpdateFullStatus(func(status *workceptor.StatusFileData) {
+			// Only update if still in Running state (atomic check)
+			if status.State == workceptor.WorkStateRunning {
+				status.State = workceptor.WorkStateSucceeded
+				status.Detail = "Finished"
+				status.StdoutSize = 100
+			}
+		})
 	}
 
-	// Analyze the results
-	mu.Lock()
-	defer mu.Unlock()
+	// Verify the status transitions
+	mu.RLock()
+	defer mu.RUnlock()
 
-	t.Logf("\n=== STATUS UPDATE SEQUENCE ===")
-	for i, update := range statusUpdates {
-		t.Logf("  %d. State=%s, Detail=%q", i+1, getStateName(update.state), update.detail)
+	t.Logf("Status transitions:")
+	for i, transition := range statusTransitions {
+		t.Logf("  %d. %s", i+1, transition)
 	}
 
-	if len(statusUpdates) != 2 {
-		t.Fatalf("Expected 2 status updates, got %d", len(statusUpdates))
+	// Assert that Failed state was preserved
+	if currentState != workceptor.WorkStateFailed {
+		t.Errorf("Failed state was overwritten! Expected WorkStateFailed, got %s", getStateName(currentState))
+		t.Errorf("This indicates a regression of the race condition fix")
 	}
 
-	if statusUpdates[0].state != workceptor.WorkStateFailed {
-		t.Errorf("First update should be WorkStateFailed, got %s", getStateName(statusUpdates[0].state))
+	// Assert that the atomic check prevented the transition
+	if len(statusTransitions) != 2 {
+		t.Errorf("Expected 2 transitions, got %d", len(statusTransitions))
 	}
 
-	if statusUpdates[1].state != workceptor.WorkStateSucceeded || statusUpdates[1].detail != "Finished" {
-		t.Errorf("Second update should be WorkStateSucceeded/'Finished', got %s/%q",
-			getStateName(statusUpdates[1].state), statusUpdates[1].detail)
+	expectedTransitions := []string{
+		"UpdateBasicStatus: Running → Failed (Error with pod's stdout: simulated error)",
+		"UpdateFullStatus: Check failed, kept Failed",
 	}
 
-	// THE BUG IS PROVEN:
-	t.Errorf("RACE CONDITION REPRODUCED: WorkStateFailed was overwritten by WorkStateSucceeded/'Finished'")
-	t.Errorf("\nRoot cause: The status check and update in RunWorkUsingLogger are not atomic:")
-	t.Errorf("  CHECK: if kw.Status().State == WorkStateRunning  // Stale read possible")
-	t.Errorf("  UPDATE: kw.UpdateBasicStatus(WorkStateSucceeded, \"Finished\", ...)  // Overwrites Failed!")
-	t.Errorf("\nFix: Use UpdateFullStatus with callback for atomic check-and-update within single lock")
+	for i, expected := range expectedTransitions {
+		if i >= len(statusTransitions) {
+			t.Errorf("Missing transition %d: expected %q", i+1, expected)
+		} else if statusTransitions[i] != expected {
+			t.Errorf("Transition %d mismatch:\n  expected: %q\n  got:      %q", i+1, expected, statusTransitions[i])
+		}
+	}
 }
 
 // Helper function to convert state int to string for logging

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -5670,7 +5670,7 @@ func TestKubeUnit_StatusTransitionToFinished(t *testing.T) {
 	}
 }
 
-// Helper function to convert state int to string for logging
+// Helper function to convert state int to string for logging.
 func getStateName(state int) string {
 	switch state {
 	case workceptor.WorkStatePending:

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -566,30 +566,6 @@ func (e *errorReadCloser) Close() error {
 	return nil
 }
 
-// errorStreamExecutor is used to simulate stdin streaming errors in tests.
-// This helps reproduce the race condition where the stdin goroutine sets
-// WorkStateFailed, but the main thread's status check sees stale state.
-type errorStreamExecutor struct {
-	returnErrorAfter int
-	callCount        int
-}
-
-func (e *errorStreamExecutor) Stream(options remotecommand.StreamOptions) error {
-	return e.StreamWithContext(context.Background(), options)
-}
-
-func (e *errorStreamExecutor) StreamWithContext(ctx context.Context, options remotecommand.StreamOptions) error {
-	e.callCount++
-	if e.callCount > e.returnErrorAfter {
-		// Return an error to trigger line 1100 in kubernetes.go:
-		// stdinErr = err
-		// And then line 1108:
-		// kw.UpdateBasicStatus(WorkStateFailed, errMsg, stdout.Size())
-		return errors.New("simulated stdin stream error")
-	}
-	return nil
-}
-
 func TestKubeLoggingWithReconnect(t *testing.T) {
 	// Set fast timeout and retry values for testing
 	os.Setenv("RECEPTOR_KUBE_TIMEOUT_START", "10ms")

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -5562,112 +5562,202 @@ func TestKubeUnit_RunWorkUsingTCP_ExtensiveErrorPaths(t *testing.T) {
 	}
 }
 
-// TestKubeUnit_StatusTransitionToFinished verifies that the final status transition
-// to "Finished" does not overwrite a failed state that was set by a concurrent operation.
+// TestKubeUnit_StatusTransitionToFinished is an integration test that verifies the fix
+// for a race condition where a failed state could be overwritten by "Finished" status.
 //
-// This test prevents regression of a race condition where:
-// 1. A goroutine sets status to WorkStateFailed
-// 2. Main thread attempts to transition to WorkStateSucceeded/"Finished"
-// 3. The failed state must be preserved (not overwritten)
+// Race condition scenario:
+// 1. A goroutine (e.g., stdout handler) encounters an error and sets WorkStateFailed
+// 2. Main thread finishes waiting for goroutines and attempts to set "Finished"
+// 3. Without atomic check-and-update, Failed state gets overwritten by Succeeded
 //
-// The fix uses UpdateFullStatus to atomically check and update the status within
-// a single lock acquisition, preventing the race.
+// The BROKEN code pattern (before fix):
+//   if kw.Status().State == WorkStateRunning {
+//       kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", ...)
+//   }
+// This has a TOCTOU race: Status() and UpdateBasicStatus() are separate operations.
+//
+// The FIXED code pattern (after fix in kubernetes.go:1158-1167):
+//   kw.UpdateFullStatus(func(status *StatusFileData) {
+//       if status.State == WorkStateRunning {
+//           status.State = WorkStateSucceeded
+//           ...
+//       }
+//   })
+// This is atomic: check and update happen within a single lock acquisition.
+//
+// This test simulates the race by having UpdateFullStatus inject a Failed state
+// right before the final transition check, then verifies Failed is preserved.
 func TestKubeUnit_StatusTransitionToFinished(t *testing.T) {
+	const (
+		testNamespace = "default"
+		testPodName   = "race-test-pod"
+		testUnitDir   = "/tmp/race-test-pod/"
+	)
+
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	os.Setenv("RECEPTOR_KUBE_SUPPORT_RECONNECT", "enabled")
+	defer os.Unsetenv("RECEPTOR_KUBE_SUPPORT_RECONNECT")
+
 	mockBaseWorkUnit := mock_workceptor.NewMockBaseWorkUnitForWorkUnit(ctrl)
+	mockNetceptor := mock_workceptor.NewMockNetceptorForWorkceptor(ctrl)
+	mockKubeAPI := mock_workceptor.NewMockKubeAPIer(ctrl)
 
-	// Track the actual status state and transitions
-	currentState := workceptor.WorkStateRunning
-	var statusTransitions []string
-	var mu sync.RWMutex
+	mockNetceptor.EXPECT().NodeID().Return("test-node").AnyTimes()
+	mockNetceptor.EXPECT().GetLogger().Return(logger.NewReceptorLogger("test")).AnyTimes()
 
-	// Mock UpdateFullStatus to simulate atomic check-and-update behavior
-	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).DoAndReturn(
-		func(updateFunc func(*workceptor.StatusFileData)) {
-			mu.Lock()
-			defer mu.Unlock()
+	ctx := context.Background()
+	w, err := workceptor.New(ctx, mockNetceptor, "/tmp")
+	if err != nil {
+		t.Fatalf("Error creating Workceptor: %v", err)
+	}
 
-			status := &workceptor.StatusFileData{
-				State:     currentState,
-				ExtraData: &workceptor.KubeExtraData{},
-			}
-			oldState := currentState
+	// Track status updates to verify the race condition fix
+	statusLock := &sync.RWMutex{}
+	statusData := &workceptor.StatusFileData{
+		State:     workceptor.WorkStateRunning,
+		ExtraData: &workceptor.KubeExtraData{},
+	}
+	statusCopy := workceptor.StatusFileData{
+		ExtraData: &workceptor.KubeExtraData{
+			KubeNamespace: testNamespace,
+			PodName:       testPodName,
+		},
+	}
 
-			// Execute the update function atomically within the lock
-			updateFunc(status)
+	updateFullStatusCalled := false
+	finalState := workceptor.WorkStateRunning
 
-			if status.State != oldState {
-				currentState = status.State
-				statusTransitions = append(statusTransitions,
-					fmt.Sprintf("UpdateFullStatus: %s → %s", getStateName(oldState), getStateName(status.State)))
-			} else {
-				statusTransitions = append(statusTransitions,
-					fmt.Sprintf("UpdateFullStatus: Check failed, kept %s", getStateName(oldState)))
-			}
-		}).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetStatusLock().Return(statusLock).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetStatusWithoutExtraData().Return(statusData).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetStatusCopy().Return(statusCopy).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetContext().Return(context.Background()).AnyTimes()
+	mockBaseWorkUnit.EXPECT().UnitDir().Return(testUnitDir).AnyTimes()
+	mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
+	mockBaseWorkUnit.EXPECT().Init(w, "", "", workceptor.FileSystem{}).AnyTimes()
 
+	// Mock Status() for the BROKEN code pattern
+	mockBaseWorkUnit.EXPECT().Status().DoAndReturn(func() *workceptor.StatusFileData {
+		statusLock.RLock()
+		defer statusLock.RUnlock()
+		return statusData
+	}).AnyTimes()
+
+	// Mock UpdateBasicStatus for both Running state and any final state calls
 	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(state int, detail string, size int64) {
-			mu.Lock()
-			defer mu.Unlock()
-			oldState := currentState
-			currentState = state
-			statusTransitions = append(statusTransitions,
-				fmt.Sprintf("UpdateBasicStatus: %s → %s (%s)", getStateName(oldState), getStateName(state), detail))
+			statusLock.Lock()
+			defer statusLock.Unlock()
+			statusData.State = state
+			statusData.Detail = detail
+			statusData.StdoutSize = size
+			finalState = state
+			t.Logf("UpdateBasicStatus: State = %s, Detail = %q", getStateName(state), detail)
 		}).AnyTimes()
 
-	// Simulate the scenario:
-	// 1. A goroutine sets the status to Failed
-	mockBaseWorkUnit.UpdateBasicStatus(workceptor.WorkStateFailed, "Error with pod's stdout: simulated error", 0)
+	// Mock UpdateFullStatus to simulate the race and verify the fix
+	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).DoAndReturn(
+		func(updateFunc func(*workceptor.StatusFileData)) {
+			updateFullStatusCalled = true
 
-	// 2. Main thread attempts to transition to Finished using atomic check-and-update
-	//    This should NOT overwrite the Failed state
-	ctx := context.Background()
-	if ctx.Err() != context.Canceled {
-		mockBaseWorkUnit.UpdateFullStatus(func(status *workceptor.StatusFileData) {
-			// Only update if still in Running state (atomic check)
-			if status.State == workceptor.WorkStateRunning {
-				status.State = workceptor.WorkStateSucceeded
-				status.Detail = "Finished"
-				status.StdoutSize = 100
-			}
-		})
+			// Simulate a concurrent goroutine setting Failed state
+			// This happens BEFORE the callback executes, simulating the race
+			statusData.State = workceptor.WorkStateFailed
+			statusData.Detail = "Error with pod's stdout: simulated error"
+
+			// Now execute the update function with Failed state
+			// The FIXED code will check status.State and see Failed, not Running
+			// So it won't overwrite with Succeeded
+			updateFunc(statusData)
+
+			finalState = statusData.State
+			t.Logf("UpdateFullStatus: Final state = %s, Detail = %q",
+				getStateName(statusData.State), statusData.Detail)
+		}).AnyTimes()
+
+	// Setup test directory
+	err = os.MkdirAll(testUnitDir, 0o700)
+	if err != nil {
+		t.Fatalf("Failed to create unit dir: %v", err)
+	}
+	defer os.RemoveAll(testUnitDir)
+
+	kubeConfig := workceptor.KubeWorkerCfg{
+		AuthMethod:   "incluster",
+		StreamMethod: "logger",
 	}
 
-	// Verify the status transitions
-	mu.RLock()
-	defer mu.RUnlock()
+	kubeUnit := kubeConfig.NewkubeWorker(mockBaseWorkUnit, w, "", "", mockKubeAPI).(*workceptor.KubeUnit)
 
-	t.Logf("Status transitions:")
-	for i, transition := range statusTransitions {
-		t.Logf("  %d. %s", i+1, transition)
+	// Create a pod that has successfully completed
+	existingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testPodName,
+			Namespace: testNamespace,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodSucceeded,
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: workceptor.WorkerContainerName,
+					State: corev1.ContainerState{
+						Terminated: &corev1.ContainerStateTerminated{
+							ExitCode: 0,
+							Reason:   "Completed",
+						},
+					},
+				},
+			},
+		},
 	}
 
-	// Assert that Failed state was preserved
-	if currentState != workceptor.WorkStateFailed {
-		t.Errorf("Failed state was overwritten! Expected WorkStateFailed, got %s", getStateName(currentState))
-		t.Errorf("This indicates a regression of the race condition fix")
+	fakeClient := fake.NewSimpleClientset(existingPod)
+	kubeUnit.SetClientset(fakeClient)
+
+	mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), testNamespace, testPodName, gomock.Any()).Return(existingPod, nil).AnyTimes()
+
+	req := fakerest.RESTClient{
+		Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("")),
+			}, nil
+		}),
+		NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+	}
+	mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+
+	// Create stdout writer
+	_, stdoutErr := workceptor.NewStdoutWriter(workceptor.FileSystem{}, testUnitDir)
+	if stdoutErr != nil {
+		t.Fatalf("Failed to create stdout writer: %v", stdoutErr)
 	}
 
-	// Assert that the atomic check prevented the transition
-	if len(statusTransitions) != 2 {
-		t.Errorf("Expected 2 transitions, got %d", len(statusTransitions))
+	// Run the actual production code
+	kubeUnit.RunWorkUsingLogger()
+
+	// CRITICAL ASSERTION: Verify UpdateFullStatus was called
+	// This ensures the fix in kubernetes.go:1158-1167 is being used
+	if !updateFullStatusCalled {
+		t.Errorf("CRITICAL: UpdateFullStatus was NOT called for the final status transition!")
+		t.Errorf("This indicates kubernetes.go was reverted to the broken pattern:")
+		t.Errorf("  BROKEN: if kw.Status().State == WorkStateRunning { kw.UpdateBasicStatus(Succeeded, ...) }")
+		t.Errorf("  FIXED:  kw.UpdateFullStatus(func(s) { if s.State == WorkStateRunning { s.State = Succeeded } })")
+		t.Fatalf("The broken pattern causes a TOCTOU race where Failed state can be overwritten by Finished")
 	}
 
-	expectedTransitions := []string{
-		"UpdateBasicStatus: Running → Failed (Error with pod's stdout: simulated error)",
-		"UpdateFullStatus: Check failed, kept Failed",
+	// Assert: Failed state should be preserved (not overwritten)
+	// With the FIXED code using UpdateFullStatus, the atomic check will see Failed state
+	// and will NOT overwrite it with Succeeded
+	if finalState != workceptor.WorkStateFailed {
+		t.Errorf("RACE CONDITION DETECTED: Failed state was overwritten!")
+		t.Errorf("Expected final state WorkStateFailed, got %s", getStateName(finalState))
+		t.Errorf("This means the atomic check-and-update in UpdateFullStatus is not working correctly")
+		t.Fatalf("The fix for the race condition has regressed")
 	}
 
-	for i, expected := range expectedTransitions {
-		if i >= len(statusTransitions) {
-			t.Errorf("Missing transition %d: expected %q", i+1, expected)
-		} else if statusTransitions[i] != expected {
-			t.Errorf("Transition %d mismatch:\n  expected: %q\n  got:      %q", i+1, expected, statusTransitions[i])
-		}
-	}
+	t.Logf("SUCCESS: Race condition fix verified - Failed state was preserved")
 }
 
 // Helper function to convert state int to string for logging.


### PR DESCRIPTION
Fix: Prevent race condition in job status updates

  Problem:
  A race condition in RunWorkUsingLogger allowed a job's failed state to be overwritten with "Finished" status, resulting in jobs that appeared both errored and finished simultaneously.

  Root Cause:
  The final status transition used a non-atomic check-then-update pattern:
```go
  // CHECK (acquires and releases lock)
  if kw.Status().State == WorkStateRunning {
      // UPDATE (acquires and releases lock separately)
      kw.UpdateBasicStatus(WorkStateSucceeded, "Finished", stdout.Size())
  }
```

  This Time-Of-Check to Time-Of-Use (TOCTOU) race allowed:
  1. A concurrent goroutine to set status to WorkStateFailed
  2. The main thread to read stale Status().State (still sees Running)
  3. The main thread to overwrite with WorkStateSucceeded/"Finished"

  Fix:
  Changed to use UpdateFullStatus with a callback for atomic check-and-update within a single lock acquisition:

```go
  kw.UpdateFullStatus(func(status *StatusFileData) {
      // Atomically check and update within single lock
      if status.State == WorkStateRunning {
          status.State = WorkStateSucceeded
          status.Detail = "Finished"
          status.StdoutSize = stdout.Size()
      }
  })
```