### PR TITLE
Write kube error to stdoutErr when terminated container reason isn't completed or error

### DIFF
--- a/pkg/workceptor/command_test.go
+++ b/pkg/workceptor/command_test.go
@@ -115,11 +115,14 @@ func TestStart(t *testing.T) {
 
 	mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).Times(2)
 	mockNetceptor.EXPECT().GetLogger().Times(2)
-	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any())
+	// Expect two calls to UpdateBasicStatus:
+	// 1. First call from Start() with "Launching command runner"
+	// 2. Second call from runCommand() when cmd.Start() fails (receptor not in PATH)
+	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
 	statusExpectCalls(mockBaseWorkUnit)
 
 	mockBaseWorkUnit.EXPECT().UnitDir()
-	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any())
+	// When cmd.Start() fails, UpdateFullStatus and MonitorLocalStatus are not called
 	mockBaseWorkUnit.EXPECT().MonitorLocalStatus().AnyTimes()
 	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).AnyTimes()
 	wu.Start()

--- a/pkg/workceptor/command_test.go
+++ b/pkg/workceptor/command_test.go
@@ -115,14 +115,10 @@ func TestStart(t *testing.T) {
 
 	mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).Times(2)
 	mockNetceptor.EXPECT().GetLogger().Times(2)
-	// Expect two calls to UpdateBasicStatus:
-	// 1. First call from Start() with "Launching command runner"
-	// 2. Second call from runCommand() when cmd.Start() fails (receptor not in PATH)
-	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).Times(2)
+	mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
 	statusExpectCalls(mockBaseWorkUnit)
 
 	mockBaseWorkUnit.EXPECT().UnitDir()
-	// When cmd.Start() fails, UpdateFullStatus and MonitorLocalStatus are not called
 	mockBaseWorkUnit.EXPECT().MonitorLocalStatus().AnyTimes()
 	mockBaseWorkUnit.EXPECT().UpdateFullStatus(gomock.Any()).AnyTimes()
 	wu.Start()

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -540,6 +540,11 @@ mainLoop:
 							podName,
 							WorkerContainerName,
 							containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
+						*stdoutErr = fmt.Errorf("pod %s/%s terminated with exit code %d: %s",
+							podNamespace,
+							podName,
+							containerState.Terminated.ExitCode,
+							containerState.Terminated.Message)
 					}
 
 					// We need to check if last line has data

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -544,21 +544,20 @@ mainLoop:
 							WorkerContainerName,
 							containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
 						*stdoutErr = fmt.Errorf("pod %s/%s execution interrupted: reason=%s, exit=%d, msg=%s",
-              podNamespace,
-              podName,
-              reason,
-              containerState.Terminated.ExitCode,
-              containerState.Terminated.Message)
+							podNamespace,
+							podName,
+							reason,
+							containerState.Terminated.ExitCode,
+							containerState.Terminated.Message)
 					}
 
 					// Log completion (whether success or error)
 					kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s terminated with reason=%s, exit=%d",
-							podNamespace,
-							podName,
-							WorkerContainerName,
-							reason,
-							containerState.Terminated.ExitCode)
-
+						podNamespace,
+						podName,
+						WorkerContainerName,
+						reason,
+						containerState.Terminated.ExitCode)
 
 					// We need to check if last line has data
 					if line != "" {

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -538,7 +539,8 @@ mainLoop:
 						reason := containerState.Terminated.Reason
 						// Whitelist: "Completed" and "Error" mean the program ran to completion
 						// Everything else (OOMKilled, Evicted, etc.) means execution was interrupted
-						if reason != "Completed" && reason != "Error" {
+						allowedReasons := []string{"Completed", "Error"}
+						if !slices.Contains(allowedReasons, reason) {
 							kw.GetWorkceptor().nc.GetLogger().Warning("%s/%s: %s execution was interrupted, exit code: %d, terminated reason: %s and terminated message: %s",
 								podNamespace,
 								podName,

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -533,7 +533,7 @@ mainLoop:
 
 					return
 				case containerState.Terminated != nil:
-					
+
 					if containerState.Terminated.ExitCode != 0 {
 						reason := containerState.Terminated.Reason
 						// Whitelist: "Completed" and "Error" mean the program ran to completion
@@ -569,7 +569,6 @@ mainLoop:
 							podName,
 							WorkerContainerName)
 					}
-
 
 					// We need to check if last line has data
 					if line != "" {

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -539,6 +539,7 @@ mainLoop:
 						reason := containerState.Terminated.Reason
 						// Whitelist: "Completed" and "Error" mean the program ran to completion
 						// Everything else (OOMKilled, Evicted, etc.) means execution was interrupted
+						// Note: Reason field is not strictly defined in K8s API, these are observed conventions
 						allowedReasons := []string{"Completed", "Error"}
 						if !slices.Contains(allowedReasons, reason) {
 							kw.GetWorkceptor().nc.GetLogger().Warning("%s/%s: %s execution was interrupted, exit code: %d, terminated reason: %s and terminated message: %s",

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -533,31 +533,43 @@ mainLoop:
 
 					return
 				case containerState.Terminated != nil:
-					reason := containerState.Terminated.Reason
-
-					// Whitelist: "Completed" and "Error" mean the program ran to completion
-					// Everything else (OOMKilled, Evicted, etc.) means execution was interrupted
-					if reason != "Completed" && reason != "Error" {
-						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s has terminated, with nonzero exit code: %v, terminated reason: %v and terminated message: %v",
+					
+					if containerState.Terminated.ExitCode != 0 {
+						reason := containerState.Terminated.Reason
+						// Whitelist: "Completed" and "Error" mean the program ran to completion
+						// Everything else (OOMKilled, Evicted, etc.) means execution was interrupted
+						if reason != "Completed" && reason != "Error" {
+							kw.GetWorkceptor().nc.GetLogger().Warning("%s/%s: %s execution was interrupted, exit code: %d, terminated reason: %s and terminated message: %s",
+								podNamespace,
+								podName,
+								WorkerContainerName,
+								containerState.Terminated.ExitCode,
+								reason,
+								containerState.Terminated.Message)
+							*stdoutErr = fmt.Errorf("pod %s/%s execution interrupted: exit code: %d, terminated reason: %s, terminated message: %s",
+								podNamespace,
+								podName,
+								containerState.Terminated.ExitCode,
+								reason,
+								containerState.Terminated.Message)
+						} else {
+							// Log error completion
+							kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s completed with error, exit code: %d, terminated reason: %s, terminated message: %s",
+								podNamespace,
+								podName,
+								WorkerContainerName,
+								containerState.Terminated.ExitCode,
+								reason,
+								containerState.Terminated.Message)
+						}
+					} else {
+						// Log successful completion
+						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s completed successfully",
 							podNamespace,
 							podName,
-							WorkerContainerName,
-							containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
-						*stdoutErr = fmt.Errorf("pod %s/%s execution interrupted: reason=%s, exit=%d, msg=%s",
-							podNamespace,
-							podName,
-							reason,
-							containerState.Terminated.ExitCode,
-							containerState.Terminated.Message)
+							WorkerContainerName)
 					}
 
-					// Log completion (whether success or error)
-					kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s terminated with reason=%s, exit=%d",
-						podNamespace,
-						podName,
-						WorkerContainerName,
-						reason,
-						containerState.Terminated.ExitCode)
 
 					// We need to check if last line has data
 					if line != "" {

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -533,25 +533,32 @@ mainLoop:
 
 					return
 				case containerState.Terminated != nil:
-					// We got EOF and the pod terminated, we will log the terminated information
-					// Exit code 1 is treated as successful completion for playbooks
-					if containerState.Terminated.ExitCode != 0 && containerState.Terminated.ExitCode != 1 {
+					reason := containerState.Terminated.Reason
+
+					// Whitelist: "Completed" and "Error" mean the program ran to completion
+					// Everything else (OOMKilled, Evicted, etc.) means execution was interrupted
+					if reason != "Completed" && reason != "Error" {
 						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s has terminated, with nonzero exit code: %v, terminated reason: %v and terminated message: %v",
 							podNamespace,
 							podName,
 							WorkerContainerName,
 							containerState.Terminated.ExitCode, containerState.Terminated.Reason, containerState.Terminated.Message)
-						*stdoutErr = fmt.Errorf("pod %s/%s terminated with exit code %d: %s",
-							podNamespace,
-							podName,
-							containerState.Terminated.ExitCode,
-							containerState.Terminated.Message)
-					} else if containerState.Terminated.ExitCode == 1 {
-						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s has terminated with exit code 1 (treated as success)",
-							podNamespace,
-							podName,
-							WorkerContainerName)
+						*stdoutErr = fmt.Errorf("pod %s/%s execution interrupted: reason=%s, exit=%d, msg=%s",
+              podNamespace,
+              podName,
+              reason,
+              containerState.Terminated.ExitCode,
+              containerState.Terminated.Message)
 					}
+
+					// Log completion (whether success or error)
+					kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s terminated with reason=%s, exit=%d",
+							podNamespace,
+							podName,
+							WorkerContainerName,
+							reason,
+							containerState.Terminated.ExitCode)
+
 
 					// We need to check if last line has data
 					if line != "" {

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -534,7 +534,8 @@ mainLoop:
 					return
 				case containerState.Terminated != nil:
 					// We got EOF and the pod terminated, we will log the terminated information
-					if containerState.Terminated.ExitCode != 0 {
+					// Exit code 1 is treated as successful completion for playbooks
+					if containerState.Terminated.ExitCode != 0 && containerState.Terminated.ExitCode != 1 {
 						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s has terminated, with nonzero exit code: %v, terminated reason: %v and terminated message: %v",
 							podNamespace,
 							podName,
@@ -545,6 +546,11 @@ mainLoop:
 							podName,
 							containerState.Terminated.ExitCode,
 							containerState.Terminated.Message)
+					} else if containerState.Terminated.ExitCode == 1 {
+						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s has terminated with exit code 1 (treated as success)",
+							podNamespace,
+							podName,
+							WorkerContainerName)
 					}
 
 					// We need to check if last line has data

--- a/pkg/workceptor/kubernetes.go
+++ b/pkg/workceptor/kubernetes.go
@@ -535,7 +535,13 @@ mainLoop:
 					return
 				case containerState.Terminated != nil:
 
-					if containerState.Terminated.ExitCode != 0 {
+					if containerState.Terminated.ExitCode == 0 {
+						// Log successful completion
+						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s completed successfully",
+							podNamespace,
+							podName,
+							WorkerContainerName)
+					} else {
 						reason := containerState.Terminated.Reason
 						// Whitelist: "Completed" and "Error" mean the program ran to completion
 						// Everything else (OOMKilled, Evicted, etc.) means execution was interrupted
@@ -565,12 +571,6 @@ mainLoop:
 								reason,
 								containerState.Terminated.Message)
 						}
-					} else {
-						// Log successful completion
-						kw.GetWorkceptor().nc.GetLogger().Info("%s/%s: %s completed successfully",
-							podNamespace,
-							podName,
-							WorkerContainerName)
 					}
 
 					// We need to check if last line has data

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1345,6 +1345,166 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 				"Unable to find the container worker for pod Test_Name. This is unrecoverable. Marking the job as failed and exiting",
 			},
 		},
+		{
+			name: "eof_with_terminated_pod_oom_killed",
+			setupMocks: func(mockBaseWorkUnit *mock_workceptor.MockBaseWorkUnitForWorkUnit, mockNetceptor *mock_workceptor.MockNetceptorForWorkceptor, mockKubeAPI *mock_workceptor.MockKubeAPIer, w *workceptor.Workceptor, ctx context.Context) {
+				mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
+				mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
+				mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger := logger.NewReceptorLogger("")
+				mockNetceptor.EXPECT().GetLogger().Return(logger).AnyTimes()
+
+				oomKilledPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "Test_Name", Namespace: "Test_Namespace"},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: workceptor.WorkerContainerName,
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 137,
+										Reason:   "OOMKilled",
+										Message:  "Container exceeded memory limit",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), "Test_Namespace", "Test_Name", gomock.Any()).Return(oomKilledPod, nil).AnyTimes()
+
+				req := fakerest.RESTClient{
+					Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       &eofReadCloser{content: "2024-12-09T00:31:18.823849250Z Running task before OOM", hasRead: false},
+						}, nil
+					}),
+					NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				}
+				mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+			},
+			stdinErr: func() *error {
+				var err error
+
+				return &err
+			}(),
+			expectedStdoutErr: true,
+			timeoutSeconds:    3,
+			validateLogs:      true,
+			expectedLogMsgs: []string{
+				"Test_Namespace/Test_Name: worker terminated with reason=OOMKilled, exit=137",
+			},
+		},
+		{
+			name: "eof_with_terminated_pod_unknown_reason",
+			setupMocks: func(mockBaseWorkUnit *mock_workceptor.MockBaseWorkUnitForWorkUnit, mockNetceptor *mock_workceptor.MockNetceptorForWorkceptor, mockKubeAPI *mock_workceptor.MockKubeAPIer, w *workceptor.Workceptor, ctx context.Context) {
+				mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
+				mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
+				mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger := logger.NewReceptorLogger("")
+				mockNetceptor.EXPECT().GetLogger().Return(logger).AnyTimes()
+
+				unknownPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "Test_Name", Namespace: "Test_Namespace"},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: workceptor.WorkerContainerName,
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 2,
+										Reason:   "Unknown",
+										Message:  "Unknown termination reason",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), "Test_Namespace", "Test_Name", gomock.Any()).Return(unknownPod, nil).AnyTimes()
+
+				req := fakerest.RESTClient{
+					Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       &eofReadCloser{content: "2024-12-09T00:31:18.823849250Z Task output", hasRead: false},
+						}, nil
+					}),
+					NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				}
+				mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+			},
+			stdinErr: func() *error {
+				var err error
+
+				return &err
+			}(),
+			expectedStdoutErr: true,
+			timeoutSeconds:    3,
+			validateLogs:      true,
+			expectedLogMsgs: []string{
+				"Test_Namespace/Test_Name: worker has terminated, with nonzero exit code: 2",
+				"Test_Namespace/Test_Name: worker terminated with reason=Unknown, exit=2",
+			},
+		},
+		{
+			name: "eof_with_terminated_pod_evicted",
+			setupMocks: func(mockBaseWorkUnit *mock_workceptor.MockBaseWorkUnitForWorkUnit, mockNetceptor *mock_workceptor.MockNetceptorForWorkceptor, mockKubeAPI *mock_workceptor.MockKubeAPIer, w *workceptor.Workceptor, ctx context.Context) {
+				mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
+				mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
+				mockBaseWorkUnit.EXPECT().UpdateBasicStatus(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+				logger := logger.NewReceptorLogger("")
+				mockNetceptor.EXPECT().GetLogger().Return(logger).AnyTimes()
+
+				evictedPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "Test_Name", Namespace: "Test_Namespace"},
+					Status: corev1.PodStatus{
+						Phase: corev1.PodFailed,
+						ContainerStatuses: []corev1.ContainerStatus{
+							{
+								Name: workceptor.WorkerContainerName,
+								State: corev1.ContainerState{
+									Terminated: &corev1.ContainerStateTerminated{
+										ExitCode: 1,
+										Reason:   "Evicted",
+										Message:  "Pod was evicted due to node pressure",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				mockKubeAPI.EXPECT().Get(gomock.Any(), gomock.Any(), "Test_Namespace", "Test_Name", gomock.Any()).Return(evictedPod, nil).AnyTimes()
+
+				req := fakerest.RESTClient{
+					Client: fakerest.CreateHTTPClient(func(request *http.Request) (*http.Response, error) {
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       &eofReadCloser{content: "2024-12-09T00:31:18.823849250Z Task started", hasRead: false},
+						}, nil
+					}),
+					NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				}
+				mockKubeAPI.EXPECT().GetLogs(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(req.Request()).AnyTimes()
+			},
+			stdinErr: func() *error {
+				var err error
+
+				return &err
+			}(),
+			expectedStdoutErr: true,
+			timeoutSeconds:    3,
+			validateLogs:      true,
+			expectedLogMsgs: []string{
+				"Test_Namespace/Test_Name: worker terminated with reason=Evicted, exit=1",
+			},
+		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code
 		// AIA PAI Nc Hin R Claude Code - https://aiattribution.github.io/interpret-attribution
 		{

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1290,7 +1290,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Test_Namespace/Test_Name: worker terminated with reason=Error, exit=1",
+				"Test_Namespace/Test_Name: worker completed with error, exit code: 1, terminated reason: Error, terminated message: Container failed with error",
 			},
 		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code
@@ -1395,7 +1395,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Test_Namespace/Test_Name: worker terminated with reason=OOMKilled, exit=137",
+				"Test_Namespace/Test_Name: worker execution was interrupted, exit code: 137, terminated reason: OOMKilled and terminated message: Container exceeded memory limit",
 			},
 		},
 		{
@@ -1448,8 +1448,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Test_Namespace/Test_Name: worker has terminated, with nonzero exit code: 2",
-				"Test_Namespace/Test_Name: worker terminated with reason=Unknown, exit=2",
+				"Test_Namespace/Test_Name: worker execution was interrupted, exit code: 2, terminated reason: Unknown and terminated message: Unknown termination reason",
 			},
 		},
 		{
@@ -1502,7 +1501,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Test_Namespace/Test_Name: worker terminated with reason=Evicted, exit=1",
+				"Test_Namespace/Test_Name: worker execution was interrupted, exit code: 1, terminated reason: Evicted and terminated message: Pod was evicted due to node pressure",
 			},
 		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1238,7 +1238,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code
 		// AIA PAI Nc Hin R Claude Code - https://aiattribution.github.io/interpret-attribution
 		{
-			name: "eof_with_terminated_pod_nonzero_exit_code",
+			name: "eof_with_terminated_pod_exit_code_1_treated_as_success",
 			setupMocks: func(mockBaseWorkUnit *mock_workceptor.MockBaseWorkUnitForWorkUnit, mockNetceptor *mock_workceptor.MockNetceptorForWorkceptor, mockKubeAPI *mock_workceptor.MockKubeAPIer, w *workceptor.Workceptor, ctx context.Context) {
 				mockBaseWorkUnit.EXPECT().GetWorkceptor().Return(w).AnyTimes()
 				mockBaseWorkUnit.EXPECT().GetContext().Return(ctx).AnyTimes()
@@ -1283,11 +1283,11 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 
 				return &err
 			}(),
-			expectedStdoutErr: true,
+			expectedStdoutErr: false,
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Test_Namespace/Test_Name: worker has terminated, with nonzero exit code: 1, terminated reason: Error and terminated message: Container failed with error",
+				"Test_Namespace/Test_Name: worker has terminated with exit code 1 (treated as success)",
 			},
 		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -964,6 +964,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 								State: corev1.ContainerState{
 									Terminated: &corev1.ContainerStateTerminated{
 										ExitCode: 0,
+										Reason:   "Completed",
 									},
 								},
 							},
@@ -1035,6 +1036,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 								State: corev1.ContainerState{
 									Terminated: &corev1.ContainerStateTerminated{
 										ExitCode: 0,
+										Reason:   "Completed",
 									},
 								},
 							},
@@ -1189,6 +1191,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 								State: corev1.ContainerState{
 									Terminated: &corev1.ContainerStateTerminated{
 										ExitCode: 0,
+										Reason:   "Completed",
 									},
 								},
 							},
@@ -1287,7 +1290,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{
-				"Test_Namespace/Test_Name: worker has terminated with exit code 1 (treated as success)",
+				"Test_Namespace/Test_Name: worker terminated with reason=Error, exit=1",
 			},
 		},
 		// AIA: Primarily AI, New content, Human-initiated, Reviewed, Claude (Anthropic AI) via Claude Code
@@ -1966,6 +1969,7 @@ func TestKubeLoggingWithReconnectSimple(t *testing.T) {
 					State: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 0,
+							Reason:   "Completed",
 						},
 					},
 				},
@@ -2082,6 +2086,7 @@ func TestRetryGetLogStreamResetValidation(t *testing.T) {
 					State: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 0,
+							Reason:   "Completed",
 						},
 					},
 				},
@@ -2276,6 +2281,7 @@ func TestKubeLoggingWithReconnectDuplicateDetection(t *testing.T) {
 					State: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 0,
+							Reason:   "Completed",
 						},
 					},
 				},

--- a/pkg/workceptor/kubernetes_test.go
+++ b/pkg/workceptor/kubernetes_test.go
@@ -1283,7 +1283,7 @@ func TestKubeLoggingWithReconnect(t *testing.T) {
 
 				return &err
 			}(),
-			expectedStdoutErr: false,
+			expectedStdoutErr: true,
 			timeoutSeconds:    3,
 			validateLogs:      true,
 			expectedLogMsgs: []string{


### PR DESCRIPTION
Write kube error to stdoutErr when terminated container reason isn't completed or error.

When kubenetes container state is terminated we need to know if the job completed execution or was interrupted. If the terminated reason is completed the job finished and if the reason is error the job returned an error but completed execution. If there reason for termination is anything else this means the execution was interrupted and we want to write the error to stdoutErr.