### PR TITLE
Fix SonarCloud issue: Replace duplicate "Error closing %s: %s" literal with constant

### DIFF
--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -34,6 +34,8 @@ const (
 
 const logFormatWithUnitID = "[%s] %s"
 
+const errMsgErrorClosing = "Error closing %s: %s"
+
 // IsComplete returns true if a given WorkState indicates the job is finished.
 func IsComplete(workState int) bool {
 	return workState == WorkStateSucceeded || workState == WorkStateFailed
@@ -193,7 +195,7 @@ func (sfd *StatusFileData) Save(filename string) error {
 		serr := file.Close()
 
 		if serr != nil {
-			MainInstance.nc.GetLogger().Error("Error closing %s: %s", filename, serr)
+			MainInstance.nc.GetLogger().Error(errMsgErrorClosing, filename, serr)
 		}
 
 		return err
@@ -235,7 +237,7 @@ func (sfd *StatusFileData) Load(filename string) error {
 	if err != nil {
 		lerr := file.Close()
 		if lerr != nil {
-			MainInstance.nc.GetLogger().Error("Error closing %s: %s", filename, lerr)
+			MainInstance.nc.GetLogger().Error(errMsgErrorClosing, filename, lerr)
 		}
 
 		return err
@@ -267,7 +269,7 @@ func (sfd *StatusFileData) UpdateFullStatus(filename string, statusFunc func(*St
 	defer func() {
 		err := file.Close()
 		if err != nil {
-			MainInstance.nc.GetLogger().Error("Error closing %s: %s", filename, err)
+			MainInstance.nc.GetLogger().Error(errMsgErrorClosing, filename, err)
 		}
 	}()
 	size, err := file.Seek(0, 2)


### PR DESCRIPTION
## Summary
- Defines a constant `errMsgErrorClosing` instead of duplicating the literal "Error closing %s: %s" 3 times in `pkg/workceptor/workunitbase.go`
- Resolves SonarCloud issue `go:S1192` (Critical severity)

## Changes
- Added `const errMsgErrorClosing = "Error closing %s: %s"` at package level
- Replaced all 3 occurrences of the error message string:
  - Line 196: File close error after load failure
  - Line 238: File close error with lerr variable
  - Line 270: File close error in defer function

## Benefits
- Improves code maintainability
- Single source of truth for the file closing error message format
- Follows Go best practices for avoiding duplicate string literals
- Reduces SonarCloud critical issue count
- Makes future error message updates easier (only one place to change)

## Test plan
- [x] Code compiles successfully (`go build ./pkg/workceptor/...`)
- [x] No functional changes - purely refactoring
- [x] Error messages remain identical to users
- [x] Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)