### PR TITLE
Test Coverage for pkg/netceptor/firewall_rules.go

### DIFF
--- a/pkg/netceptor/firewall_rules.go
+++ b/pkg/netceptor/firewall_rules.go
@@ -89,7 +89,7 @@ func (frd FirewallRuleData) ParseFirewallRule() (FirewallRuleFunc, error) {
 		case "toservice":
 			fr.ToService = val
 		default:
-			return nil, fmt.Errorf("invalid filewall rule. unknown key: %s", key)
+			return nil, fmt.Errorf("invalid firewall rule. unknown key: %s", key)
 		}
 	}
 

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -429,11 +429,11 @@ func TestRegexCompare(t *testing.T) {
 
 func TestStringCompare(t *testing.T){
 	tests := []struct {
-		name string
-		field string
-		value string
-		wantErr bool
-		testCases []struct {
+		name 		string
+		field 		string
+		value 		string
+		wantErr 	bool
+		testCases 	[]struct {
 			desc string
 			data *MessageData
 			wantMatch bool

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -225,19 +225,19 @@ func TestParseFirewallRules(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ParseFirewallRules() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			
+
 			// Check error message
 			if tt.wantErrContains != "" && err != nil {
 				if !strings.Contains(err.Error(), tt.wantErrContains) {
 					t.Errorf("ParseFirewallRules() error = %v, want error containing %q", err, tt.wantErrContains)
 				}
 			}
-			
+
 			// Check number of rules
 			if len(rules) != tt.wantCount {
 				t.Errorf("ParseFirewallRules() returned %d rules, want %d", len(rules), tt.wantCount)
 			}
-			
+
 			// Run test cases
 			for _, tc := range tt.testCases {
 				got := rules[tc.ruleIndex](tc.data)
@@ -251,11 +251,11 @@ func TestParseFirewallRules(t *testing.T) {
 
 func TestRegexCompare(t *testing.T) {
 	tests := []struct {
-		name            string
-		field           string
-		value           string
-		wantErr         bool
-		testCases       []struct {
+		name      string
+		field     string
+		value     string
+		wantErr   bool
+		testCases []struct {
 			desc      string
 			data      *MessageData
 			wantMatch bool
@@ -263,34 +263,34 @@ func TestRegexCompare(t *testing.T) {
 	}{
 		// Test with invalid regex patterns
 		{
-			name: "unclosed bracket",
-			field: "fromnode",
-			value: "/[unclosed/",
+			name:    "unclosed bracket",
+			field:   "fromnode",
+			value:   "/[unclosed/",
 			wantErr: true,
 		},
 		{
-			name: "invalid escape",
-			field: "fromnode",
-			value: "/node\\k/",
+			name:    "invalid escape",
+			field:   "fromnode",
+			value:   "/node\\k/",
 			wantErr: true,
 		},
 		{
-			name: "bad repetition range",
-			field: "fromnode",
-			value: "/node{5,2}/",
+			name:    "bad repetition range",
+			field:   "fromnode",
+			value:   "/node{5,2}/",
 			wantErr: true,
 		},
 		{
-			name: "not enclosed in slashes",
-			field: "fromnode",
-			value: "node.*",
+			name:    "not enclosed in slashes",
+			field:   "fromnode",
+			value:   "node.*",
 			wantErr: true,
 		},
 		// Test with empty regex pattern string
 		{
-			name: "matches only empty strings",
-			field: "toservice",
-			value: "//",
+			name:    "matches only empty strings",
+			field:   "toservice",
+			value:   "//",
 			wantErr: false,
 			testCases: []struct {
 				desc      string
@@ -298,22 +298,22 @@ func TestRegexCompare(t *testing.T) {
 				wantMatch bool
 			}{
 				{
-					desc: "matches empty string",
-					data: &MessageData{ToService: ""},
+					desc:      "matches empty string",
+					data:      &MessageData{ToService: ""},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match non-empty string",
-					data: &MessageData{ToService: "343.236"},
+					desc:      "does not match non-empty string",
+					data:      &MessageData{ToService: "343.236"},
 					wantMatch: false,
 				},
 			},
 		},
 		// Test with complex regex patterns
 		{
-			name: "exactly 3 digits",
-			field: "fromnode",
-			value: "/node-[0-9]{3}/",
+			name:    "exactly 3 digits",
+			field:   "fromnode",
+			value:   "/node-[0-9]{3}/",
 			wantErr: false,
 			testCases: []struct {
 				desc      string
@@ -321,27 +321,27 @@ func TestRegexCompare(t *testing.T) {
 				wantMatch bool
 			}{
 				{
-					desc: "matches node-123",
-					data: &MessageData{FromNode: "node-123"},
+					desc:      "matches node-123",
+					data:      &MessageData{FromNode: "node-123"},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match node-12",
-					data: &MessageData{FromNode: "node-12"},
+					desc:      "does not match node-12",
+					data:      &MessageData{FromNode: "node-12"},
 					wantMatch: false,
 				},
 				{
-					desc: "does not match node-1234",
-					data: &MessageData{FromNode: "node-1234"},
+					desc:      "does not match node-1234",
+					data:      &MessageData{FromNode: "node-1234"},
 					wantMatch: false,
 				},
 			},
 		},
 		// Test regex matching with special characters
 		{
-			name: "escaped dots for IP address",
-			field: "fromnode",
-			value: "/192\\.168\\.1\\.1/",
+			name:    "escaped dots for IP address",
+			field:   "fromnode",
+			value:   "/192\\.168\\.1\\.1/",
 			wantErr: false,
 			testCases: []struct {
 				desc      string
@@ -349,57 +349,57 @@ func TestRegexCompare(t *testing.T) {
 				wantMatch bool
 			}{
 				{
-					desc: "matches exact IP",
-					data: &MessageData{FromNode: "192.168.1.1"},
+					desc:      "matches exact IP",
+					data:      &MessageData{FromNode: "192.168.1.1"},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match with other chars",
-					data: &MessageData{FromNode: "192X168Y1Z1"},
+					desc:      "does not match with other chars",
+					data:      &MessageData{FromNode: "192X168Y1Z1"},
 					wantMatch: false,
 				},
 			},
 		},
 		{
-			name: "escaped parentheses",
-			field: "fromservice",
-			value: "/api-v2\\.0\\(prod\\)/",
+			name:    "escaped parentheses",
+			field:   "fromservice",
+			value:   "/api-v2\\.0\\(prod\\)/",
 			wantErr: false,
 			testCases: []struct {
-				desc string
-				data *MessageData
+				desc      string
+				data      *MessageData
 				wantMatch bool
 			}{
 				{
-					desc: "matches api-v2.0(prod)",
-					data: &MessageData{FromService: "api-v2.0(prod)"},
+					desc:      "matches api-v2.0(prod)",
+					data:      &MessageData{FromService: "api-v2.0(prod)"},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match without parentheses",
-					data: &MessageData{FromService: "api-v2.0"},
+					desc:      "does not match without parentheses",
+					data:      &MessageData{FromService: "api-v2.0"},
 					wantMatch: false,
 				},
 			},
 		},
 		{
-			name: "escaped brackets",
-			field: "tonode",
-			value: "/server\\[prod\\]/",
+			name:    "escaped brackets",
+			field:   "tonode",
+			value:   "/server\\[prod\\]/",
 			wantErr: false,
 			testCases: []struct {
-				desc string
-				data *MessageData
+				desc      string
+				data      *MessageData
 				wantMatch bool
 			}{
 				{
-					desc: "matches server[prod]",
-					data: &MessageData{ToNode: "server[prod]"},
+					desc:      "matches server[prod]",
+					data:      &MessageData{ToNode: "server[prod]"},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match server(prod)",
-					data: &MessageData{ToNode: "server(prod)"},
+					desc:      "does not match server(prod)",
+					data:      &MessageData{ToNode: "server(prod)"},
 					wantMatch: false,
 				},
 			},
@@ -413,7 +413,7 @@ func TestRegexCompare(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("regexCompare() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			
+
 			// Run test cases
 			if !tt.wantErr && comp != nil {
 				for _, tc := range tt.testCases {
@@ -427,138 +427,137 @@ func TestRegexCompare(t *testing.T) {
 	}
 }
 
-func TestStringCompare(t *testing.T){
+func TestStringCompare(t *testing.T) {
 	tests := []struct {
-		name 		string
-		field 		string
-		value 		string
-		wantErr 	bool
-		testCases 	[]struct {
-			desc string
-			data *MessageData
+		name      string
+		field     string
+		value     string
+		wantErr   bool
+		testCases []struct {
+			desc      string
+			data      *MessageData
 			wantMatch bool
 		}
 	}{
 		// Test with empty value string
 		{
-			name: "empty value string",
-			field: "fromnode",
-			value: "",
+			name:    "empty value string",
+			field:   "fromnode",
+			value:   "",
 			wantErr: false,
-			testCases: []struct{
-				desc string
-				data *MessageData
+			testCases: []struct {
+				desc      string
+				data      *MessageData
 				wantMatch bool
 			}{
 				{
-					desc: "matches empty FromNode",
-					data: &MessageData{FromNode: ""},
+					desc:      "matches empty FromNode",
+					data:      &MessageData{FromNode: ""},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match empty FromNode",
-					data: &MessageData{FromNode: "node-1"},
+					desc:      "does not match empty FromNode",
+					data:      &MessageData{FromNode: "node-1"},
 					wantMatch: false,
 				},
 			},
 		},
 		// Test with empty field string
 		{
-			name: "empty field string",
-			field: "",
-			value: "tonode",
+			name:    "empty field string",
+			field:   "",
+			value:   "tonode",
 			wantErr: true,
-
 		},
 		// Test with empty field and empty value string
 		{
-			name: "empty field and value string",
-			field: "",
-			value: "",
+			name:    "empty field and value string",
+			field:   "",
+			value:   "",
 			wantErr: true,
 		},
 		// Test with special characters in field string
 		{
-			name: "special characters in field string",
-			field: "toservice!",
-			value: "production",
+			name:    "special characters in field string",
+			field:   "toservice!",
+			value:   "production",
 			wantErr: true,
 		},
 		// Test with special characters in value string
 		{
-			name: "special characters in value string",
-			field: "tonode",
-			value: "node-123&",
+			name:    "special characters in value string",
+			field:   "tonode",
+			value:   "node-123&",
 			wantErr: false,
-			testCases: []struct{
-				desc string
-				data *MessageData
+			testCases: []struct {
+				desc      string
+				data      *MessageData
 				wantMatch bool
 			}{
 				{
-					desc: "matches value with special characters",
-					data: &MessageData{ToNode: "node-123&"},
+					desc:      "matches value with special characters",
+					data:      &MessageData{ToNode: "node-123&"},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match value with special characters",
-					data: &MessageData{ToNode: "node123"},
+					desc:      "does not match value with special characters",
+					data:      &MessageData{ToNode: "node123"},
 					wantMatch: false,
 				},
 			},
 		},
 		// Test mixed case characters
 		{
-			name: "mixed cases in field string",
-			field: "ToService",
-			value: "Prod-123",
+			name:    "mixed cases in field string",
+			field:   "ToService",
+			value:   "Prod-123",
 			wantErr: false,
-			testCases: []struct{
-				desc string
-				data *MessageData
+			testCases: []struct {
+				desc      string
+				data      *MessageData
 				wantMatch bool
 			}{
 				{
-					desc: "matches field with mixed case characters",
-					data: &MessageData{ToService: "Prod-123"},
+					desc:      "matches field with mixed case characters",
+					data:      &MessageData{ToService: "Prod-123"},
 					wantMatch: true,
 				},
 				{
-					desc: "does not match value with lower-case characters",
-					data: &MessageData{ToService: "prod-123"},
+					desc:      "does not match value with lower-case characters",
+					data:      &MessageData{ToService: "prod-123"},
 					wantMatch: false,
 				},
 			},
 		},
 		// Test uppercase characters
 		{
-			name: "upper case in field string",
-			field: "FROMSERVICE",
-			value: "dev.83",
+			name:    "upper case in field string",
+			field:   "FROMSERVICE",
+			value:   "dev.83",
 			wantErr: false,
-			testCases: []struct{
-				desc string
-				data *MessageData
+			testCases: []struct {
+				desc      string
+				data      *MessageData
 				wantMatch bool
 			}{
 				{
-					desc: "matches field with upper-case characters",
-					data: &MessageData{FromService: "dev.83"},
+					desc:      "matches field with upper-case characters",
+					data:      &MessageData{FromService: "dev.83"},
 					wantMatch: true,
 				},
 			},
 		},
 		// Test unknown field name
 		{
-			name: "unknown field name",
-			field: "unknown",
-			value: "node-85",
+			name:    "unknown field name",
+			field:   "unknown",
+			value:   "node-85",
 			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T){
+		t.Run(tt.name, func(t *testing.T) {
 			comp, err := stringCompare(tt.field, tt.value)
 			// Check error expectations
 			if (err != nil) != tt.wantErr {

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -5,6 +5,19 @@ import (
 	"testing"
 )
 
+type firewallRuleTestCase struct {
+	desc      string
+	ruleIndex int
+	data      *MessageData
+	want      FirewallResult
+}
+
+type compareTestCase struct {
+	desc      string
+	data      *MessageData
+	wantMatch bool
+}
+
 func TestFirewallRules(t *testing.T) {
 	var frd FirewallRuleData
 
@@ -92,12 +105,7 @@ func TestParseFirewallRules(t *testing.T) {
 		wantErr         bool
 		wantErrContains string
 		wantCount       int
-		testCases       []struct {
-			desc      string
-			ruleIndex int
-			data      *MessageData
-			want      FirewallResult
-		}
+		testCases       []firewallRuleTestCase
 	}{
 		// Test with empty rules slice
 		{
@@ -117,12 +125,7 @@ func TestParseFirewallRules(t *testing.T) {
 			},
 			wantErr:   false,
 			wantCount: 1,
-			testCases: []struct {
-				desc      string
-				ruleIndex int
-				data      *MessageData
-				want      FirewallResult
-			}{
+			testCases: []firewallRuleTestCase{
 				{
 					desc:      "rule 0 accepts matching node1",
 					ruleIndex: 0,
@@ -152,12 +155,7 @@ func TestParseFirewallRules(t *testing.T) {
 			},
 			wantErr:   false,
 			wantCount: 2,
-			testCases: []struct {
-				desc      string
-				ruleIndex int
-				data      *MessageData
-				want      FirewallResult
-			}{
+			testCases: []firewallRuleTestCase{
 				{
 					desc:      "rule 0 accepts matching node1",
 					ruleIndex: 0,
@@ -255,11 +253,7 @@ func TestRegexCompare(t *testing.T) {
 		field     string
 		value     string
 		wantErr   bool
-		testCases []struct {
-			desc      string
-			data      *MessageData
-			wantMatch bool
-		}
+		testCases []compareTestCase
 	}{
 		// Test with invalid regex patterns
 		{
@@ -292,11 +286,7 @@ func TestRegexCompare(t *testing.T) {
 			field:   "toservice",
 			value:   "//",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches empty string",
 					data:      &MessageData{ToService: ""},
@@ -315,11 +305,7 @@ func TestRegexCompare(t *testing.T) {
 			field:   "fromnode",
 			value:   "/node-[0-9]{3}/",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches node-123",
 					data:      &MessageData{FromNode: "node-123"},
@@ -343,11 +329,7 @@ func TestRegexCompare(t *testing.T) {
 			field:   "fromnode",
 			value:   "/192\\.168\\.1\\.1/",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches exact IP",
 					data:      &MessageData{FromNode: "192.168.1.1"},
@@ -365,11 +347,7 @@ func TestRegexCompare(t *testing.T) {
 			field:   "fromservice",
 			value:   "/api-v2\\.0\\(prod\\)/",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches api-v2.0(prod)",
 					data:      &MessageData{FromService: "api-v2.0(prod)"},
@@ -387,11 +365,7 @@ func TestRegexCompare(t *testing.T) {
 			field:   "tonode",
 			value:   "/server\\[prod\\]/",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches server[prod]",
 					data:      &MessageData{ToNode: "server[prod]"},
@@ -433,11 +407,7 @@ func TestStringCompare(t *testing.T) {
 		field     string
 		value     string
 		wantErr   bool
-		testCases []struct {
-			desc      string
-			data      *MessageData
-			wantMatch bool
-		}
+		testCases []compareTestCase
 	}{
 		// Test with empty value string
 		{
@@ -445,11 +415,7 @@ func TestStringCompare(t *testing.T) {
 			field:   "fromnode",
 			value:   "",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches empty FromNode",
 					data:      &MessageData{FromNode: ""},
@@ -489,11 +455,7 @@ func TestStringCompare(t *testing.T) {
 			field:   "tonode",
 			value:   "node-123&",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches value with special characters",
 					data:      &MessageData{ToNode: "node-123&"},
@@ -512,11 +474,7 @@ func TestStringCompare(t *testing.T) {
 			field:   "ToService",
 			value:   "Prod-123",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches field with mixed case characters",
 					data:      &MessageData{ToService: "Prod-123"},
@@ -535,11 +493,7 @@ func TestStringCompare(t *testing.T) {
 			field:   "FROMSERVICE",
 			value:   "dev.83",
 			wantErr: false,
-			testCases: []struct {
-				desc      string
-				data      *MessageData
-				wantMatch bool
-			}{
+			testCases: []compareTestCase{
 				{
 					desc:      "matches field with upper-case characters",
 					data:      &MessageData{FromService: "dev.83"},

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -1,6 +1,7 @@
 package netceptor
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -81,5 +82,498 @@ func TestFirewallRules(t *testing.T) {
 		ToNode: "Appleb",
 	}) != FirewallResultReject {
 		t.Fatal("rule #4 did not return Reject")
+	}
+}
+
+func TestParseFirewallRules(t *testing.T) {
+	tests := []struct {
+		name            string
+		rules           []FirewallRuleData
+		wantErr         bool
+		wantErrContains string
+		wantCount       int
+		testCases       []struct {
+			desc      string
+			ruleIndex int
+			data      *MessageData
+			want      FirewallResult
+		}
+	}{
+		// Test with empty rules slice
+		{
+			name:      "empty rules slice",
+			rules:     []FirewallRuleData{},
+			wantErr:   false,
+			wantCount: 0,
+		},
+		// Test with single valid rule
+		{
+			name: "single valid rule",
+			rules: []FirewallRuleData{
+				{
+					"action":   "accept",
+					"fromnode": "node1",
+				},
+			},
+			wantErr:   false,
+			wantCount: 1,
+			testCases: []struct {
+				desc      string
+				ruleIndex int
+				data      *MessageData
+				want      FirewallResult
+			}{
+				{
+					desc:      "rule 0 accepts matching node1",
+					ruleIndex: 0,
+					data:      &MessageData{FromNode: "node1"},
+					want:      FirewallResultAccept,
+				},
+				{
+					desc:      "rule 0 continues for non-matching node2",
+					ruleIndex: 0,
+					data:      &MessageData{FromNode: "node2"},
+					want:      FirewallResultContinue,
+				},
+			},
+		},
+		// Test with multiple valid rules
+		{
+			name: "multiple valid rules",
+			rules: []FirewallRuleData{
+				{
+					"action":   "accept",
+					"fromnode": "node1",
+				},
+				{
+					"action":   "reject",
+					"fromnode": "node2",
+				},
+			},
+			wantErr:   false,
+			wantCount: 2,
+			testCases: []struct {
+				desc      string
+				ruleIndex int
+				data      *MessageData
+				want      FirewallResult
+			}{
+				{
+					desc:      "rule 0 accepts matching node1",
+					ruleIndex: 0,
+					data:      &MessageData{FromNode: "node1"},
+					want:      FirewallResultAccept,
+				},
+				{
+					desc:      "rule 0 continues for non-matching node2",
+					ruleIndex: 0,
+					data:      &MessageData{FromNode: "node2"},
+					want:      FirewallResultContinue,
+				},
+				{
+					desc:      "rule 1 rejects matching node2",
+					ruleIndex: 1,
+					data:      &MessageData{FromNode: "node2"},
+					want:      FirewallResultReject,
+				},
+				{
+					desc:      "rule 1 continues for non-matching node1",
+					ruleIndex: 1,
+					data:      &MessageData{FromNode: "node1"},
+					want:      FirewallResultContinue,
+				},
+			},
+		},
+		// Test wiith invalid rule data
+		{
+			name: "invalid rule",
+			rules: []FirewallRuleData{
+				{
+					"action": "",
+				},
+			},
+			wantErr:   true,
+			wantCount: 0,
+		},
+		// Test that error message includes the rule index number
+		{
+			name: "error message includes rule index",
+			rules: []FirewallRuleData{
+				{
+					"action":   "accept",
+					"fromnode": "node1",
+				},
+				{
+					"action":     "reject",
+					"invalidkey": "value",
+				},
+				{
+					"action":   "drop",
+					"fromnode": "node3",
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "error in rule 1",
+			wantCount:       0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rules, err := ParseFirewallRules(tt.rules)
+			// Check error expectations
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ParseFirewallRules() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			
+			// Check error message
+			if tt.wantErrContains != "" && err != nil {
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("ParseFirewallRules() error = %v, want error containing %q", err, tt.wantErrContains)
+				}
+			}
+			
+			// Check number of rules
+			if len(rules) != tt.wantCount {
+				t.Errorf("ParseFirewallRules() returned %d rules, want %d", len(rules), tt.wantCount)
+			}
+			
+			// Run test cases
+			for _, tc := range tt.testCases {
+				got := rules[tc.ruleIndex](tc.data)
+				if got != tc.want {
+					t.Errorf("%s: got %v, want %v", tc.desc, got, tc.want)
+				}
+			}
+		})
+	}
+}
+
+func TestRegexCompare(t *testing.T) {
+	tests := []struct {
+		name            string
+		field           string
+		value           string
+		wantErr         bool
+		testCases       []struct {
+			desc      string
+			data      *MessageData
+			wantMatch bool
+		}
+	}{
+		// Test with invalid regex patterns
+		{
+			name:            "unclosed bracket",
+			field:           "fromnode",
+			value:           "/[unclosed/",
+			wantErr:         true,
+		},
+		{
+			name:            "invalid escape",
+			field:           "fromnode",
+			value:           "/node\\k/",
+			wantErr:         true,
+		},
+		{
+			name:            "bad repetition range",
+			field:           "fromnode",
+			value:           "/node{5,2}/",
+			wantErr:         true,
+		},
+		{
+			name: "not enclosed in slashes",
+			field: "fromnode",
+			value: "node.*",
+			wantErr: true,
+		},
+		// Test with empty regex pattern string
+		{
+			name:    "matches only empty strings",
+			field:   "toservice",
+			value:   "//",
+			wantErr: false,
+			testCases: []struct {
+				desc      string
+				data      *MessageData
+				wantMatch bool
+			}{
+				{
+					desc:      "matches empty string",
+					data:      &MessageData{ToService: ""},
+					wantMatch: true,
+				},
+				{
+					desc:      "does not match non-empty string",
+					data:      &MessageData{ToService: "343.236"},
+					wantMatch: false,
+				},
+			},
+		},
+		// Test with complex regex patterns
+		{
+			name:    "exactly 3 digits",
+			field:   "fromnode",
+			value:   "/node-[0-9]{3}/",
+			wantErr: false,
+			testCases: []struct {
+				desc      string
+				data      *MessageData
+				wantMatch bool
+			}{
+				{
+					desc:      "matches node-123",
+					data:      &MessageData{FromNode: "node-123"},
+					wantMatch: true,
+				},
+				{
+					desc:      "does not match node-12",
+					data:      &MessageData{FromNode: "node-12"},
+					wantMatch: false,
+				},
+				{
+					desc:      "does not match node-1234",
+					data:      &MessageData{FromNode: "node-1234"},
+					wantMatch: false,
+				},
+			},
+		},
+		// Test regex matching with special characters
+		{
+			name:    "escaped dots for IP address",
+			field:   "fromnode",
+			value:   "/192\\.168\\.1\\.1/",
+			wantErr: false,
+			testCases: []struct {
+				desc      string
+				data      *MessageData
+				wantMatch bool
+			}{
+				{
+					desc:      "matches exact IP",
+					data:      &MessageData{FromNode: "192.168.1.1"},
+					wantMatch: true,
+				},
+				{
+					desc:      "does not match with other chars",
+					data:      &MessageData{FromNode: "192X168Y1Z1"},
+					wantMatch: false,
+				},
+			},
+		},
+		{
+			name:    "escaped parentheses",
+			field:   "fromservice",
+			value:   "/api-v2\\.0\\(prod\\)/",
+			wantErr: false,
+			testCases: []struct {
+				desc      string
+				data      *MessageData
+				wantMatch bool
+			}{
+				{
+					desc:      "matches api-v2.0(prod)",
+					data:      &MessageData{FromService: "api-v2.0(prod)"},
+					wantMatch: true,
+				},
+				{
+					desc:      "does not match without parentheses",
+					data:      &MessageData{FromService: "api-v2.0"},
+					wantMatch: false,
+				},
+			},
+		},
+		{
+			name:    "escaped brackets",
+			field:   "tonode",
+			value:   "/server\\[prod\\]/",
+			wantErr: false,
+			testCases: []struct {
+				desc      string
+				data      *MessageData
+				wantMatch bool
+			}{
+				{
+					desc:      "matches server[prod]",
+					data:      &MessageData{ToNode: "server[prod]"},
+					wantMatch: true,
+				},
+				{
+					desc:      "does not match server(prod)",
+					data:      &MessageData{ToNode: "server(prod)"},
+					wantMatch: false,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			comp, err := regexCompare(tt.field, tt.value)
+			// Check error expectations
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("regexCompare() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			
+			// Run test cases
+			if !tt.wantErr && comp != nil {
+				for _, tc := range tt.testCases {
+					got := comp(tc.data)
+					if got != tc.wantMatch {
+						t.Errorf("%s: comp() = %v, want %v", tc.desc, got, tc.wantMatch)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStringCompare(t *testing.T){
+	tests := []struct {
+		name            string
+		field           string
+		value           string
+		wantErr         bool
+		testCases       []struct {
+			desc      string
+			data      *MessageData
+			wantMatch bool
+		}
+	}{
+		// Test with empty value string
+		{
+			name: "empty value string",
+			field: "fromnode",
+			value: "",
+			wantErr: false,
+			testCases: []struct{
+				desc string
+				data *MessageData
+				wantMatch bool
+			}{
+				{
+					desc: "matches empty FromNode",
+					data: &MessageData{FromNode: ""},
+					wantMatch: true,
+				},
+				{
+					desc: "does not match empty FromNode",
+					data: &MessageData{FromNode: "node-1"},
+					wantMatch: false,
+				},
+			},
+		},
+		// Test with empty field string
+		{
+			name: "empty field string",
+			field: "",
+			value: "tonode",
+			wantErr: true,
+
+		},
+		// Test with empty field and empty value string
+		{
+			name: "empty field and value string",
+			field: "",
+			value: "",
+			wantErr: true,
+		},
+		// Test with special characters in field string
+		{
+			name: "special characters in field string",
+			field: "toservice!",
+			value: "production",
+			wantErr: true,
+		},
+		// Test with special characters in value string
+		{
+			name: "special characters in value string",
+			field: "tonode",
+			value: "node-123&",
+			wantErr: false,
+			testCases: []struct{
+				desc string
+				data *MessageData
+				wantMatch bool
+			}{
+				{
+					desc: "matches value with special characters",
+					data: &MessageData{ToNode: "node-123&"},
+					wantMatch: true,
+				},
+				{
+					desc: "does not match value with special characters",
+					data: &MessageData{ToNode: "node123"},
+					wantMatch: false,
+				},
+			},
+		},
+		// Test mixed case characters
+		{
+			name: "mixed cases in field string",
+			field: "ToService",
+			value: "Prod-123",
+			wantErr: false,
+			testCases: []struct{
+				desc string
+				data *MessageData
+				wantMatch bool
+			}{
+				{
+					desc: "matches field with mixed case characters",
+					data: &MessageData{ToService: "Prod-123"},
+					wantMatch: true,
+				},
+				{
+					desc: "does not match value with lower-case characters",
+					data: &MessageData{ToService: "prod-123"},
+					wantMatch: false,
+				},
+			},
+		},
+		// Test uppercase characters
+		{
+			name: "upper case in field string",
+			field: "FROMSERVICE",
+			value: "dev.83",
+			wantErr: false,
+			testCases: []struct{
+				desc string
+				data *MessageData
+				wantMatch bool
+			}{
+				{
+					desc: "matches field with upper-case characters",
+					data: &MessageData{FromService: "dev.83"},
+					wantMatch: true,
+				},
+			},
+		},
+		// Test unknown field name
+		{
+			name: "unknown field name",
+			field: "unknown",
+			value: "node-85",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T){
+			comp, err := stringCompare(tt.field, tt.value)
+			// Check error expectations
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("stringCompare() error = %v, want %v", err, tt.wantErr)
+			}
+
+			// Run test cases
+			if !tt.wantErr && comp != nil {
+				for _, tc := range tt.testCases {
+					got := comp(tc.data)
+					if got != tc.wantMatch {
+						t.Errorf("%s: comp() = %v, want %v", tc.desc, got, tc.wantMatch)
+					}
+				}
+			}
+		})
 	}
 }

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -182,17 +182,7 @@ func TestParseFirewallRules(t *testing.T) {
 				},
 			},
 		},
-		// Test wiith invalid rule data
-		{
-			name: "invalid rule",
-			rules: []FirewallRuleData{
-				{
-					"action": "",
-				},
-			},
-			wantErr:   true,
-			wantCount: 0,
-		},
+
 		// Test that error message includes the rule index number
 		{
 			name: "error message includes rule index",
@@ -212,6 +202,58 @@ func TestParseFirewallRules(t *testing.T) {
 			},
 			wantErr:         true,
 			wantErrContains: "error in rule 1",
+			wantCount:       0,
+		},
+		// Test with invalid rule data
+		{
+			name: "empty value",
+			rules: []FirewallRuleData{
+				{
+					"action": "",
+				},
+			},
+			wantErr:         true,
+			wantCount:       0,
+			wantErrContains: "unknown action",
+		},
+		{
+			name: "error message for invalid key",
+			rules: []FirewallRuleData{
+				{
+					"invalidkey": "value",
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "invalid firewall rule. unknown key: invalidkey",
+			wantCount:       0,
+		},
+		{
+			name: "empty map with no action",
+			rules: []FirewallRuleData{
+				{},
+			},
+			wantErr:         true,
+			wantErrContains: "unknown action",
+			wantCount:       0,
+		},
+		{
+			name: "nil map",
+			rules: []FirewallRuleData{
+				nil,
+			},
+			wantErr:         true,
+			wantErrContains: "unknown action",
+			wantCount:       0,
+		},
+		{
+			name: "non-string value",
+			rules: []FirewallRuleData{
+				{
+					493: 123,
+				},
+			},
+			wantErr:         true,
+			wantErrContains: "invalid firewall rule. <int Value> must be a string",
 			wantCount:       0,
 		},
 	}

--- a/pkg/netceptor/firewall_rules_test.go
+++ b/pkg/netceptor/firewall_rules_test.go
@@ -263,22 +263,22 @@ func TestRegexCompare(t *testing.T) {
 	}{
 		// Test with invalid regex patterns
 		{
-			name:            "unclosed bracket",
-			field:           "fromnode",
-			value:           "/[unclosed/",
-			wantErr:         true,
+			name: "unclosed bracket",
+			field: "fromnode",
+			value: "/[unclosed/",
+			wantErr: true,
 		},
 		{
-			name:            "invalid escape",
-			field:           "fromnode",
-			value:           "/node\\k/",
-			wantErr:         true,
+			name: "invalid escape",
+			field: "fromnode",
+			value: "/node\\k/",
+			wantErr: true,
 		},
 		{
-			name:            "bad repetition range",
-			field:           "fromnode",
-			value:           "/node{5,2}/",
-			wantErr:         true,
+			name: "bad repetition range",
+			field: "fromnode",
+			value: "/node{5,2}/",
+			wantErr: true,
 		},
 		{
 			name: "not enclosed in slashes",
@@ -288,9 +288,9 @@ func TestRegexCompare(t *testing.T) {
 		},
 		// Test with empty regex pattern string
 		{
-			name:    "matches only empty strings",
-			field:   "toservice",
-			value:   "//",
+			name: "matches only empty strings",
+			field: "toservice",
+			value: "//",
 			wantErr: false,
 			testCases: []struct {
 				desc      string
@@ -298,22 +298,22 @@ func TestRegexCompare(t *testing.T) {
 				wantMatch bool
 			}{
 				{
-					desc:      "matches empty string",
-					data:      &MessageData{ToService: ""},
+					desc: "matches empty string",
+					data: &MessageData{ToService: ""},
 					wantMatch: true,
 				},
 				{
-					desc:      "does not match non-empty string",
-					data:      &MessageData{ToService: "343.236"},
+					desc: "does not match non-empty string",
+					data: &MessageData{ToService: "343.236"},
 					wantMatch: false,
 				},
 			},
 		},
 		// Test with complex regex patterns
 		{
-			name:    "exactly 3 digits",
-			field:   "fromnode",
-			value:   "/node-[0-9]{3}/",
+			name: "exactly 3 digits",
+			field: "fromnode",
+			value: "/node-[0-9]{3}/",
 			wantErr: false,
 			testCases: []struct {
 				desc      string
@@ -321,27 +321,27 @@ func TestRegexCompare(t *testing.T) {
 				wantMatch bool
 			}{
 				{
-					desc:      "matches node-123",
-					data:      &MessageData{FromNode: "node-123"},
+					desc: "matches node-123",
+					data: &MessageData{FromNode: "node-123"},
 					wantMatch: true,
 				},
 				{
-					desc:      "does not match node-12",
-					data:      &MessageData{FromNode: "node-12"},
+					desc: "does not match node-12",
+					data: &MessageData{FromNode: "node-12"},
 					wantMatch: false,
 				},
 				{
-					desc:      "does not match node-1234",
-					data:      &MessageData{FromNode: "node-1234"},
+					desc: "does not match node-1234",
+					data: &MessageData{FromNode: "node-1234"},
 					wantMatch: false,
 				},
 			},
 		},
 		// Test regex matching with special characters
 		{
-			name:    "escaped dots for IP address",
-			field:   "fromnode",
-			value:   "/192\\.168\\.1\\.1/",
+			name: "escaped dots for IP address",
+			field: "fromnode",
+			value: "/192\\.168\\.1\\.1/",
 			wantErr: false,
 			testCases: []struct {
 				desc      string
@@ -349,57 +349,57 @@ func TestRegexCompare(t *testing.T) {
 				wantMatch bool
 			}{
 				{
-					desc:      "matches exact IP",
-					data:      &MessageData{FromNode: "192.168.1.1"},
+					desc: "matches exact IP",
+					data: &MessageData{FromNode: "192.168.1.1"},
 					wantMatch: true,
 				},
 				{
-					desc:      "does not match with other chars",
-					data:      &MessageData{FromNode: "192X168Y1Z1"},
+					desc: "does not match with other chars",
+					data: &MessageData{FromNode: "192X168Y1Z1"},
 					wantMatch: false,
 				},
 			},
 		},
 		{
-			name:    "escaped parentheses",
-			field:   "fromservice",
-			value:   "/api-v2\\.0\\(prod\\)/",
+			name: "escaped parentheses",
+			field: "fromservice",
+			value: "/api-v2\\.0\\(prod\\)/",
 			wantErr: false,
 			testCases: []struct {
-				desc      string
-				data      *MessageData
+				desc string
+				data *MessageData
 				wantMatch bool
 			}{
 				{
-					desc:      "matches api-v2.0(prod)",
-					data:      &MessageData{FromService: "api-v2.0(prod)"},
+					desc: "matches api-v2.0(prod)",
+					data: &MessageData{FromService: "api-v2.0(prod)"},
 					wantMatch: true,
 				},
 				{
-					desc:      "does not match without parentheses",
-					data:      &MessageData{FromService: "api-v2.0"},
+					desc: "does not match without parentheses",
+					data: &MessageData{FromService: "api-v2.0"},
 					wantMatch: false,
 				},
 			},
 		},
 		{
-			name:    "escaped brackets",
-			field:   "tonode",
-			value:   "/server\\[prod\\]/",
+			name: "escaped brackets",
+			field: "tonode",
+			value: "/server\\[prod\\]/",
 			wantErr: false,
 			testCases: []struct {
-				desc      string
-				data      *MessageData
+				desc string
+				data *MessageData
 				wantMatch bool
 			}{
 				{
-					desc:      "matches server[prod]",
-					data:      &MessageData{ToNode: "server[prod]"},
+					desc: "matches server[prod]",
+					data: &MessageData{ToNode: "server[prod]"},
 					wantMatch: true,
 				},
 				{
-					desc:      "does not match server(prod)",
-					data:      &MessageData{ToNode: "server(prod)"},
+					desc: "does not match server(prod)",
+					data: &MessageData{ToNode: "server(prod)"},
 					wantMatch: false,
 				},
 			},
@@ -429,13 +429,13 @@ func TestRegexCompare(t *testing.T) {
 
 func TestStringCompare(t *testing.T){
 	tests := []struct {
-		name            string
-		field           string
-		value           string
-		wantErr         bool
-		testCases       []struct {
-			desc      string
-			data      *MessageData
+		name string
+		field string
+		value string
+		wantErr bool
+		testCases []struct {
+			desc string
+			data *MessageData
 			wantMatch bool
 		}
 	}{


### PR DESCRIPTION
AAP-57038

# Summary
Add comprehensive unit tests for firewall rule parsing functions to improve code coverage and ensure robust error handling.

# Changes
### 1. Added TestParseFirewallRules Function
- Edge case testing for ParseFirewallRules()
- Coverage: 100%

### 2. Added TestRegexCompare Function
- Edge case testing for regex pattern matching
- Coverage: 93.8%

### 3. Added TestStringCompare Function
- Edge case testing for exact string matching
- Coverage: 100%

### 4. Fix typo in pkg/netceptor/firewall_rules.go

# Files Modified 
- pkg/netceptor/firewall_rules_test.go
- pkg/netceptor/firewall_rules.go
