### PR TITLE
Remove receptorctl dir sonar exclusion

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,7 +23,6 @@ sonar.projectName=receptor
 sonar.sources=.
 sonar.exclusions=\
     **/*_test.go,\
-    **/receptorctl/**,\
     **/mock_*,\
     **/tests/**
 


### PR DESCRIPTION
When trying to set up a monorepo I had excluded the `receptorctl` directory from the sonar configuration for the Go project. This needs to be included again to get coverage working like it was before.