### PR TITLE
Fix crypto error handling

### DIFF
--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -10,7 +10,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"strings"
 	"time"
@@ -482,44 +481,6 @@ func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expecte
 
 		return nil
 	}
-}
-
-// handleHostnameError handles a hostname error from the Certificate.Verify function. It
-// was put in place temporarily to mitigate CVE-2025-61729 until the project is able to
-// upgrade to a Golang version containing a fix.
-//
-// This function should be removed once the project can upgrade to a Golang version with
-// a fix for the CVE.
-func handleHostnameError(h x509.HostnameError) error {
-	c := h.Certificate
-	maxNamesIncluded := 100
-
-	var valid strings.Builder
-	if ip := net.ParseIP(h.Host); ip != nil {
-		// Trying to validate an IP
-		if len(c.IPAddresses) == 0 {
-			return errors.New("x509: cannot validate certificate for " + h.Host + " because it doesn't contain any IP SANs")
-		}
-		if len(c.IPAddresses) >= maxNamesIncluded {
-			return fmt.Errorf("x509: certificate is valid for %d IP SANs, but none matched %s", len(c.IPAddresses), h.Host)
-		}
-		for _, san := range c.IPAddresses {
-			if valid.Len() > 0 {
-				valid.WriteString(", ")
-			}
-			valid.WriteString(san.String())
-		}
-	} else {
-		if len(c.DNSNames) >= maxNamesIncluded {
-			return fmt.Errorf("x509: certificate is valid for %d names, but none matched %s", len(c.DNSNames), h.Host)
-		}
-		valid.WriteString(strings.Join(c.DNSNames, ", "))
-	}
-
-	if valid.Len() == 0 {
-		return errors.New("x509: certificate is not valid for any names, but wanted to match " + h.Host)
-	}
-	return errors.New("x509: certificate is valid for " + valid.String() + ", not " + h.Host)
 }
 
 func init() {

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -469,8 +469,6 @@ func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expecte
 			logger.Error("RVF failed verify: %s\nRootCAs: %v\nServerName: %s", handledError, tlscfg.RootCAs, tlscfg.ServerName)
 
 			return handledError
-
-			return err
 		}
 
 		// Verify Receptor node ID if required.
@@ -495,10 +493,6 @@ func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expecte
 func handleHostnameError(h x509.HostnameError) error {
 	c := h.Certificate
 	maxNamesIncluded := 100
-
-	// if !c.hasSANExtension() && matchHostnames(c.Subject.CommonName, h.Host) {
-	// 	return "x509: certificate relies on legacy Common Name field, use SANs instead"
-	// }
 
 	var valid strings.Builder
 	if ip := net.ParseIP(h.Host); ip != nil {

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -462,11 +462,13 @@ func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expecte
 		_, err = certs[0].Verify(opts)
 		if err != nil {
 			var hostnameError x509.HostnameError
+			handledError := err
 			if errors.As(err, &hostnameError) {
-				return handleHostnameError(hostnameError)
-			} else {
-				logger.Error("RVF failed verify: %s\nRootCAs: %v\nServerName: %s", err, tlscfg.RootCAs, tlscfg.ServerName)
+				handledError = handleHostnameError(hostnameError)
 			}
+			logger.Error("RVF failed verify: %s\nRootCAs: %v\nServerName: %s", handledError, tlscfg.RootCAs, tlscfg.ServerName)
+
+			return handledError
 
 			return err
 		}

--- a/pkg/netceptor/tlsconfig.go
+++ b/pkg/netceptor/tlsconfig.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"strings"
 	"time"
@@ -460,7 +461,12 @@ func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expecte
 		// Verify the certificate chain.
 		_, err = certs[0].Verify(opts)
 		if err != nil {
-			logger.Error("RVF failed verify: %s\nRootCAs: %v\nServerName: %s", err, tlscfg.RootCAs, tlscfg.ServerName)
+			var hostnameError x509.HostnameError
+			if errors.As(err, &hostnameError) {
+				return handleHostnameError(hostnameError)
+			} else {
+				logger.Error("RVF failed verify: %s\nRootCAs: %v\nServerName: %s", err, tlscfg.RootCAs, tlscfg.ServerName)
+			}
 
 			return err
 		}
@@ -476,6 +482,48 @@ func ReceptorVerifyFunc(tlscfg *tls.Config, pinnedFingerprints [][]byte, expecte
 
 		return nil
 	}
+}
+
+// handleHostnameError handles a hostname error from the Certificate.Verify function. It
+// was put in place temporarily to mitigate CVE-2025-61729 until the project is able to
+// upgrade to a Golang version containing a fix.
+//
+// This function should be removed once the project can upgrade to a Golang version with
+// a fix for the CVE.
+func handleHostnameError(h x509.HostnameError) error {
+	c := h.Certificate
+	maxNamesIncluded := 100
+
+	// if !c.hasSANExtension() && matchHostnames(c.Subject.CommonName, h.Host) {
+	// 	return "x509: certificate relies on legacy Common Name field, use SANs instead"
+	// }
+
+	var valid strings.Builder
+	if ip := net.ParseIP(h.Host); ip != nil {
+		// Trying to validate an IP
+		if len(c.IPAddresses) == 0 {
+			return errors.New("x509: cannot validate certificate for " + h.Host + " because it doesn't contain any IP SANs")
+		}
+		if len(c.IPAddresses) >= maxNamesIncluded {
+			return fmt.Errorf("x509: certificate is valid for %d IP SANs, but none matched %s", len(c.IPAddresses), h.Host)
+		}
+		for _, san := range c.IPAddresses {
+			if valid.Len() > 0 {
+				valid.WriteString(", ")
+			}
+			valid.WriteString(san.String())
+		}
+	} else {
+		if len(c.DNSNames) >= maxNamesIncluded {
+			return fmt.Errorf("x509: certificate is valid for %d names, but none matched %s", len(c.DNSNames), h.Host)
+		}
+		valid.WriteString(strings.Join(c.DNSNames, ", "))
+	}
+
+	if valid.Len() == 0 {
+		return errors.New("x509: certificate is not valid for any names, but wanted to match " + h.Host)
+	}
+	return errors.New("x509: certificate is valid for " + valid.String() + ", not " + h.Host)
 }
 
 func init() {

--- a/pkg/netceptor/tlsconfig_hostname_error.go
+++ b/pkg/netceptor/tlsconfig_hostname_error.go
@@ -21,7 +21,7 @@ func handleHostnameError(h x509.HostnameError) error {
 	maxNamesIncluded := 100
 
 	var valid strings.Builder
-	if ip := net.ParseIP(h.Host); ip != nil {
+	if net.ParseIP(h.Host) != nil {
 		// Trying to validate an IP
 		if len(c.IPAddresses) == 0 {
 			return errors.New("x509: cannot validate certificate for " + h.Host + " because it doesn't contain any IP SANs")

--- a/pkg/netceptor/tlsconfig_hostname_error.go
+++ b/pkg/netceptor/tlsconfig_hostname_error.go
@@ -1,0 +1,49 @@
+//go:build go1.23
+
+package netceptor
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// handleHostnameError handles a hostname error from the Certificate.Verify function. It
+// was put in place temporarily to mitigate CVE-2025-61729 until the project is able to
+// upgrade to a Golang version containing a fix.
+//
+// This function should be removed once the project can upgrade to a Golang version with
+// a fix for the CVE.
+func handleHostnameError(h x509.HostnameError) error {
+	c := h.Certificate
+	maxNamesIncluded := 100
+
+	var valid strings.Builder
+	if ip := net.ParseIP(h.Host); ip != nil {
+		// Trying to validate an IP
+		if len(c.IPAddresses) == 0 {
+			return errors.New("x509: cannot validate certificate for " + h.Host + " because it doesn't contain any IP SANs")
+		}
+		if len(c.IPAddresses) >= maxNamesIncluded {
+			return fmt.Errorf("x509: certificate is valid for %d IP SANs, but none matched %s", len(c.IPAddresses), h.Host)
+		}
+		for _, san := range c.IPAddresses {
+			if valid.Len() > 0 {
+				valid.WriteString(", ")
+			}
+			valid.WriteString(san.String())
+		}
+	} else {
+		if len(c.DNSNames) >= maxNamesIncluded {
+			return fmt.Errorf("x509: certificate is valid for %d names, but none matched %s", len(c.DNSNames), h.Host)
+		}
+		valid.WriteString(strings.Join(c.DNSNames, ", "))
+	}
+
+	if valid.Len() == 0 {
+		return errors.New("x509: certificate is not valid for any names, but wanted to match " + h.Host)
+	}
+	return errors.New("x509: certificate is valid for " + valid.String() + ", not " + h.Host)
+}

--- a/pkg/netceptor/tlsconfig_hostname_error.go
+++ b/pkg/netceptor/tlsconfig_hostname_error.go
@@ -45,5 +45,6 @@ func handleHostnameError(h x509.HostnameError) error {
 	if valid.Len() == 0 {
 		return errors.New("x509: certificate is not valid for any names, but wanted to match " + h.Host)
 	}
+
 	return errors.New("x509: certificate is valid for " + valid.String() + ", not " + h.Host)
 }

--- a/pkg/netceptor/tlsconfig_hostname_error_test.go
+++ b/pkg/netceptor/tlsconfig_hostname_error_test.go
@@ -1,11 +1,13 @@
-//go:build go1.23
-
 package netceptor
 
 import (
+	"context"
+	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 )
@@ -118,5 +120,54 @@ func TestTLSConfigCertCount(t *testing.T) {
 				t.Fatalf("Error message should contain %q, got %q", tt.expectedError, errMsg)
 			}
 		})
+	}
+}
+
+func TestHostnameErrorHandlerCalled(t *testing.T) {
+	hostnameToMatch := "MyHostname"
+	expectedError := "x509: certificate is not valid for any names, but wanted to match MyHostname"
+
+	caCertFilename, certFilename, _, teardownFunc := useUtilsSetupSuiteWithGenerateWithCA(t, hostnameToMatch)
+	defer teardownFunc(t)
+
+	// Read CA certificate.
+	caBytes, err := os.ReadFile(caCertFilename)
+	if err != nil {
+		t.Fatalf("failed to read CA certificate file: %v", err)
+	}
+	rootCA := x509.NewCertPool()
+	rootCA.AppendCertsFromPEM(caBytes)
+
+	// Read regular certificate.
+	certBytes, err := os.ReadFile(certFilename)
+	if err != nil {
+		t.Fatalf("failed to read certificate file: %v", err)
+	}
+	block, rest := pem.Decode(certBytes)
+	if block == nil {
+		t.Fatal("failed to decode PEM certificate")
+	}
+	if len(rest) != 0 {
+		t.Fatalf("unexpected remaining bytes after PEM decode: %d bytes remaining", len(rest))
+	}
+
+	cfg := &tls.Config{
+		RootCAs:            rootCA,
+		InsecureSkipVerify: true,
+	}
+
+	MainInstance = New(context.Background(), "testnode")
+	verifyFunc := ReceptorVerifyFunc(cfg, nil, hostnameToMatch, ExpectedHostnameTypeDNS, VerifyServer, MainInstance.Logger)
+
+	rawCerts := [][]byte{block.Bytes}
+	err = verifyFunc(rawCerts, nil)
+
+	if err == nil {
+		t.Fatalf("Expected an error but received none")
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, expectedError) {
+		t.Fatalf("Error message should contain %q, got %q", expectedError, errMsg)
 	}
 }

--- a/pkg/netceptor/tlsconfig_hostname_error_test.go
+++ b/pkg/netceptor/tlsconfig_hostname_error_test.go
@@ -28,6 +28,13 @@ func TestTLSConfigCertCount(t *testing.T) {
 		expectedError   string
 	}{
 		{
+			testName:        "Zero DNS names",
+			testType:        dnsName,
+			hostnameToMatch: "MyHostname",
+			itemCount:       0,
+			expectedError:   "x509: certificate is not valid for any names, but wanted to match MyHostname",
+		},
+		{
 			testName:        "Less than 100 DNS names",
 			testType:        dnsName,
 			hostnameToMatch: "MyHostname",
@@ -47,6 +54,13 @@ func TestTLSConfigCertCount(t *testing.T) {
 			hostnameToMatch: "MyHostname",
 			itemCount:       100,
 			expectedError:   "x509: certificate is valid for 100 names, but none matched MyHostname",
+		},
+		{
+			testName:        "Zero IP SANs",
+			testType:        ipAddress,
+			hostnameToMatch: "127.0.0.1",
+			itemCount:       0,
+			expectedError:   "x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs",
 		},
 		{
 			testName:        "Less than 100 IP SANs",

--- a/pkg/netceptor/tlsconfig_hostname_error_test.go
+++ b/pkg/netceptor/tlsconfig_hostname_error_test.go
@@ -1,0 +1,108 @@
+//go:build go1.23
+
+package netceptor
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+)
+
+type certTestType int
+
+const (
+	dnsName certTestType = iota
+	ipAddress
+)
+
+func TestTLSConfigCertCount(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName        string
+		testType        certTestType
+		hostnameToMatch string
+		itemCount       int
+		expectedError   string
+	}{
+		{
+			testName:        "Less than 100 DNS names",
+			testType:        dnsName,
+			hostnameToMatch: "MyHostname",
+			itemCount:       3,
+			expectedError:   "x509: certificate is valid for server-0, server-1, server-2, not MyHostname",
+		},
+		{
+			testName:        "More than 100 DNS names",
+			testType:        dnsName,
+			hostnameToMatch: "MyHostname",
+			itemCount:       105,
+			expectedError:   "x509: certificate is valid for 105 names, but none matched MyHostname",
+		},
+		{
+			testName:        "Exactly 100 DNS names",
+			testType:        dnsName,
+			hostnameToMatch: "MyHostname",
+			itemCount:       100,
+			expectedError:   "x509: certificate is valid for 100 names, but none matched MyHostname",
+		},
+		{
+			testName:        "Less than 100 IP SANs",
+			testType:        ipAddress,
+			hostnameToMatch: "127.0.0.1",
+			itemCount:       3,
+			expectedError:   "x509: certificate is valid for 1.2.3.4, 1.2.3.4, 1.2.3.4, not 127.0.0.1",
+		},
+		{
+			testName:        "More than 100 IP SANs",
+			testType:        ipAddress,
+			hostnameToMatch: "127.0.0.1",
+			itemCount:       105,
+			expectedError:   "x509: certificate is valid for 105 IP SANs, but none matched 127.0.0.1",
+		},
+		{
+			testName:        "Exactly 100 IP SANs",
+			testType:        ipAddress,
+			hostnameToMatch: "127.0.0.1",
+			itemCount:       100,
+			expectedError:   "x509: certificate is valid for 100 IP SANs, but none matched 127.0.0.1",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			t.Parallel()
+
+			cert := &x509.Certificate{}
+
+			switch tt.testType {
+			case dnsName:
+				cert.DNSNames = make([]string, tt.itemCount)
+				for n := range tt.itemCount {
+					cert.DNSNames[n] = fmt.Sprintf("server-%d", n)
+				}
+			case ipAddress:
+				cert.IPAddresses = make([]net.IP, tt.itemCount)
+				for n := range tt.itemCount {
+					cert.IPAddresses[n] = net.IPv4(1, 2, 3, 4)
+				}
+			default:
+				t.Errorf("invalid test type: %d", tt.testType)
+			}
+
+			hostnameErr := x509.HostnameError{
+				Host:        tt.hostnameToMatch,
+				Certificate: cert,
+			}
+
+			err := handleHostnameError(hostnameErr)
+
+			errMsg := err.Error()
+			if !strings.Contains(errMsg, tt.expectedError) {
+				t.Fatalf("Error message should contain %q, got %q", tt.expectedError, errMsg)
+			}
+		})
+	}
+}

--- a/pkg/netceptor/tlsconfig_test.go
+++ b/pkg/netceptor/tlsconfig_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
-	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -183,24 +182,6 @@ func useUtilsSetupSuiteWithGenerateWithCA(t *testing.T, name string) (string, st
 		t.Error(err.Error())
 	}
 	certKey, cert, err := utils.GenerateCertWithCA(name, caKey, caCert, name, nil, []string{"foobar"})
-	if err != nil {
-		t.Error(err.Error())
-	}
-
-	return caCert, cert, certKey, func(t *testing.T) {
-		defer os.Remove(caCert)
-		defer os.Remove(caKey)
-		defer os.Remove(certKey)
-		defer os.Remove(cert)
-	}
-}
-
-func useUtilsSetupSuiteWithGenerateWithCAWithManyNames(t *testing.T, name string, dnsNames []string) (string, string, string, func(t *testing.T)) {
-	caKey, caCert, err := utils.GenerateCA(name, name)
-	if err != nil {
-		t.Error(err.Error())
-	}
-	certKey, cert, err := utils.GenerateCertWithCA(name, caKey, caCert, name, dnsNames, []string{"foobar"})
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -967,95 +948,6 @@ func TestTLSClientConfigMinTLS13(t *testing.T) {
 					tlsVersionToString(tt.expectedMinVersion),
 					tt.expectedMinVersion,
 					tlscfg.MinVersion)
-			}
-		})
-	}
-}
-
-// TestTLSConfigCertificateCount checks that a certificate can contain
-// no more than 100 certificates due to CVE.
-func TestTLSConfigCertificateCount(t *testing.T) {
-	testCases := []struct {
-		testName        string
-		hostnameToMatch string
-		nameCount       int
-		expectedError   string
-	}{
-		{
-			testName:        "Less than 100 DNS names",
-			hostnameToMatch: "MyHostname",
-			nameCount:       3,
-			expectedError:   "x509: certificate is valid for server-0, server-1, server-2, not MyHostname",
-		},
-		{
-			testName:        "More than 100 DNS names",
-			hostnameToMatch: "MyHostname",
-			nameCount:       105,
-			expectedError:   "x509: certificate is valid for 105 names, but none matched MyHostname",
-		},
-		{
-			testName:        "Exactly 100 DNS names",
-			hostnameToMatch: "MyHostname",
-			nameCount:       100,
-			expectedError:   "x509: certificate is valid for 100 names, but none matched MyHostname",
-		},
-		{
-			testName:        "Less than 100 IP SANs",
-			hostnameToMatch: "127.0.0.1",
-			nameCount:       3,
-			expectedError:   "abc",
-		},
-	}
-
-	for _, tt := range testCases {
-		t.Run(tt.testName, func(t *testing.T) {
-			dnsNames := []string{}
-			for n := range tt.nameCount {
-				dnsNames = append(dnsNames, fmt.Sprintf("server-%d", n))
-			}
-
-			caCertFilename, certFilename, _, teardownFunc := useUtilsSetupSuiteWithGenerateWithCAWithManyNames(t, "foobar", dnsNames)
-			defer teardownFunc(t)
-
-			// Read CA certificate.
-			caBytes, err := os.ReadFile(caCertFilename)
-			if err != nil {
-				t.Fatalf("failed to read CA certificate file: %v", err)
-			}
-			rootCA := x509.NewCertPool()
-			rootCA.AppendCertsFromPEM(caBytes)
-
-			// Read regular certificate.
-			certBytes, err := os.ReadFile(certFilename)
-			if err != nil {
-				t.Fatalf("failed to read certificate file: %v", err)
-			}
-			block, rest := pem.Decode(certBytes)
-			if block == nil {
-				t.Fatal("failed to decode PEM certificate")
-			}
-			if len(rest) != 0 {
-				t.Fatalf("unexpected remaining bytes after PEM decode: %d bytes remaining", len(rest))
-			}
-
-			cfg := &tls.Config{
-				RootCAs:            rootCA,
-				InsecureSkipVerify: true,
-			}
-
-			MainInstance = New(context.Background(), "testnode")
-			verifyFunc := ReceptorVerifyFunc(cfg, nil, tt.hostnameToMatch, ExpectedHostnameTypeDNS, VerifyServer, MainInstance.Logger)
-
-			rawCerts := [][]byte{block.Bytes}
-			err = verifyFunc(rawCerts, nil)
-
-			if err == nil {
-				t.Fatalf("Expected an error but received none")
-			}
-
-			errMsg := err.Error()
-			if !strings.Contains(errMsg, tt.expectedError) {
-				t.Fatalf("Error message should contain %q, got %q", tt.expectedError, errMsg)
 			}
 		})
 	}

--- a/pkg/netceptor/tlsconfig_test.go
+++ b/pkg/netceptor/tlsconfig_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -182,6 +183,24 @@ func useUtilsSetupSuiteWithGenerateWithCA(t *testing.T, name string) (string, st
 		t.Error(err.Error())
 	}
 	certKey, cert, err := utils.GenerateCertWithCA(name, caKey, caCert, name, nil, []string{"foobar"})
+	if err != nil {
+		t.Error(err.Error())
+	}
+
+	return caCert, cert, certKey, func(t *testing.T) {
+		defer os.Remove(caCert)
+		defer os.Remove(caKey)
+		defer os.Remove(certKey)
+		defer os.Remove(cert)
+	}
+}
+
+func useUtilsSetupSuiteWithGenerateWithCAWithManyNames(t *testing.T, name string, dnsNames []string) (string, string, string, func(t *testing.T)) {
+	caKey, caCert, err := utils.GenerateCA(name, name)
+	if err != nil {
+		t.Error(err.Error())
+	}
+	certKey, cert, err := utils.GenerateCertWithCA(name, caKey, caCert, name, dnsNames, []string{"foobar"})
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -948,6 +967,95 @@ func TestTLSClientConfigMinTLS13(t *testing.T) {
 					tlsVersionToString(tt.expectedMinVersion),
 					tt.expectedMinVersion,
 					tlscfg.MinVersion)
+			}
+		})
+	}
+}
+
+// TestTLSConfigCertificateCount checks that a certificate can contain
+// no more than 100 certificates due to CVE.
+func TestTLSConfigCertificateCount(t *testing.T) {
+	testCases := []struct {
+		testName        string
+		hostnameToMatch string
+		nameCount       int
+		expectedError   string
+	}{
+		{
+			testName:        "Less than 100 DNS names",
+			hostnameToMatch: "MyHostname",
+			nameCount:       3,
+			expectedError:   "x509: certificate is valid for server-0, server-1, server-2, not MyHostname",
+		},
+		{
+			testName:        "More than 100 DNS names",
+			hostnameToMatch: "MyHostname",
+			nameCount:       105,
+			expectedError:   "x509: certificate is valid for 105 names, but none matched MyHostname",
+		},
+		{
+			testName:        "Exactly 100 DNS names",
+			hostnameToMatch: "MyHostname",
+			nameCount:       100,
+			expectedError:   "x509: certificate is valid for 100 names, but none matched MyHostname",
+		},
+		{
+			testName:        "Less than 100 IP SANs",
+			hostnameToMatch: "127.0.0.1",
+			nameCount:       3,
+			expectedError:   "abc",
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.testName, func(t *testing.T) {
+			dnsNames := []string{}
+			for n := range tt.nameCount {
+				dnsNames = append(dnsNames, fmt.Sprintf("server-%d", n))
+			}
+
+			caCertFilename, certFilename, _, teardownFunc := useUtilsSetupSuiteWithGenerateWithCAWithManyNames(t, "foobar", dnsNames)
+			defer teardownFunc(t)
+
+			// Read CA certificate.
+			caBytes, err := os.ReadFile(caCertFilename)
+			if err != nil {
+				t.Fatalf("failed to read CA certificate file: %v", err)
+			}
+			rootCA := x509.NewCertPool()
+			rootCA.AppendCertsFromPEM(caBytes)
+
+			// Read regular certificate.
+			certBytes, err := os.ReadFile(certFilename)
+			if err != nil {
+				t.Fatalf("failed to read certificate file: %v", err)
+			}
+			block, rest := pem.Decode(certBytes)
+			if block == nil {
+				t.Fatal("failed to decode PEM certificate")
+			}
+			if len(rest) != 0 {
+				t.Fatalf("unexpected remaining bytes after PEM decode: %d bytes remaining", len(rest))
+			}
+
+			cfg := &tls.Config{
+				RootCAs:            rootCA,
+				InsecureSkipVerify: true,
+			}
+
+			MainInstance = New(context.Background(), "testnode")
+			verifyFunc := ReceptorVerifyFunc(cfg, nil, tt.hostnameToMatch, ExpectedHostnameTypeDNS, VerifyServer, MainInstance.Logger)
+
+			rawCerts := [][]byte{block.Bytes}
+			err = verifyFunc(rawCerts, nil)
+
+			if err == nil {
+				t.Fatalf("Expected an error but received none")
+			}
+
+			errMsg := err.Error()
+			if !strings.Contains(errMsg, tt.expectedError) {
+				t.Fatalf("Error message should contain %q, got %q", tt.expectedError, errMsg)
 			}
 		})
 	}


### PR DESCRIPTION
This fixes a security issue in how crypto error messages are generated. This is a temporary change that should be reverted once the receptor project can upgrade to a patched Golang version.