### PR TITLE
Add unit tests to improve test coverage

### DIFF
--- a/pkg/certificates/oser_test.go
+++ b/pkg/certificates/oser_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestOsWrapperReadFile(t *testing.T) {
+	t.Parallel()
+
 	// Create a temporary file for testing
 	tmpDir := t.TempDir()
 	testFile := filepath.Join(tmpDir, "test.txt")
@@ -40,7 +42,10 @@ func TestOsWrapperReadFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			wrapper := &certificates.OsWrapper{}
 			content, err := wrapper.ReadFile(tt.filename)
 
@@ -61,6 +66,8 @@ func TestOsWrapperReadFile(t *testing.T) {
 }
 
 func TestOsWrapperWriteFile(t *testing.T) {
+	t.Parallel()
+
 	tmpDir := t.TempDir()
 
 	tests := []struct {
@@ -87,7 +94,10 @@ func TestOsWrapperWriteFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			wrapper := &certificates.OsWrapper{}
 			err := wrapper.WriteFile(tt.filename, tt.content, tt.perm)
 

--- a/pkg/certificates/oser_test.go
+++ b/pkg/certificates/oser_test.go
@@ -1,0 +1,114 @@
+package certificates_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ansible/receptor/pkg/certificates"
+)
+
+func TestOsWrapperReadFile(t *testing.T) {
+	// Create a temporary file for testing
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.txt")
+	testContent := []byte("test content")
+
+	err := os.WriteFile(testFile, testContent, 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		filename      string
+		expectError   bool
+		expectContent []byte
+	}{
+		{
+			name:          "Successfully read existing file",
+			filename:      testFile,
+			expectError:   false,
+			expectContent: testContent,
+		},
+		{
+			name:        "Fail to read non-existent file",
+			filename:    filepath.Join(tmpDir, "nonexistent.txt"),
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := &certificates.OsWrapper{}
+			content, err := wrapper.ReadFile(tt.filename)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if string(content) != string(tt.expectContent) {
+					t.Errorf("Expected content %q, got %q", tt.expectContent, content)
+				}
+			}
+		})
+	}
+}
+
+func TestOsWrapperWriteFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		filename    string
+		content     []byte
+		perm        fs.FileMode
+		expectError bool
+	}{
+		{
+			name:        "Successfully write file",
+			filename:    filepath.Join(tmpDir, "write_test.txt"),
+			content:     []byte("test write content"),
+			perm:        0o644,
+			expectError: false,
+		},
+		{
+			name:        "Write to invalid directory",
+			filename:    "/invalid/path/that/does/not/exist/file.txt",
+			content:     []byte("test content"),
+			perm:        0o644,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := &certificates.OsWrapper{}
+			err := wrapper.WriteFile(tt.filename, tt.content, tt.perm)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+
+				// Verify the file was written correctly
+				content, readErr := os.ReadFile(tt.filename)
+				if readErr != nil {
+					t.Errorf("Failed to read written file: %v", readErr)
+				}
+				if string(content) != string(tt.content) {
+					t.Errorf("Expected content %q, got %q", tt.content, content)
+				}
+			}
+		})
+	}
+}

--- a/pkg/certificates/oser_test.go
+++ b/pkg/certificates/oser_test.go
@@ -42,7 +42,6 @@ func TestOsWrapperReadFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -94,7 +93,6 @@ func TestOsWrapperWriteFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/certificates/rsaer_test.go
+++ b/pkg/certificates/rsaer_test.go
@@ -33,7 +33,6 @@ func TestRsaWrapperGenerateKey(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/certificates/rsaer_test.go
+++ b/pkg/certificates/rsaer_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func TestRsaWrapperGenerateKey(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		bits        int
@@ -31,7 +33,10 @@ func TestRsaWrapperGenerateKey(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			wrapper := &certificates.RsaWrapper{}
 			key, err := wrapper.GenerateKey(rand.Reader, tt.bits)
 

--- a/pkg/certificates/rsaer_test.go
+++ b/pkg/certificates/rsaer_test.go
@@ -1,0 +1,55 @@
+package certificates_test
+
+import (
+	"crypto/rand"
+	"testing"
+
+	"github.com/ansible/receptor/pkg/certificates"
+)
+
+func TestRsaWrapperGenerateKey(t *testing.T) {
+	tests := []struct {
+		name        string
+		bits        int
+		expectError bool
+	}{
+		{
+			name:        "Successfully generate 2048-bit RSA key",
+			bits:        2048,
+			expectError: false,
+		},
+		{
+			name:        "Successfully generate 4096-bit RSA key",
+			bits:        4096,
+			expectError: false,
+		},
+		{
+			name:        "Fail to generate key with invalid bit size",
+			bits:        1,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			wrapper := &certificates.RsaWrapper{}
+			key, err := wrapper.GenerateKey(rand.Reader, tt.bits)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected an error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if key == nil {
+					t.Error("Expected a valid key but got nil")
+				}
+				if key != nil && key.N.BitLen() != tt.bits {
+					t.Errorf("Expected key size %d bits, got %d bits", tt.bits, key.N.BitLen())
+				}
+			}
+		})
+	}
+}

--- a/pkg/netceptor/external_backend_test.go
+++ b/pkg/netceptor/external_backend_test.go
@@ -23,18 +23,6 @@ func setupExternalBackend(t *testing.T) *netceptor.ExternalBackend {
 	return backend
 }
 
-func TestNewExternalBackend(t *testing.T) {
-	t.Parallel()
-
-	backend, err := netceptor.NewExternalBackend()
-	if err != nil {
-		t.Errorf("NewExternalBackend() returned unexpected error: %v", err)
-	}
-	if backend == nil {
-		t.Error("NewExternalBackend() returned nil backend")
-	}
-}
-
 func TestExternalBackendStart(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/netceptor/external_backend_test.go
+++ b/pkg/netceptor/external_backend_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestNewExternalBackend(t *testing.T) {
+	t.Parallel()
+
 	backend, err := netceptor.NewExternalBackend()
 	if err != nil {
 		t.Errorf("NewExternalBackend() returned unexpected error: %v", err)
@@ -20,6 +22,8 @@ func TestNewExternalBackend(t *testing.T) {
 }
 
 func TestExternalBackendStart(t *testing.T) {
+	t.Parallel()
+
 	backend, err := netceptor.NewExternalBackend()
 	if err != nil {
 		t.Fatalf("Failed to create external backend: %v", err)
@@ -39,6 +43,8 @@ func TestExternalBackendStart(t *testing.T) {
 }
 
 func TestExternalBackendNewConnection(t *testing.T) {
+	t.Parallel()
+
 	backend, err := netceptor.NewExternalBackend()
 	if err != nil {
 		t.Fatalf("Failed to create external backend: %v", err)

--- a/pkg/netceptor/external_backend_test.go
+++ b/pkg/netceptor/external_backend_test.go
@@ -1,0 +1,100 @@
+package netceptor_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ansible/receptor/pkg/netceptor"
+)
+
+func TestNewExternalBackend(t *testing.T) {
+	backend, err := netceptor.NewExternalBackend()
+	if err != nil {
+		t.Errorf("NewExternalBackend() returned unexpected error: %v", err)
+	}
+	if backend == nil {
+		t.Error("NewExternalBackend() returned nil backend")
+	}
+}
+
+func TestExternalBackendStart(t *testing.T) {
+	backend, err := netceptor.NewExternalBackend()
+	if err != nil {
+		t.Fatalf("Failed to create external backend: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	sessChan, err := backend.Start(ctx, &wg)
+
+	if err != nil {
+		t.Errorf("Start() returned unexpected error: %v", err)
+	}
+	if sessChan == nil {
+		t.Error("Start() returned nil session channel")
+	}
+}
+
+func TestExternalBackendNewConnection(t *testing.T) {
+	backend, err := netceptor.NewExternalBackend()
+	if err != nil {
+		t.Fatalf("Failed to create external backend: %v", err)
+	}
+
+	ctx := context.Background()
+	var wg sync.WaitGroup
+	sessChan, err := backend.Start(ctx, &wg)
+	if err != nil {
+		t.Fatalf("Failed to start backend: %v", err)
+	}
+
+	// Create a mock MessageConn for testing
+	mockConn := &mockMessageConn{}
+
+	// Start a goroutine to receive the session
+	done := make(chan bool)
+	go func() {
+		select {
+		case sess := <-sessChan:
+			if sess == nil {
+				t.Error("Received nil session from channel")
+			}
+			done <- true
+		case <-time.After(2 * time.Second):
+			t.Error("Timeout waiting for session")
+			done <- false
+		}
+	}()
+
+	// Create a new connection
+	connCtx := backend.NewConnection(mockConn, true)
+	if connCtx == nil {
+		t.Error("NewConnection() returned nil context")
+	}
+
+	// Wait for the session to be received
+	<-done
+}
+
+// mockMessageConn is a simple mock implementation of MessageConn for testing
+type mockMessageConn struct{}
+
+func (m *mockMessageConn) WriteMessage(_ context.Context, _ []byte) error {
+	return nil
+}
+
+func (m *mockMessageConn) ReadMessage(_ context.Context, _ time.Duration) ([]byte, error) {
+	return []byte{}, nil
+}
+
+func (m *mockMessageConn) SetReadDeadline(_ time.Time) error {
+	return nil
+}
+
+func (m *mockMessageConn) Close() error {
+	return nil
+}

--- a/pkg/netceptor/external_backend_test.go
+++ b/pkg/netceptor/external_backend_test.go
@@ -11,6 +11,18 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+// setupExternalBackend is a helper function that creates a new external backend for testing.
+func setupExternalBackend(t *testing.T) *netceptor.ExternalBackend {
+	t.Helper()
+
+	backend, err := netceptor.NewExternalBackend()
+	if err != nil {
+		t.Fatalf("Failed to create external backend: %v", err)
+	}
+
+	return backend
+}
+
 func TestNewExternalBackend(t *testing.T) {
 	t.Parallel()
 
@@ -26,10 +38,7 @@ func TestNewExternalBackend(t *testing.T) {
 func TestExternalBackendStart(t *testing.T) {
 	t.Parallel()
 
-	backend, err := netceptor.NewExternalBackend()
-	if err != nil {
-		t.Fatalf("Failed to create external backend: %v", err)
-	}
+	backend := setupExternalBackend(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -50,10 +59,7 @@ func TestExternalBackendNewConnection(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	backend, err := netceptor.NewExternalBackend()
-	if err != nil {
-		t.Fatalf("Failed to create external backend: %v", err)
-	}
+	backend := setupExternalBackend(t)
 
 	ctx := context.Background()
 	var wg sync.WaitGroup

--- a/pkg/netceptor/external_backend_test.go
+++ b/pkg/netceptor/external_backend_test.go
@@ -30,7 +30,6 @@ func TestExternalBackendStart(t *testing.T) {
 
 	var wg sync.WaitGroup
 	sessChan, err := backend.Start(ctx, &wg)
-
 	if err != nil {
 		t.Errorf("Start() returned unexpected error: %v", err)
 	}
@@ -80,7 +79,7 @@ func TestExternalBackendNewConnection(t *testing.T) {
 	<-done
 }
 
-// mockMessageConn is a simple mock implementation of MessageConn for testing
+// mockMessageConn is a simple mock implementation of MessageConn for testing.
 type mockMessageConn struct{}
 
 func (m *mockMessageConn) WriteMessage(_ context.Context, _ []byte) error {

--- a/pkg/netceptor/external_backend_test.go
+++ b/pkg/netceptor/external_backend_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/ansible/receptor/pkg/netceptor"
+	"github.com/ansible/receptor/pkg/netceptor/mock_netceptor"
+	"go.uber.org/mock/gomock"
 )
 
 func TestNewExternalBackend(t *testing.T) {
@@ -45,6 +47,9 @@ func TestExternalBackendStart(t *testing.T) {
 func TestExternalBackendNewConnection(t *testing.T) {
 	t.Parallel()
 
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	backend, err := netceptor.NewExternalBackend()
 	if err != nil {
 		t.Fatalf("Failed to create external backend: %v", err)
@@ -57,8 +62,8 @@ func TestExternalBackendNewConnection(t *testing.T) {
 		t.Fatalf("Failed to start backend: %v", err)
 	}
 
-	// Create a mock MessageConn for testing
-	mockConn := &mockMessageConn{}
+	// Create a mock MessageConn using the existing mock
+	mockConn := mock_netceptor.NewMockMessageConn(ctrl)
 
 	// Start a goroutine to receive the session
 	done := make(chan bool)
@@ -83,23 +88,4 @@ func TestExternalBackendNewConnection(t *testing.T) {
 
 	// Wait for the session to be received
 	<-done
-}
-
-// mockMessageConn is a simple mock implementation of MessageConn for testing.
-type mockMessageConn struct{}
-
-func (m *mockMessageConn) WriteMessage(_ context.Context, _ []byte) error {
-	return nil
-}
-
-func (m *mockMessageConn) ReadMessage(_ context.Context, _ time.Duration) ([]byte, error) {
-	return []byte{}, nil
-}
-
-func (m *mockMessageConn) SetReadDeadline(_ time.Time) error {
-	return nil
-}
-
-func (m *mockMessageConn) Close() error {
-	return nil
 }

--- a/pkg/utils/unixsock_errors_test.go
+++ b/pkg/utils/unixsock_errors_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestMakeUnixSocketError(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		err            error
@@ -42,7 +44,10 @@ func TestMakeUnixSocketError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := utils.MakeUnixSocketError(tt.err, tt.underlyingErr)
 			if result == nil {
 				t.Error("Expected an error but got nil")
@@ -55,6 +60,8 @@ func TestMakeUnixSocketError(t *testing.T) {
 }
 
 func TestMakeWindowsSocketError(t *testing.T) {
+	t.Parallel()
+
 	err := utils.MakeWindowsSocketError()
 	if err == nil {
 		t.Error("Expected an error but got nil")
@@ -69,6 +76,8 @@ func TestMakeWindowsSocketError(t *testing.T) {
 }
 
 func TestUnixSocketErrorConstants(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name        string
 		err         error
@@ -102,7 +111,10 @@ func TestUnixSocketErrorConstants(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			if tt.err == nil {
 				t.Error("Error constant is nil")
 			}

--- a/pkg/utils/unixsock_errors_test.go
+++ b/pkg/utils/unixsock_errors_test.go
@@ -1,0 +1,114 @@
+package utils_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ansible/receptor/pkg/utils"
+)
+
+func TestMakeUnixSocketError(t *testing.T) {
+	tests := []struct {
+		name           string
+		err            error
+		underlyingErr  error
+		expectedSubstr string
+	}{
+		{
+			name:           "Socket lock file not acquired",
+			err:            utils.ErrSocketLockFileNotAcquired,
+			underlyingErr:  errors.New("permission denied"),
+			expectedSubstr: "could not acquire lock on socket file: permission denied",
+		},
+		{
+			name:           "Socket file not overwritten",
+			err:            utils.ErrSocketFileNotOverwritten,
+			underlyingErr:  errors.New("file exists"),
+			expectedSubstr: "could not overwrite socket file: file exists",
+		},
+		{
+			name:           "Socket file listen error",
+			err:            utils.ErrSocketFileListen,
+			underlyingErr:  errors.New("address already in use"),
+			expectedSubstr: "could not listen on socket file: address already in use",
+		},
+		{
+			name:           "Socket file permissions not set",
+			err:            utils.ErrSocketFilePermissionsNotSet,
+			underlyingErr:  errors.New("chmod failed"),
+			expectedSubstr: "error setting socket file permissions: chmod failed",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := utils.MakeUnixSocketError(tt.err, tt.underlyingErr)
+			if result == nil {
+				t.Error("Expected an error but got nil")
+			}
+			if !strings.Contains(result.Error(), tt.expectedSubstr) {
+				t.Errorf("Expected error to contain %q, got %q", tt.expectedSubstr, result.Error())
+			}
+		})
+	}
+}
+
+func TestMakeWindowsSocketError(t *testing.T) {
+	err := utils.MakeWindowsSocketError()
+	if err == nil {
+		t.Error("Expected an error but got nil")
+	}
+	if err != utils.ErrWindowsNotSupported {
+		t.Errorf("Expected ErrWindowsNotSupported, got %v", err)
+	}
+	expectedMsg := "unix sockets not available on Windows"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error message %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestUnixSocketErrorConstants(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		expectedMsg string
+	}{
+		{
+			name:        "ErrSocketLockFileNotAcquired",
+			err:         utils.ErrSocketLockFileNotAcquired,
+			expectedMsg: "could not acquire lock on socket file",
+		},
+		{
+			name:        "ErrSocketFileNotOverwritten",
+			err:         utils.ErrSocketFileNotOverwritten,
+			expectedMsg: "could not overwrite socket file",
+		},
+		{
+			name:        "ErrSocketFileListen",
+			err:         utils.ErrSocketFileListen,
+			expectedMsg: "could not listen on socket file",
+		},
+		{
+			name:        "ErrSocketFilePermissionsNotSet",
+			err:         utils.ErrSocketFilePermissionsNotSet,
+			expectedMsg: "error setting socket file permissions",
+		},
+		{
+			name:        "ErrWindowsNotSupported",
+			err:         utils.ErrWindowsNotSupported,
+			expectedMsg: "unix sockets not available on Windows",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.err == nil {
+				t.Error("Error constant is nil")
+			}
+			if tt.err.Error() != tt.expectedMsg {
+				t.Errorf("Expected error message %q, got %q", tt.expectedMsg, tt.err.Error())
+			}
+		})
+	}
+}

--- a/pkg/utils/unixsock_errors_test.go
+++ b/pkg/utils/unixsock_errors_test.go
@@ -44,7 +44,6 @@ func TestMakeUnixSocketError(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -111,7 +110,6 @@ func TestUnixSocketErrorConstants(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
Added comprehensive unit tests for previously untested files:
- pkg/certificates/oser_test.go: Tests for OsWrapper ReadFile/WriteFile
- pkg/certificates/rsaer_test.go: Tests for RsaWrapper GenerateKey
- pkg/netceptor/external_backend_test.go: Tests for ExternalBackend functionality
- pkg/utils/unixsock_errors_test.go: Tests for Unix socket error utilities

All tests follow the existing codebase style using table-driven tests with proper error handling and validation.

Generated by: Claude