### PR TITLE
Add unit tests for receptorctl to improve code coverage

### DIFF
--- a/receptorctl/tests/test_cli.py
+++ b/receptorctl/tests/test_cli.py
@@ -117,9 +117,9 @@ class TestCLI:
         unit_id = work.pop("unitid")
 
         # Wait for work to complete
-        timeout_seconds = 10
+        max_retries = 10
         work_completed = False
-        for _ in range(timeout_seconds):
+        for _ in range(max_retries):
             status = node1_controller.simple_command(f"work status {unit_id}")
             if status.get("StateName") == "Succeeded" and status.get("Detail") == "exit status 0":
                 work_completed = True

--- a/receptorctl/tests/test_cli.py
+++ b/receptorctl/tests/test_cli.py
@@ -1,10 +1,13 @@
+import json
+import re
+import time
+
+import pytest
+
 from receptorctl import cli as commands
 
 # The goal is to write tests following the click documentation:
 # https://click.palletsprojects.com/en/8.0.x/testing/
-
-import pytest
-import json
 
 
 @pytest.mark.usefixtures("receptor_mesh_mesh1")
@@ -29,6 +32,36 @@ class TestCLI:
         result = invoke(commands.ping, ["node2"])
         assert result.exit_code == 0
         assert "Reply from node2 in" in result.output
+
+    def test_cmd_traceroute(self, invoke):
+        """Test traceroute command to a valid node"""
+        result = invoke(commands.traceroute, ["node2"])
+        assert result.exit_code == 0
+
+        # Verify output format: "hop_number: NodeName in TimeStr"
+        # Example: "0: node1 in 200.323µs", "1: node2 in 490.723µs"
+        lines = result.output.strip().split("\n")
+        assert len(lines) == 2, "Traceroute should produce a line for each node"
+
+        # Regex pattern: hop_number: node_name in time_value(µs|ms|ns|s)
+        pattern = r"^\d+: \S+ in [\d.]+(?:µs|ms|ns|s)$"
+
+        for i, line in enumerate(lines):
+            assert re.match(pattern, line), f"Line '{line}' does not match expected format"
+            # Verify hop number matches line index
+            hop_number = int(line.split(":")[0])
+            assert hop_number == i, f"Expected hop {i}, got {hop_number}"
+
+        # Verify the destination node appears in the last line
+        assert "node2" in lines[-1]
+
+    def test_cmd_traceroute_invalid_node(self, invoke):
+        """Test traceroute command to a non-existent node"""
+        result = invoke(commands.traceroute, ["nonexistent-node"])
+        lines = result.output.strip().split("\n")
+        assert len(lines) == 1, "Traceroute should produce a line for each node"
+        assert result.exit_code == 0
+        assert "ERROR: 1: Error no route to node from node1 in " in str(result.stderr_bytes)
 
     @pytest.mark.skip(
         reason="skip code is 0 bug related here https://github.com/ansible/receptor/issues/431"
@@ -67,6 +100,40 @@ class TestCLI:
     def test_cmd_work_list_successfully(self, invoke):
         # Require fixture with a node running work
         pass
+
+    def test_cmd_work_results_invalid_unit_id(self, invoke):
+        """Test results command with an invalid work unit ID"""
+        result = invoke(commands.work, ["results", "invalid-unit-id"])
+        assert result.exit_code != 0
+        assert result.exception is not None
+        assert "invalid-unit-id" in str(result.exception)
+
+    def test_cmd_work_results_successful(self, invoke, default_receptor_controller_socket_file):
+        node1_controller = default_receptor_controller_socket_file
+
+        # Submit a simple echo work unit
+        payload = "test-output-data"
+        work = node1_controller.submit_work("echo-uppercase", payload, node="node3")
+        unit_id = work.pop("unitid")
+
+        # Wait for work to complete
+        timeout_seconds = 10
+        work_completed = False
+        for _ in range(timeout_seconds):
+            status = node1_controller.simple_command(f"work status {unit_id}")
+            if status.get("StateName") == "Succeeded" and status.get("Detail") == "exit status 0":
+                work_completed = True
+                break
+            time.sleep(1)
+
+        assert work_completed, "Work unit timed out and never finished"
+
+        # Test the CLI results command
+        result = invoke(commands.work, ["results", unit_id])
+        assert result.exit_code == 0
+        assert payload.upper() in result.output
+
+        node1_controller.close()
 
     def test_cmd_work_invalid(self, invoke):
         result = invoke(commands.work, ["cancel", "foobar"])

--- a/receptorctl/tests/test_connection.py
+++ b/receptorctl/tests/test_connection.py
@@ -1,4 +1,10 @@
+import os
+import tempfile
+
 import pytest
+import yaml
+
+from receptorctl.socket_interface import ReceptorControl
 
 
 @pytest.mark.usefixtures("receptor_mesh_mesh1")
@@ -67,3 +73,87 @@ class TestReceptorCtlConnection:
             )
             - status.keys()
         )
+
+
+class TestReceptorCtlConfig:
+    @pytest.mark.parametrize(
+        "config_data,expected",
+        [
+            pytest.param(
+                {
+                    "name": "happy-path",
+                    "rootcas": "/path/to/rootcas.crt",
+                    "key": "/path/to/key.pem",
+                    "cert": "/path/to/cert.pem",
+                    "insecureskipverify": True,
+                },
+                {
+                    "_rootcas": "/path/to/rootcas.crt",
+                    "_key": "/path/to/key.pem",
+                    "_cert": "/path/to/cert.pem",
+                    "_insecureskipverify": True,
+                },
+                id="happy-path",
+            ),
+            pytest.param(
+                {"name": "only-root-ca", "rootcas": "/path/to/rootcas.crt"},
+                {
+                    "_rootcas": "/path/to/rootcas.crt",
+                    "_key": None,
+                    "_cert": None,
+                    "_insecureskipverify": False,
+                },
+                id="only-root-ca",
+            ),
+            pytest.param(
+                {"name": "only-client-cert", "cert": "/path/to/cert.pem"},
+                {
+                    "_rootcas": None,
+                    "_key": None,
+                    "_cert": "/path/to/cert.pem",
+                    "_insecureskipverify": False,
+                },
+                id="only-client-cert",
+            ),
+            pytest.param(
+                {},
+                {"_rootcas": None, "_key": None, "_cert": None, "_insecureskipverify": False},
+                id="empty-config-data",
+            ),
+        ],
+    )
+    def test_readconfig(self, config_data, expected):
+        """Test readconfig with various configuration scenarios"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml_data = [{"tls-client": config_data}] if config_data else []
+            yaml.dump(yaml_data, f)
+            config_file = f.name
+        controller = ReceptorControl("unix:///tmp/test.sock")
+        controller.readconfig(config_file, config_data.get("name", None))
+
+        try:
+            for key, value in expected.items():
+                attr = getattr(controller, key)
+                assert attr == value, f"Expected {key}={value}, got {attr}"
+        finally:
+            if os.path.exists(config_file):
+                os.unlink(config_file)
+
+    def test_readconfig_file_not_found(self):
+        """Test readconfig with non-existent file"""
+        controller = ReceptorControl("unix:///tmp/test.sock")
+        with pytest.raises(FileNotFoundError):
+            controller.readconfig("/nonexistent/path/config.yaml", "test-client")
+
+    def test_readconfig_malformed_yaml(self):
+        """Test readconfig with malformed YAML"""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("this is not: valid: yaml: content:\n  - broken")
+            config_file = f.name
+
+        try:
+            controller = ReceptorControl("unix:///tmp/test.sock")
+            with pytest.raises(yaml.YAMLError):
+                controller.readconfig(config_file, "test-client")
+        finally:
+            os.unlink(config_file)


### PR DESCRIPTION
## Summary
This PR adds comprehensive unit tests for receptorctl CLI commands and configuration functionality to improve code coverage:

- **CLI Tests (test_cli.py)**:
  - `test_cmd_traceroute`: Tests traceroute command with valid node, verifies output format
  - `test_cmd_traceroute_invalid_node`: Tests traceroute with non-existent node, verifies error handling
  - `test_cmd_work_results_invalid_unit_id`: Tests work results command with invalid unit ID
  - `test_cmd_work_results_successful`: Tests successful work unit submission and results retrieval

- **Configuration Tests (test_connection.py)**:
  - New `TestReceptorCtlConfig` class with `readconfig` tests
  - Parametrized tests for various TLS configuration scenarios (full config, partial config, empty config)
  - Tests for error handling (missing file, malformed YAML)

## Test Coverage
All new tests pass successfully:
- 4 new CLI command tests
- 6 new configuration tests (4 parametrized scenarios + 2 error cases)

## Changes
- Added missing imports and test fixtures
- Fixed test organization by moving config tests out of the mesh fixture class
- All tests follow existing patterns and use proper pytest fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)