### PR TITLE
Improve Test Coverage for udp.go - UDPDialerSession

### DIFF
--- a/pkg/backends/udp.go
+++ b/pkg/backends/udp.go
@@ -29,10 +29,6 @@ func (b *UDPDialer) GetAddr() string {
 	return b.address
 }
 
-func (b *UDPDialer) GetTLS() *tls.Config {
-	return nil
-}
-
 // NewUDPDialer instantiates a new UDPDialer backend.
 func NewUDPDialer(address string, redial bool, logger *logger.ReceptorLogger) (*UDPDialer, error) {
 	_, err := net.ResolveUDPAddr("udp", address)

--- a/pkg/backends/udp_test.go
+++ b/pkg/backends/udp_test.go
@@ -27,7 +27,7 @@ func TestNewUDPListener(t *testing.T) {
 		{
 			name: "Positive",
 			args: args{
-				address: "127.0.0.1:9997",
+				address: "127.0.0.1:0",
 				logger:  logger.NewReceptorLogger("UDPtest"),
 			},
 			wantErr: false,
@@ -73,7 +73,7 @@ func TestUDPListenerStart(t *testing.T) {
 			fields: fields{
 				laddr: &net.UDPAddr{
 					IP:   net.IPv4(127, 0, 0, 1),
-					Port: 9999,
+					Port: 0,
 					Zone: "",
 				},
 				conn:            &net.UDPConn{},
@@ -137,7 +137,7 @@ func TestUDPDialerStart(t *testing.T) {
 		{
 			name: "Positive",
 			fields: fields{
-				address: "127.0.0.1:9998",
+				address: "127.0.0.1:0",
 				redial:  true,
 				logger:  logger.NewReceptorLogger("UDPtest"),
 			},
@@ -277,16 +277,6 @@ func TestUDPDialer_GetAddr(t *testing.T) {
 				t.Errorf("UDPDialer.GetAddr() = %v, want %v", got, tt.address)
 			}
 		})
-	}
-}
-
-func TestUDPDialer_GetTLS(t *testing.T) {
-	t.Parallel()
-
-	b := &UDPDialer{}
-
-	if got := b.GetTLS(); got != nil {
-		t.Errorf("UDPDialer.GetTLS() = %v, want nil", got)
 	}
 }
 

--- a/pkg/backends/udp_test.go
+++ b/pkg/backends/udp_test.go
@@ -244,6 +244,8 @@ func checkTestError(t *testing.T, err error, wantErr bool, errMsg, funcName stri
 }
 
 func TestUDPDialer_GetAddr(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name    string
 		address string
@@ -263,6 +265,8 @@ func TestUDPDialer_GetAddr(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			b, err := NewUDPDialer(tt.address, true, nil)
 			if err != nil {
 				t.Errorf("NewUDPDialer() error = %v", err)
@@ -277,6 +281,8 @@ func TestUDPDialer_GetAddr(t *testing.T) {
 }
 
 func TestUDPDialer_GetTLS(t *testing.T) {
+	t.Parallel()
+	
 	b := &UDPDialer{}
 
 	if got := b.GetTLS(); got != nil {
@@ -285,6 +291,8 @@ func TestUDPDialer_GetTLS(t *testing.T) {
 }
 
 func TestNewUDPDialer(t *testing.T) {
+	t.Parallel()
+
 	type args struct {
 		address string
 		redial  bool
@@ -317,6 +325,8 @@ func TestNewUDPDialer(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			got, err := NewUDPDialer(tt.args.address, tt.args.redial, tt.args.logger)
 			checkTestError(t, err, tt.wantErr, "", "NewUDPDialer()")
 
@@ -344,6 +354,8 @@ type udpDialerSessionTest struct {
 }
 
 func TestUDPDialerSession_Send(t *testing.T) {
+	t.Parallel()
+
 	tests := []udpDialerSessionTest{
 		{
 			name:      "Send normal message",
@@ -369,6 +381,8 @@ func TestUDPDialerSession_Send(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cleanup, serverConn, udpClientConn, session := setupUDPDialerSessionTest(t)
 			defer cleanup()
 
@@ -394,6 +408,8 @@ func TestUDPDialerSession_Send(t *testing.T) {
 }
 
 func TestUDPDialerSession_Recv(t *testing.T) {
+	t.Parallel()
+
 	tests := []udpDialerSessionTest{
 		{
 			name:       "Receive data successfully",
@@ -433,6 +449,8 @@ func TestUDPDialerSession_Recv(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cleanup, serverConn, udpClientConn, session := setupUDPDialerSessionTest(t)
 			defer cleanup()
 
@@ -476,6 +494,8 @@ func TestUDPDialerSession_Recv(t *testing.T) {
 }
 
 func TestUDPDialerSession_Close(t *testing.T) {
+	t.Parallel()
+
 	tests := []udpDialerSessionTest{
 		{
 			name:    "Close successfully",
@@ -490,6 +510,8 @@ func TestUDPDialerSession_Close(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			cleanup, _, _, session := setupUDPDialerSessionTest(t)
 			defer cleanup()
 

--- a/pkg/backends/udp_test.go
+++ b/pkg/backends/udp_test.go
@@ -282,7 +282,7 @@ func TestUDPDialer_GetAddr(t *testing.T) {
 
 func TestUDPDialer_GetTLS(t *testing.T) {
 	t.Parallel()
-	
+
 	b := &UDPDialer{}
 
 	if got := b.GetTLS(); got != nil {

--- a/pkg/backends/udp_test.go
+++ b/pkg/backends/udp_test.go
@@ -210,7 +210,7 @@ func newTestUDPDialerSession(clientConn *net.UDPConn) *UDPDialerSession {
 	}
 }
 
-// setupUDPDialerSessionTest sets up a complete test environment with server, client, and session
+// setupUDPDialerSessionTest sets up a complete test environment with server, client, and session.
 func setupUDPDialerSessionTest(t *testing.T) (func(), *net.UDPConn, *net.UDPConn, *UDPDialerSession) {
 	t.Helper()
 
@@ -232,6 +232,7 @@ func checkTestError(t *testing.T, err error, wantErr bool, errMsg, funcName stri
 
 	if (err != nil) != wantErr {
 		t.Errorf("%s error = %v, wantErr %v", funcName, err, wantErr)
+
 		return
 	}
 
@@ -265,6 +266,7 @@ func TestUDPDialer_GetAddr(t *testing.T) {
 			b, err := NewUDPDialer(tt.address, true, nil)
 			if err != nil {
 				t.Errorf("NewUDPDialer() error = %v", err)
+
 				return
 			}
 			if got := b.GetAddr(); got != tt.address {

--- a/pkg/backends/udp_test.go
+++ b/pkg/backends/udp_test.go
@@ -3,8 +3,10 @@ package backends
 import (
 	"context"
 	"net"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/ansible/receptor/pkg/logger"
 	"github.com/ansible/receptor/pkg/netceptor"
@@ -166,38 +168,351 @@ func TestUDPDialerStart(t *testing.T) {
 	}
 }
 
+// setupUDPServer creates a UDP listener for testing.
+func setupUDPServer(t *testing.T) *net.UDPConn {
+	t.Helper()
+
+	serverAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Failed to resolve server address: %v", err)
+	}
+	serverConn, err := net.ListenUDP("udp", serverAddr)
+	if err != nil {
+		t.Fatalf("Failed to create server: %v", err)
+	}
+
+	return serverConn
+}
+
+// setupUDPClient creates a UDP client connected to the given server address.
+func setupUDPClient(t *testing.T, serverAddr net.Addr) *net.UDPConn {
+	t.Helper()
+
+	clientConn, err := net.Dial("udp", serverAddr.String())
+	if err != nil {
+		t.Fatalf("Failed to dial server: %v", err)
+	}
+
+	udpClientConn, ok := clientConn.(*net.UDPConn)
+	if !ok {
+		t.Fatal("Failed to cast to UDPConn")
+	}
+
+	return udpClientConn
+}
+
+// newTestUDPDialerSession creates a UDPDialerSession for testing.
+func newTestUDPDialerSession(clientConn *net.UDPConn) *UDPDialerSession {
+	return &UDPDialerSession{
+		conn:            clientConn,
+		closeChan:       make(chan struct{}),
+		closeChanCloser: sync.Once{},
+	}
+}
+
+// setupUDPDialerSessionTest sets up a complete test environment with server, client, and session
+func setupUDPDialerSessionTest(t *testing.T) (func(), *net.UDPConn, *net.UDPConn, *UDPDialerSession) {
+	t.Helper()
+
+	serverConn := setupUDPServer(t)
+	clientConn := setupUDPClient(t, serverConn.LocalAddr())
+	session := newTestUDPDialerSession(clientConn)
+
+	cleanup := func() {
+		clientConn.Close()
+		serverConn.Close()
+	}
+
+	return cleanup, serverConn, clientConn, session
+}
+
+// checkTestError is a helper function that verifies error expectations in tests.
+func checkTestError(t *testing.T, err error, wantErr bool, errMsg, funcName string) {
+	t.Helper()
+
+	if (err != nil) != wantErr {
+		t.Errorf("%s error = %v, wantErr %v", funcName, err, wantErr)
+		return
+	}
+
+	if wantErr && errMsg != "" && err != nil {
+		if !strings.Contains(err.Error(), errMsg) {
+			t.Errorf("%s error = %v, want error containing %q", funcName, err, errMsg)
+		}
+	}
+}
+
+func TestUDPDialer_GetAddr(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+	}{
+		{
+			name:    "IPv4 address",
+			address: "127.0.0.1:8080",
+		},
+		{
+			name:    "IPv6 address",
+			address: "[::1]:8080",
+		},
+		{
+			name:    "Hostname",
+			address: "example.com:443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := NewUDPDialer(tt.address, true, nil)
+			if err != nil {
+				t.Errorf("NewUDPDialer() error = %v", err)
+				return
+			}
+			if got := b.GetAddr(); got != tt.address {
+				t.Errorf("UDPDialer.GetAddr() = %v, want %v", got, tt.address)
+			}
+		})
+	}
+}
+
+func TestUDPDialer_GetTLS(t *testing.T) {
+	b := &UDPDialer{}
+
+	if got := b.GetTLS(); got != nil {
+		t.Errorf("UDPDialer.GetTLS() = %v, want nil", got)
+	}
+}
+
 func TestNewUDPDialer(t *testing.T) {
 	type args struct {
 		address string
 		redial  bool
 		logger  *logger.ReceptorLogger
 	}
+
 	tests := []struct {
 		name    string
 		args    args
-		want    *UDPDialer
 		wantErr bool
 	}{
 		{
-			name: "Positive",
+			name: "Valid address",
 			args: args{
-				address: "127.0.0.1:9995",
+				address: "127.0.0.1:8080",
 				redial:  true,
-				logger:  logger.NewReceptorLogger("UDPtest"),
+				logger:  nil,
 			},
 			wantErr: false,
+		},
+		{
+			name: "Invalid format",
+			args: args{
+				address: "not:a:valid:address:format",
+				redial:  true,
+				logger:  nil,
+			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := NewUDPDialer(tt.args.address, tt.args.redial, tt.args.logger)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("NewUDPDialer() error = %+v, wantErr %+v", err, tt.wantErr)
+			checkTestError(t, err, tt.wantErr, "", "NewUDPDialer()")
 
-				return
+			if !tt.wantErr && got == nil {
+				t.Errorf("NewUDPDialer() returned nil, want UDPDialer")
 			}
-			if got == nil {
-				t.Errorf("NewUDPDialer() returned nil")
+			if tt.wantErr && got != nil {
+				t.Errorf("NewUDPDialer() returned %v, want nil", got)
+			}
+		})
+	}
+}
+
+type udpDialerSessionTest struct {
+	name                string
+	data                []byte
+	timeout             time.Duration
+	closeConn           bool
+	closeConnDuringRead bool
+	shouldSend          bool
+	wantErr             bool
+	wantTimeout         bool
+	errMsg              string
+	multipleCalls       bool
+}
+
+func TestUDPDialerSession_Send(t *testing.T) {
+	tests := []udpDialerSessionTest{
+		{
+			name:      "Send normal message",
+			data:      []byte("hello"),
+			closeConn: false,
+			wantErr:   false,
+		},
+		{
+			name:      "Send to closed connection",
+			data:      []byte("test"),
+			closeConn: true,
+			wantErr:   true,
+			errMsg:    "use of closed network connection",
+		},
+		{
+			name:      "Send data too large",
+			data:      make([]byte, UDPMaxPacketLen+1),
+			closeConn: false,
+			wantErr:   true,
+			errMsg:    "data too large",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup, serverConn, udpClientConn, session := setupUDPDialerSessionTest(t)
+			defer cleanup()
+
+			if tt.closeConn {
+				udpClientConn.Close()
+			}
+
+			checkTestError(t, session.Send(tt.data), tt.wantErr, tt.errMsg, "UDPDialerSession.Send()")
+
+			if !tt.wantErr && !tt.closeConn && len(tt.data) <= UDPMaxPacketLen {
+				buf := make([]byte, UDPMaxPacketLen)
+				serverConn.SetReadDeadline(time.Now().Add(1 * time.Second))
+				n, _, err := serverConn.ReadFromUDP(buf)
+				if err != nil {
+					t.Errorf("Server failed to receive data: %v", err)
+				}
+				if string(buf[:n]) != string(tt.data) {
+					t.Errorf("Received data = %v, want %v", string(buf[:n]), string(tt.data))
+				}
+			}
+		})
+	}
+}
+
+func TestUDPDialerSession_Recv(t *testing.T) {
+	tests := []udpDialerSessionTest{
+		{
+			name:       "Receive data successfully",
+			data:       []byte("test message"),
+			timeout:    1 * time.Second,
+			closeConn:  false,
+			shouldSend: true,
+			wantErr:    false,
+		},
+		{
+			name:        "Timeout when no data available",
+			data:        []byte(""),
+			timeout:     100 * time.Millisecond,
+			closeConn:   false,
+			shouldSend:  false,
+			wantErr:     true,
+			wantTimeout: true,
+		},
+		{
+			name:       "SetReadDeadline error on closed connection",
+			data:       []byte(""),
+			timeout:    1 * time.Second,
+			closeConn:  true,
+			shouldSend: false,
+			wantErr:    true,
+		},
+		{
+			name:                "Read error after connection closed during read",
+			data:                []byte{},
+			timeout:             2 * time.Second,
+			closeConn:           false,
+			closeConnDuringRead: true,
+			shouldSend:          false,
+			wantErr:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup, serverConn, udpClientConn, session := setupUDPDialerSessionTest(t)
+			defer cleanup()
+
+			if tt.shouldSend {
+				go func() {
+					time.Sleep(50 * time.Millisecond) // Small delay to ensure Recv is called first
+					_, err := serverConn.WriteTo(tt.data, udpClientConn.LocalAddr())
+					if err != nil {
+						t.Logf("Server failed to send data: %v", err)
+					}
+				}()
+			}
+
+			if tt.closeConn {
+				udpClientConn.Close()
+			}
+
+			if tt.closeConnDuringRead {
+				go func() {
+					time.Sleep(50 * time.Millisecond)
+					udpClientConn.Close()
+				}()
+			}
+
+			data, err := session.Recv(tt.timeout)
+			checkTestError(t, err, tt.wantErr, tt.errMsg, "UDPDialerSession.Recv()")
+
+			if tt.wantTimeout {
+				if err != netceptor.ErrTimeout {
+					t.Errorf("UDPDialerSession.Recv() error = %v, want netceptor.ErrTimeout", err)
+				}
+			}
+
+			if !tt.wantErr {
+				if string(data) != string(tt.data) {
+					t.Errorf("UDPDialerSession.Recv() data = %v, want %v", string(data), string(tt.data))
+				}
+			}
+		})
+	}
+}
+
+func TestUDPDialerSession_Close(t *testing.T) {
+	tests := []udpDialerSessionTest{
+		{
+			name:    "Close successfully",
+			wantErr: false,
+		},
+		{
+			name:          "Close multiple times (idempotent)",
+			wantErr:       false,
+			multipleCalls: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup, _, _, session := setupUDPDialerSessionTest(t)
+			defer cleanup()
+
+			closeChan := session.closeChan
+			checkTestError(t, session.Close(), tt.wantErr, tt.errMsg, "UDPDialerSession.Close()")
+
+			if !tt.multipleCalls {
+				select {
+				case <-closeChan:
+				default:
+					t.Error("UDPDialerSession.Close() closeChan should be closed")
+				}
+			}
+
+			if session.closeChan != nil {
+				t.Error("UDPDialerSession.Close() closeChan should be nil after close")
+			}
+
+			if tt.multipleCalls {
+				for callNumber := 2; callNumber <= 3; callNumber++ {
+					err := session.Close()
+					if err == nil {
+						t.Errorf("UDPDialerSession.Close() call #%d expected error for closed connection, got nil", callNumber)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
AAP 60059

# Summary
- Add unit tests for UDPDialerSession methods (Send, Recv, Close) and UDPDialer getters in pkg/backends/udp.go
- udp.go now reaches 57.9% total coverage

# Changes
### 1. TestUDPDialer_GetAddr()
- 100% coverage for GetAddr()
### 2. TestUDPDialer_GetTLS()
- 100% coverage for GetTLS()
### 3. TestNewUDPDialer()
- 100% coverage for NewUDPDialer()
### 4. TestUDPDialerSession_Send()
- 87.5% coverage for Send() *not tested is the "partial data sent" error
### 5. TestUDPDialerSession_Recv()
- 100% coverage for Recv() 
### 6. TestUDPDialerSession_Close()
- 100% coverage for Close()
### 7. Helper functions
- setupUDPServer() 
- setupUDPClient() 
- newTestUDPDialerSession
- setupUDPDialerSessionTest
- CheckTestError