### PR TITLE
Fix SonarCloud issue: Replace duplicate decode error message with constant

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,8 @@ var (
 	backendConfig *BackendConfig
 )
 
+const errMsgUnableToDecode = "unable to decode into struct, %v"
+
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "receptor",
@@ -117,19 +119,19 @@ func handleRootCommand(cmd *cobra.Command, args []string) {
 
 	receptorConfig, err := ParseReceptorConfig(cfgFile)
 	if err != nil {
-		fmt.Printf("unable to decode into struct, %v", err)
+		fmt.Printf(errMsgUnableToDecode, err)
 		os.Exit(1)
 	}
 
 	certifcatesConfig, err := ParseCertificatesConfig(cfgFile)
 	if err != nil {
-		fmt.Printf("unable to decode into struct, %v", err)
+		fmt.Printf(errMsgUnableToDecode, err)
 		os.Exit(1)
 	}
 
 	backendConfig, err = ParseBackendConfig(cfgFile)
 	if err != nil {
-		fmt.Printf("unable to decode into struct, %v", err)
+		fmt.Printf(errMsgUnableToDecode, err)
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary
- Defines a constant `errMsgUnableToDecode` instead of duplicating the literal "unable to decode into struct, %v" 3 times in `cmd/root.go`
- Resolves SonarCloud issue `go:S1192` (Critical severity)

## Changes
- Added `const errMsgUnableToDecode = "unable to decode into struct, %v"` at package level
- Replaced all 3 occurrences of the error message string in:
  - `ParseReceptorConfig` error handling (line 122)
  - `ParseCertificatesConfig` error handling (line 128)
  - `ParseBackendConfig` error handling (line 134)

## Benefits
- Improves code maintainability
- Single source of truth for the decode error message format
- Follows Go best practices for avoiding duplicate string literals
- Reduces SonarCloud critical issue count

## Test plan
- [x] Code compiles successfully (`go build ./cmd/...`)
- [x] No functional changes - purely refactoring
- [x] Error messages remain identical to users
- [x] Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)