### PR TITLE
Fix SonarCloud issue: Replace duplicate "Red Hat Ansible" literal with constant

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,9 +13,11 @@
 # sys.path.insert(0, os.path.abspath('.'))
 # -- Project information -----------------------------------------------------
 
+AUTHOR_NAME = "Red Hat Ansible"
+
 project = "receptor"
-copyright = "Red Hat Ansible"
-author = "Red Hat Ansible"
+copyright = AUTHOR_NAME
+author = AUTHOR_NAME
 
 # The full version, including alpha/beta/rc tags
 # release = '0.0.0'
@@ -81,7 +83,7 @@ latex_elements = {
 }
 
 latex_documents = [
-    (master_doc, "receptor.tex", "receptor Documentation", "Red Hat Ansible", "manual"),
+    (master_doc, "receptor.tex", "receptor Documentation", AUTHOR_NAME, "manual"),
 ]
 
 # -- Options for manual page output ---------------------------------------


### PR DESCRIPTION
## Summary
- Defines a constant `AUTHOR_NAME` instead of duplicating the literal "Red Hat Ansible" 3 times in `docs/source/conf.py`
- Resolves SonarCloud issue `python:S1192` (Critical severity)

## Changes
- Added `AUTHOR_NAME = "Red Hat Ansible"` at module level
- Replaced all 3 occurrences of the string literal with the constant:
  - `copyright` variable
  - `author` variable  
  - `latex_documents` tuple

## Benefits
- Improves documentation configuration maintainability
- Single source of truth for the author name across Sphinx config
- Follows Python best practices for avoiding magic strings
- Reduces SonarCloud critical issue count

## Test plan
- [x] Configuration loads successfully (tested with Python import)
- [x] All variables resolve to correct values
- [x] No functional changes - purely refactoring
- [x] Compatible with Sphinx - uses standard Python variable assignment

## Validation
```python
✓ Config loads successfully
  author = 'Red Hat Ansible'
  copyright = 'Red Hat Ansible'
  project = 'receptor'
  latex_documents[0][3] = 'Red Hat Ansible'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)