### PR TITLE
Fix unhandled errors in test files

### DIFF
--- a/pkg/backends/websocket_interop_test.go
+++ b/pkg/backends/websocket_interop_test.go
@@ -114,7 +114,8 @@ func TestWebsocketExternalInterop(t *testing.T) {
 	}
 
 	// Wait for the nodes to establish routing to each other
-	timeout, _ := context.WithTimeout(context.Background(), 2*time.Second)
+	timeout, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 	for {
 		if timeout.Err() != nil {
 			t.Fatal(timeout.Err())

--- a/pkg/certificates/ca_test.go
+++ b/pkg/certificates/ca_test.go
@@ -353,8 +353,11 @@ IemSZj8QaR2JNPwXEbBEh8uPDhNvPBQFrw==
 }
 
 // Incompatible certificate with receptor as it is missing `DNSNames`, `IPAddresses`, `NodeIDs` fields.
-func setupBadCertificateRequestPEMData() []byte {
-	privateKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+func setupBadCertificateRequestPEMData() ([]byte, error) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
 	certRequestTemplate := x509.CertificateRequest{
 		Subject: pkix.Name{
 			CommonName:   "Example",
@@ -362,13 +365,16 @@ func setupBadCertificateRequestPEMData() []byte {
 		},
 		SignatureAlgorithm: x509.SHA256WithRSA,
 	}
-	certRequestBytes, _ := x509.CreateCertificateRequest(rand.Reader, &certRequestTemplate, privateKey)
+	certRequestBytes, err := x509.CreateCertificateRequest(rand.Reader, &certRequestTemplate, privateKey)
+	if err != nil {
+		return nil, err
+	}
 	certRequestPEM := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE REQUEST",
 		Bytes: certRequestBytes,
 	})
 
-	return certRequestPEM
+	return certRequestPEM, nil
 }
 
 func setupGoodCertificateRequestRsaPrivateKey() (*rsa.PrivateKey, error) {
@@ -641,7 +647,10 @@ func TestCreateCAValid(t *testing.T) {
 					},
 				)
 
-			got, _ := certificates.CreateCA(tt.args.opts, mockRsa)
+			got, err := certificates.CreateCA(tt.args.opts, mockRsa)
+			if err != nil {
+				t.Fatalf("CreateCA() unexpected error = %v", err)
+			}
 			if !reflect.DeepEqual(got.PrivateKey, tt.want.PrivateKey) {
 				t.Errorf("CreateCA() Private Key got = %+v, want = %+v", got.PrivateKey, tt.want.PrivateKey)
 

--- a/pkg/certificates/cli_test.go
+++ b/pkg/certificates/cli_test.go
@@ -530,10 +530,14 @@ func TestSignReq(t *testing.T) {
 						Return([]byte{}, nil).
 						AnyTimes()
 				case "No names in Req file":
+					badCertReqPEM, err := setupBadCertificateRequestPEMData()
+					if err != nil {
+						t.Fatalf("Failed to setup bad certificate request PEM data: %v", err)
+					}
 					o.
 						EXPECT().
 						ReadFile(gomock.Eq(negativeReqPath)).
-						Return(setupBadCertificateRequestPEMData(), nil).
+						Return(badCertReqPEM, nil).
 						AnyTimes()
 				}
 			default:

--- a/pkg/controlsvc/ping_test.go
+++ b/pkg/controlsvc/ping_test.go
@@ -113,7 +113,10 @@ func TestPingControlFunc(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.expectedCalls()
 
-			cfr, _ := pingCommand.ControlFunc(context.Background(), mockNetceptor, mockControlFunc)
+			cfr, funcErr := pingCommand.ControlFunc(context.Background(), mockNetceptor, mockControlFunc)
+			if funcErr != nil {
+				t.Errorf("ControlFunc returned unexpected error: %v", funcErr)
+			}
 			err, ok := cfr["Error"]
 
 			if testCase.expectedError && testCase.errorMessage != err {

--- a/pkg/controlsvc/traceroute_test.go
+++ b/pkg/controlsvc/traceroute_test.go
@@ -109,7 +109,10 @@ func TestTracerouteControlFunc(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			testCase.expectedCalls()
 
-			cfr, _ := tracerouteCommand.ControlFunc(context.Background(), mockNetceptor, mockControlFunc)
+			cfr, funcErr := tracerouteCommand.ControlFunc(context.Background(), mockNetceptor, mockControlFunc)
+			if funcErr != nil {
+				t.Errorf("ControlFunc returned unexpected error: %v", funcErr)
+			}
 			err, ok := cfr["Error"]
 
 			if testCase.expectedError && testCase.errorMessage != err {

--- a/pkg/netceptor/adapter_test.go
+++ b/pkg/netceptor/adapter_test.go
@@ -253,7 +253,13 @@ func TestQuicConnAdapterAcceptStream(t *testing.T) {
 			adapter := &netceptor.QuicListenerAdapter{Listener: listener}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			conn, _ := adapter.Accept(ctx)
+			conn, err := adapter.Accept(ctx)
+			if err != nil {
+				t.Errorf("Failed to accept connection: %v", err)
+				close(serverChan)
+
+				return
+			}
 			serverChan <- conn
 		}()
 
@@ -289,7 +295,11 @@ func TestQuicConnAdapterAcceptStream(t *testing.T) {
 			adapter := &netceptor.QuicListenerAdapter{Listener: listener}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
-			serverConn, _ = adapter.Accept(ctx)
+			var err error
+			serverConn, err = adapter.Accept(ctx)
+			if err != nil {
+				t.Errorf("Failed to accept connection: %v", err)
+			}
 		}()
 
 		// Create client but don't open stream

--- a/pkg/netceptor/conn_test.go
+++ b/pkg/netceptor/conn_test.go
@@ -813,7 +813,10 @@ func TestNeceptorListen(t *testing.T) {
 		ctx := context.Background()
 		mockNetC := netceptor.New(ctx, "node1")
 		wantErr := errors.New("service node1 is already listening")
-		_, _ = mockNetC.Listen("node1", &tls.Config{})
+		_, err := mockNetC.Listen("node1", &tls.Config{})
+		if err != nil {
+			t.Fatalf("Failed to create first listener: %v", err)
+		}
 		_, gotErr := mockNetC.Listen("node1", &tls.Config{})
 		if gotErr.Error() != wantErr.Error() {
 			t.Errorf("Wanted %v, got %v", wantErr, gotErr)
@@ -825,7 +828,10 @@ func TestNeceptorListen(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		mockNetC := netceptor.New(ctx, "nodecc")
-		_, _ = mockNetC.Listen("nodecc", &tls.Config{})
+		_, err := mockNetC.Listen("nodecc", &tls.Config{})
+		if err != nil {
+			t.Fatalf("Failed to create listener: %v", err)
+		}
 		// Assert cancelling netceptor context doesn't create panic
 		assert.NotPanics(t, func() { time.AfterFunc(500*time.Millisecond, cancel) })
 	})

--- a/pkg/netceptor/netceptor_test.go
+++ b/pkg/netceptor/netceptor_test.go
@@ -301,6 +301,8 @@ func TestLotsOfPings(t *testing.T) {
 					buf := []byte("test")
 					rAddr := sender.NewAddr(recipient.nodeID, "ping")
 					for {
+						// Ignore write errors - routes may not be established yet.
+						// The loop will keep retrying until the ping succeeds.
 						_, _ = pc.WriteTo(buf, rAddr)
 						select {
 						case <-ctx.Done():
@@ -848,7 +850,10 @@ func TestSetMaxConnectionIdleTime(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	time, _ := time.ParseDuration("60s")
+	time, err := time.ParseDuration("60s")
+	if err != nil {
+		t.Fatalf("Failed to parse duration: %v", err)
+	}
 	if node.MaxConnectionIdleTime() != time {
 		t.Fatal("setter behaved incorrectly")
 	}
@@ -967,6 +972,9 @@ func TestTracerCreatesNonEmptyFiles(t *testing.T) {
 	// Create a netceptor instance and attempt to dial a service that does not exist
 	node1 := New(context.Background(), "node1")
 
+	// Dial error is expected and ignored - the test only verifies qlog file creation.
+	// The service "testsvc" does not exist, so the dial may fail, but qlog files
+	// should still be created during the connection attempt.
 	conn, _ := node1.Dial("node1", "testsvc", nil)
 	if conn != nil {
 		conn.Close()

--- a/pkg/netceptor/tlsconfig_test.go
+++ b/pkg/netceptor/tlsconfig_test.go
@@ -331,9 +331,12 @@ func TestVerifyPinnedFingerprint(t *testing.T) {
 		t.Fatalf("Failed to read cert: %v", err)
 	}
 
-	block, _ := pem.Decode(certPEMBytes)
+	block, rest := pem.Decode(certPEMBytes)
 	if block == nil {
 		t.Fatal("Failed to decode PEM certificate")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("Unexpected remaining bytes after PEM decode: %d bytes", len(rest))
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
@@ -457,7 +460,10 @@ func TestHashAlgorithms(t *testing.T) {
 					t.Errorf("expected hash length %d, got %d", tt.expectedHashLen, len(hash))
 				}
 				// Verify hash is deterministic.
-				hash2, _ := computeHashForFingerprint(certData, tt.fingerprintLen, algorithms)
+				hash2, valid2 := computeHashForFingerprint(certData, tt.fingerprintLen, algorithms)
+				if !valid2 {
+					t.Error("second hash computation should be valid")
+				}
 				if !bytes.Equal(hash, hash2) {
 					t.Error("hash computation should be deterministic")
 				}
@@ -566,9 +572,12 @@ func TestVerifyReceptorNodeID(t *testing.T) {
 		t.Fatalf("Failed to read cert: %v", err)
 	}
 
-	block, _ := pem.Decode(certPEMBytes)
+	block, rest := pem.Decode(certPEMBytes)
 	if block == nil {
 		t.Fatal("Failed to decode PEM certificate")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("Unexpected remaining bytes after PEM decode: %d bytes", len(rest))
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
@@ -633,9 +642,12 @@ func TestAddIntermediateCerts(t *testing.T) {
 		t.Fatalf("Failed to read cert: %v", err)
 	}
 
-	block, _ := pem.Decode(certPEMBytes)
+	block, rest := pem.Decode(certPEMBytes)
 	if block == nil {
 		t.Fatal("Failed to decode PEM certificate")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("Unexpected remaining bytes after PEM decode: %d bytes", len(rest))
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
@@ -681,9 +693,12 @@ func TestReceptorVerifyFunc(t *testing.T) {
 		t.Fatalf("Failed to read cert: %v", err)
 	}
 
-	block, _ := pem.Decode(certPEMBytes)
+	block, rest := pem.Decode(certPEMBytes)
 	if block == nil {
 		t.Fatal("Failed to decode PEM certificate")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("Unexpected remaining bytes after PEM decode: %d bytes", len(rest))
 	}
 
 	rootCAs := x509.NewCertPool()

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -52,17 +52,32 @@ nnG0JqlerSVvSPSiZ2kdn4OwzV2eA3Gj3uyTSGsjjoj82bhhRwKaSWmUh+AJByQ9
 kE6r/6za1Hvm+i/mz8f1cTUxFjF5pKzrprNRz5NMzs6NkQ0pg+mq5CNzav1ATSyv
 Bdt96MbGrC0=
 -----END CERTIFICATE-----`
-	goodBlock, _ := pem.Decode([]byte(testGoodCertPEMData))
-	testGoodCert, _ := x509.ParseCertificate(goodBlock.Bytes)
+	goodBlock, rest := pem.Decode([]byte(testGoodCertPEMData))
+	if len(rest) != 0 {
+		t.Fatalf("Unexpected remaining bytes after PEM decode: %d bytes", len(rest))
+	}
+	testGoodCert, err := x509.ParseCertificate(goodBlock.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
 
 	extSubjectAltName := pkix.Extension{}
 	extSubjectAltName.Id = asn1.ObjectIdentifier{2, 5, 29, 17}
 	extSubjectAltName.Critical = false
 
-	testUglyCert, _ := x509.ParseCertificate(goodBlock.Bytes)
+	testUglyCert, err := x509.ParseCertificate(goodBlock.Bytes)
+	if err != nil {
+		t.Fatalf("Failed to parse certificate: %v", err)
+	}
 
-	pi, _ := new(big.Int).SetString("3.14159", 10)
-	extSubjectAltName.Value, _ = asn1.Marshal(pi)
+	pi, ok := new(big.Int).SetString("314159", 10)
+	if !ok {
+		t.Fatalf("Failed to parse big.Int from string")
+	}
+	extSubjectAltName.Value, err = asn1.Marshal(pi)
+	if err != nil {
+		t.Fatalf("Failed to marshal ASN.1 value: %v", err)
+	}
 
 	testUglyCert.Extensions = append(testUglyCert.Extensions, extSubjectAltName)
 	var uglyWant1 []string

--- a/pkg/utils/sysinfo_test.go
+++ b/pkg/utils/sysinfo_test.go
@@ -17,10 +17,16 @@ func TestGetSysCPUCount(t *testing.T) {
 	}
 
 	if runtime.GOOS == "linux" {
-		commandOutput, _ := exec.Command("nproc").CombinedOutput()
+		commandOutput, err := exec.Command("nproc").CombinedOutput()
+		if err != nil {
+			t.Fatalf("Failed to execute nproc command: %v", err)
+		}
 
 		commandOutputWithout := strings.TrimSpace(string(commandOutput))
-		want, _ := strconv.Atoi(commandOutputWithout)
+		want, err := strconv.Atoi(commandOutputWithout)
+		if err != nil {
+			t.Fatalf("Failed to parse CPU count: %v", err)
+		}
 
 		if got != want {
 			t.Errorf("Expected CPU count: %d, got %d\n", want, got)
@@ -35,10 +41,16 @@ func TestGetSysMemoryMiB(t *testing.T) {
 	}
 
 	if runtime.GOOS == "linux" {
-		commandOutput, _ := exec.Command("sed", "-n", "s/^MemTotal:[[:space:]]*\\([[:digit:]]*\\).*/\\1/p", "/proc/meminfo").CombinedOutput()
+		commandOutput, err := exec.Command("sed", "-n", "s/^MemTotal:[[:space:]]*\\([[:digit:]]*\\).*/\\1/p", "/proc/meminfo").CombinedOutput()
+		if err != nil {
+			t.Fatalf("Failed to execute sed command: %v", err)
+		}
 
 		commandOutputWithout := strings.TrimSpace(string(commandOutput))
-		wantKb, _ := strconv.ParseUint(commandOutputWithout, 10, 64)
+		wantKb, err := strconv.ParseUint(commandOutputWithout, 10, 64)
+		if err != nil {
+			t.Fatalf("Failed to parse memory size: %v", err)
+		}
 
 		want := wantKb / 1024
 		if got != want {


### PR DESCRIPTION
AAP-60060

Fixes unhandled error returns in test files across the codebase.

**Changes:**
- Handle PEM decode rest bytes and hash computation validity flags in TLS config tests
- Fix big.Int parsing to use integer string instead of decimal
- Fix variable shadowing in adapter test goroutine
- Handle context cancellation and other error returns in various test files


🤖 Generated with [Claude Code](https://claude.com/claude-code)