### PR TITLE
Fix SonarCloud issue: Replace duplicate "remote ExtraData missing" literal with constant

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -20,6 +21,8 @@ import (
 	"github.com/ansible/receptor/pkg/netceptor"
 	"github.com/ansible/receptor/pkg/utils"
 )
+
+const errMsgRemoteExtraDataMissing = "remote ExtraData missing"
 
 // remoteUnit implements the WorkUnit interface for the Receptor remote worker plugin.
 type remoteUnit struct {
@@ -49,7 +52,7 @@ func (rw *remoteUnit) ConnectToRemote(ctx context.Context) (net.Conn, *bufio.Rea
 	status := rw.Status()
 	red, ok := status.ExtraData.(*RemoteExtraData)
 	if !ok {
-		return nil, nil, fmt.Errorf("remote ExtraData missing")
+		return nil, nil, errors.New(errMsgRemoteExtraDataMissing)
 	}
 	tlsConfig, err := rw.GetWorkceptor().nc.GetClientTLSConfig(red.TLSClient, red.RemoteNode, netceptor.ExpectedHostnameTypeReceptor)
 	if err != nil {
@@ -294,7 +297,7 @@ func (rw *remoteUnit) monitorRemoteStatus(mw *utils.JobContext, forRelease bool)
 	status := rw.Status()
 	red, ok := status.ExtraData.(*RemoteExtraData)
 	if !ok {
-		rw.GetWorkceptor().nc.GetLogger().Error("remote ExtraData missing")
+		rw.GetWorkceptor().nc.GetLogger().Error(errMsgRemoteExtraDataMissing)
 
 		return
 	}
@@ -387,7 +390,7 @@ func (rw *remoteUnit) monitorRemoteStdout(mw *utils.JobContext) {
 	status := rw.Status()
 	red, ok := status.ExtraData.(*RemoteExtraData)
 	if !ok {
-		rw.GetWorkceptor().nc.GetLogger().Error("remote ExtraData missing")
+		rw.GetWorkceptor().nc.GetLogger().Error(errMsgRemoteExtraDataMissing)
 
 		return
 	}


### PR DESCRIPTION
## Summary
- Defines a constant `errMsgRemoteExtraDataMissing` instead of duplicating the literal "remote ExtraData missing" 3 times in `pkg/workceptor/remote_work.go`
- Resolves SonarCloud issue `go:S1192` (Critical severity)

## Changes
- Added `const errMsgRemoteExtraDataMissing = "remote ExtraData missing"` at package level
- Replaced all 3 occurrences of the error message string:
  - Line 54: `ConnectToRemote` error return path
  - Line 299: Logger error call in one code path
  - Line 392: Logger error call in another code path

## Benefits
- Improves code maintainability
- Single source of truth for the remote ExtraData error message
- Follows Go best practices for avoiding duplicate string literals
- Reduces SonarCloud critical issue count
- Makes future error message updates easier (only one place to change)

## Test plan
- [x] Code compiles successfully (`go build ./pkg/workceptor/...`)
- [x] No functional changes - purely refactoring
- [x] Error messages remain identical to users
- [x] Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)