### PR TITLE
Fix "Error locating unit" in execution node

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -328,13 +328,11 @@ func (rw *remoteUnit) monitorRemoteStatus(mw *utils.JobContext, forRelease bool)
 		}
 		if status[:5] == "ERROR" {
 			if strings.Contains(status, "unknown work unit") {
-				if !forRelease {
-					rw.GetWorkceptor().nc.GetLogger().Debug("Work unit %s on node %s is gone.\n", remoteUnitID, remoteNode)
-					rw.UpdateFullStatus(func(status *StatusFileData) {
-						status.State = WorkStateFailed
-						status.Detail = "Remote work unit is gone"
-					})
-				}
+				rw.GetWorkceptor().nc.GetLogger().Debug("Work unit %s on node %s is gone.\n", remoteUnitID, remoteNode)
+				rw.UpdateFullStatus(func(status *StatusFileData) {
+					status.State = WorkStateFailed
+					status.Detail = "Remote work unit is gone"
+				})
 
 				return
 			}
@@ -510,16 +508,11 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 }
 
 // monitorRemoteUnit watches a remote unit on another node and maintains local status.
-func (rw *remoteUnit) monitorRemoteUnit(ctx context.Context, forRelease bool) {
+func (rw *remoteUnit) monitorRemoteUnit(ctx context.Context) {
 	subJC := &utils.JobContext{}
-	if forRelease {
-		subJC.NewJob(ctx, 1, false)
-		go rw.monitorRemoteStatus(subJC, true)
-	} else {
-		subJC.NewJob(ctx, 2, false)
-		go rw.monitorRemoteStatus(subJC, false)
-		go rw.monitorRemoteStdout(subJC)
-	}
+	subJC.NewJob(ctx, 2, false)
+	go rw.monitorRemoteStatus(subJC, false)
+	go rw.monitorRemoteStdout(subJC)
 	subJC.Wait()
 }
 
@@ -579,12 +572,13 @@ func (rw *remoteUnit) runAndMonitor(mw *utils.JobContext, forRelease bool, actio
 			return err
 		}
 		go func() {
-			rw.monitorRemoteUnit(ctx, forRelease)
 			if forRelease {
 				err := rw.BaseWorkUnitForWorkUnit.Release(false)
 				if err != nil {
 					rw.GetWorkceptor().nc.GetLogger().Error("Error releasing unit %s: %s", rw.UnitDir(), err)
 				}
+			} else {
+				rw.monitorRemoteUnit(ctx)
 			}
 			mw.WorkerDone()
 		}()
@@ -634,7 +628,7 @@ func (rw *remoteUnit) startOrRestart(start bool) error {
 		})
 	}
 	go func() {
-		rw.monitorRemoteUnit(rw.topJC, false)
+		rw.monitorRemoteUnit(rw.topJC)
 		rw.topJC.WorkerDone()
 	}()
 

--- a/pkg/workceptor/remote_work_test.go
+++ b/pkg/workceptor/remote_work_test.go
@@ -434,9 +434,8 @@ func TestRemoteWorkLifecycleOperations(t *testing.T) {
 					"execution\n", // Hello message with remote node ID
 					"{\"State\": 4, \"Detail\": \"Cancelled\", \"StdoutSize\": 0}\n", // Acknowledgment to release command
 				}
-				anyTimes := true // Needed because this will monitor the remote work unit in a loop
-				createRemoteWorkNetworkSetup(t, ctrl, contextWithCancel, messages, mockNetceptor, mockBaseWorkUnit, tmpDir, remoteExtraData, anyTimes)
-				mockBaseWorkUnit.EXPECT().Release(false).Return(nil).AnyTimes() // Called after monitoring completes (may not complete before context cancels)
+				createRemoteWorkNetworkSetup(t, ctrl, contextWithCancel, messages, mockNetceptor, mockBaseWorkUnit, tmpDir, remoteExtraData, false)
+				mockBaseWorkUnit.EXPECT().Release(false).Return(nil)
 				err = wu.Release(false)
 			case "force_release_already_started":
 				messages := []string{


### PR DESCRIPTION
AAP-51624

## The bug
Every time a work unit gets released in a controller node of receptor, the following lines are logged in the corresponding execution node:
```
ERROR 2025/08/06 16:04:59 Error locating unit: aapp01ZOF8tB3W {"node_id":"aap-exec01.example.com","remote_id":"aap-ctrl01.example.com"}
ERROR 2025/08/06 16:04:59 : unknown work unit aapp01ZOF8tB3W  {"remote_id":"aap-ctrl01.example.com","node_id":"aap-exec01.example.com"} 
```

## Root cause
The lines are logged in the execution node because every time `Release` is called in the controller node, the following callstack is triggered in the controller node:

https://github.com/ansible/receptor/blob/28517aed1a91e9dab1561e0014db6eada5faee6d/pkg/workceptor/remote_work.go#L705-L707

`cancelOrRelease` calls `runAndMonitor`:

https://github.com/ansible/receptor/blob/28517aed1a91e9dab1561e0014db6eada5faee6d/pkg/workceptor/remote_work.go#L661

`runAndMonitor` calls `monitorRemoteUnit`:
https://github.com/ansible/receptor/blob/28517aed1a91e9dab1561e0014db6eada5faee6d/pkg/workceptor/remote_work.go#L694-L696

`monitorRemoteUnit` calls `monitorRemoteStatus`:
https://github.com/ansible/receptor/blob/28517aed1a91e9dab1561e0014db6eada5faee6d/pkg/workceptor/remote_work.go#L581-L588

`monitorRemoteStatus`:
https://github.com/ansible/receptor/blob/28517aed1a91e9dab1561e0014db6eada5faee6d/pkg/workceptor/remote_work.go#L513-L517

And the problem with `monitorRemoteStatus` is that it submits a `work status` command right after the work unit was released in `cancelOrRelease`:

https://github.com/ansible/receptor/blob/28517aed1a91e9dab1561e0014db6eada5faee6d/pkg/workceptor/remote_work.go#L307

So when `work status` command reaches the execution node, it triggers the bug, because the work unit has been released already.

## How to fix this?

* There are related issues such as https://github.com/ansible/receptor/pull/1275 (AAP-22149) that fix this by adding a new state, `Released`. However this would require additional changes in Controller.
* Discussion in AAP-22149 suggests modifying status so an additional flag can be passed to ignore errors and supress logs.

However, what I implemented in this PR is removing the submission of the `work status` command entirely. My reasoning is as follows:
* The status retrieved from the execution node does not seem to be used for anything. The local status in the controller gets updated to `LocalCancelled` and `LocalReleased` before the status command gets submitted.
* What is the point of retrieving the status of a work unit we want to release anyway?
* This fix will get rid of the consistent and reproducible bug.
* This fix will NOT get rid of real race-conditions where a status call is submitted at the same time a release call is. BUT we don't have proof of seeing this in the wild.




