### PR TITLE
Consolidate receptor and receptorctl test coverage reporting

### DIFF
--- a/.github/workflows/coverage_reporting.yml
+++ b/.github/workflows/coverage_reporting.yml
@@ -8,6 +8,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   DESIRED_GO_VERSION: '1.23'
+  DESIRED_PYTHON_VERSION: '3.12'
 
 jobs:
   go_test_coverage:
@@ -88,41 +89,17 @@ jobs:
           name: receptor
           path: /usr/local/bin/receptor
 
-  receptorctl-test-coverage:
-    name: Receptorctl test coverage
-    needs: receptor
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        session:
-          - coverage
-    steps:
-      - name: Download the `receptor` binary
-        uses: actions/download-artifact@v4
-        with:
-          name: receptor-${{ env.DESIRED_GO_VERSION }}
-          path: /usr/local/bin/
-
-      - name: Set executable bit on the `receptor` binary
-        run: sudo chmod a+x /usr/local/bin/receptor
-
       - name: Set up nox
         uses: wntrblm/nox@2025.05.01
         with:
           python-versions: ${{ env.DESIRED_PYTHON_VERSION }}
 
-      - name: Check out the source code from Git
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Needed for the automation in Nox to find the last tag
-
-      - name: Provision nox environment for ${{ matrix.session }}
-        run: nox --install-only --session ${{ matrix.session }}
+      - name: Provision nox environment for coverage
+        run: nox --install-only --session coverage
         working-directory: ./receptorctl
 
-      - name: Run `receptorctl` nox ${{ matrix.session }} session
-        run: nox --no-install --session ${{ matrix.session }}
+      - name: Run `receptorctl` nox coverage session
+        run: nox --no-install --session coverage
         working-directory: ./receptorctl
 
       - name: Upload Code Coverage Report from Receptorctl Unit Tests


### PR DESCRIPTION
Due to dependency issues in how the workflows were previously set up, it's necessary to consolidate the test coverage reporting jobs into one job.