### PR TITLE
Fix SonarCloud issue: Replace duplicate "[%s] %s" literal with constant

### DIFF
--- a/pkg/workceptor/workunitbase.go
+++ b/pkg/workceptor/workunitbase.go
@@ -32,6 +32,8 @@ const (
 	WorkStateCanceled  = 4
 )
 
+const logFormatWithUnitID = "[%s] %s"
+
 // IsComplete returns true if a given WorkState indicates the job is finished.
 func IsComplete(workState int) bool {
 	return workState == WorkStateSucceeded || workState == WorkStateFailed
@@ -98,25 +100,25 @@ func (bwu *BaseWorkUnit) Init(w *Workceptor, unitID string, workType string, fs 
 
 // Error logs message with unitID prepended.
 func (bwu *BaseWorkUnit) Error(format string, v ...interface{}) {
-	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	format = fmt.Sprintf(logFormatWithUnitID, bwu.unitID, format)
 	bwu.w.nc.GetLogger().Error(format, v...)
 }
 
 // Warning logs message with unitID prepended.
 func (bwu *BaseWorkUnit) Warning(format string, v ...interface{}) {
-	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	format = fmt.Sprintf(logFormatWithUnitID, bwu.unitID, format)
 	bwu.w.nc.GetLogger().Warning(format, v...)
 }
 
 // Info logs message with unitID prepended.
 func (bwu *BaseWorkUnit) Info(format string, v ...interface{}) {
-	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	format = fmt.Sprintf(logFormatWithUnitID, bwu.unitID, format)
 	bwu.w.nc.GetLogger().Info(format, v...)
 }
 
 // Debug logs message with unitID prepended.
 func (bwu *BaseWorkUnit) Debug(format string, v ...interface{}) {
-	format = fmt.Sprintf("[%s] %s", bwu.unitID, format)
+	format = fmt.Sprintf(logFormatWithUnitID, bwu.unitID, format)
 	bwu.w.nc.GetLogger().Debug(format, v...)
 }
 


### PR DESCRIPTION
## Summary
- Defines a constant `logFormatWithUnitID` instead of duplicating the literal "[%s] %s" 4 times in `pkg/workceptor/workunitbase.go`
- Resolves SonarCloud issue `go:S1192` (Critical severity)

## Changes
- Added `const logFormatWithUnitID = "[%s] %s"` at package level
- Replaced all 4 occurrences of the format string in logging methods:
  - Line 101: `Error` method - prepends unit ID to error messages
  - Line 107: `Warning` method - prepends unit ID to warning messages
  - Line 113: `Info` method - prepends unit ID to info messages
  - Line 119: `Debug` method - prepends unit ID to debug messages

## Benefits
- Improves code maintainability
- Single source of truth for the log format string
- Follows Go best practices for avoiding duplicate string literals
- Reduces SonarCloud critical issue count
- Makes future format updates easier (only one place to change)
- Consistent logging format across all log levels

## Test plan
- [x] Code compiles successfully (`go build ./pkg/workceptor/...`)
- [x] No functional changes - purely refactoring
- [x] Log format remains identical to existing behavior
- [x] Existing tests should pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)