### PR TITLE
Fix SonarCloud issue: Replace duplicate string literal with constant

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -2,13 +2,15 @@ package cmd
 
 import "github.com/ansible/receptor/pkg/types"
 
+const DefaultBindAddr = "0.0.0.0"
+
 func SetTCPListenerDefaults(config *BackendConfig) {
 	for _, listener := range config.TCPListeners {
 		if listener.Cost == 0 {
 			listener.Cost = 1.0
 		}
 		if listener.BindAddr == "" {
-			listener.BindAddr = "0.0.0.0"
+			listener.BindAddr = DefaultBindAddr
 		}
 	}
 }
@@ -19,7 +21,7 @@ func SetUDPListenerDefaults(config *BackendConfig) {
 			listener.Cost = 1.0
 		}
 		if listener.BindAddr == "" {
-			listener.BindAddr = "0.0.0.0"
+			listener.BindAddr = DefaultBindAddr
 		}
 	}
 }
@@ -30,7 +32,7 @@ func SetWSListenerDefaults(config *BackendConfig) {
 			listener.Cost = 1.0
 		}
 		if listener.BindAddr == "" {
-			listener.BindAddr = "0.0.0.0"
+			listener.BindAddr = DefaultBindAddr
 		}
 		if listener.Path == "" {
 			listener.Path = "/"


### PR DESCRIPTION
## Summary
- Defines a constant `DefaultBindAddr` instead of duplicating the literal "0.0.0.0" 3 times in `cmd/defaults.go`
- Resolves SonarCloud issue `go:S1192` (Critical severity)

## Changes
- Added `const DefaultBindAddr = "0.0.0.0"` at the package level
- Replaced all 3 occurrences of the string literal with the constant in:
  - `SetTCPListenerDefaults()`
  - `SetUDPListenerDefaults()`
  - `SetWSListenerDefaults()`

## Benefits
- Improves code maintainability
- Single source of truth for the default bind address
- Follows Go best practices for avoiding magic strings
- Reduces SonarCloud critical issue count

## Test plan
- [x] Code compiles successfully
- [x] No functional changes - purely refactoring
- [x] Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)