### PR TITLE
Fix flaky qlog test

### DIFF
--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -923,7 +923,6 @@ func TestTracerCreatesCorrectFilePath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			os.Setenv("QLOGDIR", tt.qlogDirectory)
 			tracer := testNetcepter.tracer(testNetcepter.context, clientLoggingPerspective, connID)
 			defer tracer.Close()

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -900,8 +900,6 @@ func TestTracerDoesNotReturnsNewConnectionTracer(t *testing.T) {
 // TestTracerCreatesCorrectFilePath tests the Netceptor.tracer() function that sets up
 // QUIC tracing does not depend on the QLOGDIR having a trailing slash character.
 func TestTracerCreatesCorrectFilePath(t *testing.T) {
-	t.Parallel()
-
 	testNetcepter := New(context.Background(), "node1")
 	clientLoggingPerspective := logging.PerspectiveClient
 	connID := quic.ConnectionIDFromBytes([]byte{})


### PR DESCRIPTION
Fixes a test that intermittently fails. The tests cannot run in parallel because the code being tested relies environment variables to determine a file path.