### PR TITLE
Remove unused parameters from config functions

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -74,7 +74,7 @@ func PrintPhaseErrorMessage(configName string, phase string, err error) {
 	fmt.Printf("ERROR: %s for %s on %s phase\n", err, configName, phase)
 }
 
-func ParseReceptorConfig(configFile string) (*ReceptorConfig, error) {
+func ParseReceptorConfig() (*ReceptorConfig, error) {
 	var receptorConfig ReceptorConfig
 	err := viper.Unmarshal(&receptorConfig)
 	if err != nil {
@@ -84,7 +84,7 @@ func ParseReceptorConfig(configFile string) (*ReceptorConfig, error) {
 	return &receptorConfig, nil
 }
 
-func ParseCertificatesConfig(configFile string) (*CertificatesConfig, error) {
+func ParseCertificatesConfig() (*CertificatesConfig, error) {
 	var certifcatesConfig CertificatesConfig
 	err := viper.Unmarshal(&certifcatesConfig)
 	if err != nil {
@@ -94,7 +94,7 @@ func ParseCertificatesConfig(configFile string) (*CertificatesConfig, error) {
 	return &certifcatesConfig, nil
 }
 
-func ParseBackendConfig(configFile string) (*BackendConfig, error) {
+func ParseBackendConfig() (*BackendConfig, error) {
 	var backendConfig BackendConfig
 	err := viper.Unmarshal(&backendConfig)
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,7 +106,7 @@ func initConfig() {
 	}
 }
 
-func handleRootCommand(cmd *cobra.Command, args []string) {
+func handleRootCommand(_ *cobra.Command, _ []string) {
 	if version {
 		fmt.Println(receptorVersion.Version)
 		os.Exit(0)
@@ -117,19 +117,19 @@ func handleRootCommand(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	receptorConfig, err := ParseReceptorConfig(cfgFile)
+	receptorConfig, err := ParseReceptorConfig()
 	if err != nil {
 		fmt.Printf(errMsgUnableToDecode, err)
 		os.Exit(1)
 	}
 
-	certifcatesConfig, err := ParseCertificatesConfig(cfgFile)
+	certifcatesConfig, err := ParseCertificatesConfig()
 	if err != nil {
 		fmt.Printf(errMsgUnableToDecode, err)
 		os.Exit(1)
 	}
 
-	backendConfig, err = ParseBackendConfig(cfgFile)
+	backendConfig, err = ParseBackendConfig()
 	if err != nil {
 		fmt.Printf(errMsgUnableToDecode, err)
 		os.Exit(1)


### PR DESCRIPTION
AAP-60060

## Summary
- Remove unused `configFile` parameter from `ParseReceptorConfig`, `ParseCertificatesConfig`, and `ParseBackendConfig` in `cmd/config.go`
- These functions use `viper.Unmarshal()` which doesn't require the `configFile` parameter
- Mark unused `cmd` and `args` parameters in `handleRootCommand` with underscore in `cmd/root.go`
- Update all call sites to match new signatures

## Changes
- **cmd/config.go**: Removed unused `configFile` parameter from three config parsing functions (lines 77, 87, 97)
- **cmd/root.go**: Marked unused parameters with `_` in `handleRootCommand` (line 109) and updated function calls (lines 120, 126, 132)

🤖 Generated with [Claude Code](https://claude.com/claude-code)