### PR TITLE
Fix SonarCloud issue: Replace duplicate status file error message with constant

### DIFF
--- a/pkg/workceptor/command.go
+++ b/pkg/workceptor/command.go
@@ -24,6 +24,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+const errMsgStatusFileUpdate = "Error updating status file %s: %s"
+
 type BaseWorkUnitForWorkUnit interface {
 	CancelContext()
 	ID() string
@@ -103,7 +105,7 @@ func commandRunner(command string, params string, unitdir string) error {
 	statusFilename := path.Join(unitdir, "status")
 	err := status.UpdateBasicStatus(statusFilename, WorkStatePending, "Not started yet", 0)
 	if err != nil {
-		MainInstance.nc.GetLogger().Error("Error updating status file %s: %s", statusFilename, err)
+		MainInstance.nc.GetLogger().Error(errMsgStatusFileUpdate, statusFilename, err)
 	}
 	var cmd *exec.Cmd
 	if params == "" {
@@ -174,13 +176,13 @@ loop:
 			termThenKill(cmd, doneChan)
 			err = status.UpdateBasicStatus(statusFilename, WorkStateFailed, "Killed", stdoutSize(unitdir))
 			if err != nil {
-				MainInstance.nc.GetLogger().Error("Error updating status file %s: %s", statusFilename, err)
+				MainInstance.nc.GetLogger().Error(errMsgStatusFileUpdate, statusFilename, err)
 			}
 			os.Exit(-1)
 		case <-time.After(250 * time.Millisecond):
 			err = status.UpdateBasicStatus(statusFilename, WorkStateRunning, fmt.Sprintf("Running: PID %d", cmd.Process.Pid), stdoutSize(unitdir))
 			if err != nil {
-				MainInstance.nc.GetLogger().Error("Error updating status file %s: %s", statusFilename, err)
+				MainInstance.nc.GetLogger().Error(errMsgStatusFileUpdate, statusFilename, err)
 				writeStatusFailures++
 				if writeStatusFailures > 3 {
 					MainInstance.nc.GetLogger().Error("Exceeded retries for updating status file %s: %s", statusFilename, err)
@@ -194,7 +196,7 @@ loop:
 	if err != nil {
 		err = status.UpdateBasicStatus(statusFilename, WorkStateFailed, fmt.Sprintf("Error: %s", err), stdoutSize(unitdir))
 		if err != nil {
-			MainInstance.nc.GetLogger().Error("Error updating status file %s: %s", statusFilename, err)
+			MainInstance.nc.GetLogger().Error(errMsgStatusFileUpdate, statusFilename, err)
 		}
 
 		return err
@@ -202,12 +204,12 @@ loop:
 	if cmd.ProcessState.Success() {
 		err = status.UpdateBasicStatus(statusFilename, WorkStateSucceeded, cmd.ProcessState.String(), stdoutSize(unitdir))
 		if err != nil {
-			MainInstance.nc.GetLogger().Error("Error updating status file %s: %s", statusFilename, err)
+			MainInstance.nc.GetLogger().Error(errMsgStatusFileUpdate, statusFilename, err)
 		}
 	} else {
 		err = status.UpdateBasicStatus(statusFilename, WorkStateFailed, cmd.ProcessState.String(), stdoutSize(unitdir))
 		if err != nil {
-			MainInstance.nc.GetLogger().Error("Error updating status file %s: %s", statusFilename, err)
+			MainInstance.nc.GetLogger().Error(errMsgStatusFileUpdate, statusFilename, err)
 		}
 	}
 	err = stdin.Close()
@@ -450,7 +452,7 @@ func (cfg commandRunnerCfg) Run() error {
 		statusFilename := path.Join(cfg.UnitDir, "status")
 		err2 := (&StatusFileData{}).UpdateBasicStatus(statusFilename, WorkStateFailed, err.Error(), stdoutSize(cfg.UnitDir))
 		if err2 != nil {
-			MainInstance.nc.GetLogger().Error("Error updating status file %s: %s", statusFilename, err2)
+			MainInstance.nc.GetLogger().Error(errMsgStatusFileUpdate, statusFilename, err2)
 		}
 		MainInstance.nc.GetLogger().Error("Command runner exited with error: %s\n", err)
 		os.Exit(-1)


### PR DESCRIPTION
## Summary
- Defines a constant `errMsgStatusFileUpdate` instead of duplicating the literal "Error updating status file %s: %s" 7 times in `pkg/workceptor/command.go`
- Resolves SonarCloud issue `go:S1192` (Critical severity)

## Changes
- Added `const errMsgStatusFileUpdate = "Error updating status file %s: %s"` at package level
- Replaced all 7 occurrences of the error message string throughout the file:
  - Line 108: Command execution error handling
  - Line 179: Status update error handling
  - Line 185: Another status update error
  - Line 199: Command runner status update
  - Line 207: Additional status update path
  - Line 212: Status file update error
  - Line 455: Command exit error handling

## Benefits
- Improves code maintainability
- Single source of truth for the status file update error message format
- Follows Go best practices for avoiding duplicate string literals
- Reduces SonarCloud critical issue count
- Makes future error message updates easier (only one place to change)

## Test plan
- [x] Code compiles successfully (`go build ./pkg/workceptor/...`)
- [x] No functional changes - purely refactoring
- [x] Error messages remain identical to users
- [x] Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)