### PR TITLE
AAP - 60058 Improve test coverage for tcp.go

### DIFF
--- a/pkg/backends/tcp_test.go
+++ b/pkg/backends/tcp_test.go
@@ -115,6 +115,7 @@ func TestTCPDialerStart(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testLogger := logger.NewReceptorLogger("TCPtest")
 
 			address := tt.address
@@ -310,15 +311,15 @@ func TestTCPListener_GetTLS(t *testing.T) {
 func TestTCPListenerStart(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name          string
-		address       string
-		tls           *tls.Config
+		name           string
+		address        string
+		tls            *tls.Config
 		makeConnection bool
 	}{
 		{
-			name:          "Non-TLS listener with connection",
-			address:       "127.0.0.1:0",
-			tls:           nil,
+			name:           "Non-TLS listener with connection",
+			address:        "127.0.0.1:0",
+			tls:            nil,
 			makeConnection: true,
 		},
 		{
@@ -329,6 +330,7 @@ func TestTCPListenerStart(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			b, err := NewTCPListener(tt.address, tt.tls, logger.NewReceptorLogger("TCPtest"))
 			if err != nil {
 				t.Errorf("NewTCPListener() error = %v", err)
@@ -930,6 +932,7 @@ func TestTCPDialerCfg_Run(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			netceptor.MainInstance = netceptor.New(context.Background(), "tcp_dialer_run_test")
 			err := tt.cfg.Run()
 			if (err != nil) != tt.wantErr {
@@ -1022,6 +1025,7 @@ func TestTCPListenerCfg_Run(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			netceptor.MainInstance = netceptor.New(context.Background(), "tcp_listener_run_test")
 			err := tt.cfg.Run()
 			if (err != nil) != tt.wantErr {
@@ -1044,5 +1048,3 @@ func TestTCPListenerCfg_Reload(t *testing.T) {
 		t.Errorf("TCPListenerCfg.Reload() error = %v", err)
 	}
 }
-
-

--- a/pkg/backends/tcp_test.go
+++ b/pkg/backends/tcp_test.go
@@ -158,7 +158,7 @@ func TestTCPDialerStart(t *testing.T) {
 			if got == nil {
 				t.Errorf("TCPDialer.Start() returned nil channel")
 			}
-			
+
 			// Wait for connection with 10ms timeout. This is sufficient for loopback
 			// connections (typical datacenter RTT is 0.5ms) while keeping tests fast.
 			select {
@@ -365,9 +365,9 @@ func TestTCPListenerStart(t *testing.T) {
 				} else {
 					conn.Close()
 				}
-				
+
 				// Wait for connection with 10ms timeout. This is sufficient for loopback
-			    // connections (typical datacenter RTT is 0.5ms) while keeping tests fast.
+				// connections (typical datacenter RTT is 0.5ms) while keeping tests fast.
 				select {
 				case <-got:
 					// Connection received

--- a/pkg/backends/tcp_test.go
+++ b/pkg/backends/tcp_test.go
@@ -10,7 +10,22 @@ import (
 	"time"
 
 	"github.com/ansible/receptor/pkg/logger"
+	"github.com/ansible/receptor/pkg/netceptor"
 )
+
+type tcpDialerCfgTest struct {
+	name    string
+	cfg     TCPDialerCfg
+	wantErr bool
+	errMsg  string
+}
+
+type tcpListenerCfgTest struct {
+	name    string
+	cfg     TCPListenerCfg
+	wantErr bool
+	errMsg  string
+}
 
 func TestTCPDialer_GetAddr(t *testing.T) {
 	tests := []struct {
@@ -79,24 +94,49 @@ func TestTCPDialer_GetTLS(t *testing.T) {
 }
 
 func TestTCPDialerStart(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name    string
-		address string
-		redial  bool
-		tls     *tls.Config
-		wantErr bool
+		name          string
+		address       string
+		tls           *tls.Config
+		setupListener bool
 	}{
 		{
-			name:    "Successful start",
-			address: "127.0.0.1:0",
-			redial:  true,
-			tls:     nil,
-			wantErr: false,
+			name:          "Successful non-TLS connection",
+			address:       "",
+			tls:           nil,
+			setupListener: true,
+		},
+		{
+			name:    "TLS connection failure",
+			address: "127.0.0.1:1",
+			tls:     &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b, err := NewTCPDialer(tt.address, tt.redial, tt.tls, logger.NewReceptorLogger("TCPtest"))
+			testLogger := logger.NewReceptorLogger("TCPtest")
+
+			address := tt.address
+			var listener net.Listener
+			if tt.setupListener {
+				var err error
+				listener, err = net.Listen("tcp", "127.0.0.1:0")
+				if err != nil {
+					t.Fatalf("Failed to create test listener: %v", err)
+				}
+				defer listener.Close()
+				address = listener.Addr().String()
+
+				go func() {
+					conn, _ := listener.Accept()
+					if conn != nil {
+						conn.Close()
+					}
+				}()
+			}
+
+			b, err := NewTCPDialer(address, false, tt.tls, testLogger)
 			if err != nil {
 				t.Errorf("NewTCPDialer() error = %v", err)
 
@@ -111,14 +151,17 @@ func TestTCPDialerStart(t *testing.T) {
 			}()
 
 			got, err := b.Start(ctx, wg)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TCPDialer.Start() error = %v, wantErr %v", err, tt.wantErr)
+			if err != nil {
+				t.Errorf("TCPDialer.Start() error = %v", err)
 
 				return
 			}
 			if got == nil {
 				t.Errorf("TCPDialer.Start() returned nil channel")
 			}
+
+			// Allow time for connection attempt to complete before context cancellation
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -265,17 +308,23 @@ func TestTCPListener_GetTLS(t *testing.T) {
 }
 
 func TestTCPListenerStart(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name    string
-		address string
-		tls     *tls.Config
-		wantErr bool
+		name          string
+		address       string
+		tls           *tls.Config
+		makeConnection bool
 	}{
 		{
-			name:    "Successful start",
+			name:          "Non-TLS listener with connection",
+			address:       "127.0.0.1:0",
+			tls:           nil,
+			makeConnection: true,
+		},
+		{
+			name:    "TLS listener",
 			address: "127.0.0.1:0",
-			tls:     nil,
-			wantErr: false,
+			tls:     &tls.Config{MinVersion: tls.VersionTLS12},
 		},
 	}
 	for _, tt := range tests {
@@ -295,14 +344,26 @@ func TestTCPListenerStart(t *testing.T) {
 			}()
 
 			got, err := b.Start(ctx, wg)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("TCPListener.Start() error = %v, wantErr %v", err, tt.wantErr)
+			if err != nil {
+				t.Errorf("TCPListener.Start() error = %v", err)
 
 				return
 			}
 			if got == nil {
 				t.Errorf("TCPListener.Start() returned nil channel")
 			}
+
+			if tt.makeConnection {
+				// Make a connection to trigger accept path
+				conn, err := net.Dial("tcp", b.GetAddr())
+				if err != nil {
+					t.Errorf("Failed to connect to listener: %v", err)
+				} else {
+					conn.Close()
+				}
+			}
+
+			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -544,10 +605,7 @@ func TestTCPSession_Close(t *testing.T) {
 }
 
 func TestTCPListenerCfg_GetCost(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  TCPListenerCfg
-	}{
+	tests := []tcpListenerCfgTest{
 		{
 			name: "Positive cost",
 			cfg: TCPListenerCfg{
@@ -577,10 +635,7 @@ func TestTCPListenerCfg_GetCost(t *testing.T) {
 }
 
 func TestTCPListenerCfg_GetNodeCost(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  TCPListenerCfg
-	}{
+	tests := []tcpListenerCfgTest{
 		{
 			name: "No node costs",
 			cfg: TCPListenerCfg{
@@ -622,10 +677,7 @@ func TestTCPListenerCfg_GetNodeCost(t *testing.T) {
 }
 
 func TestTCPListenerCfg_GetAddr(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  TCPListenerCfg
-	}{
+	tests := []tcpListenerCfgTest{
 		{
 			name: "Empty address",
 			cfg: TCPListenerCfg{
@@ -661,10 +713,7 @@ func TestTCPListenerCfg_GetAddr(t *testing.T) {
 }
 
 func TestTCPListenerCfg_GetTLS(t *testing.T) {
-	tests := []struct {
-		name string
-		cfg  TCPListenerCfg
-	}{
+	tests := []tcpListenerCfgTest{
 		{
 			name: "Empty TLS",
 			cfg: TCPListenerCfg{
@@ -688,12 +737,7 @@ func TestTCPListenerCfg_GetTLS(t *testing.T) {
 }
 
 func TestTCPListenerCfg_Prepare(t *testing.T) {
-	tests := []struct {
-		name    string
-		cfg     TCPListenerCfg
-		wantErr bool
-		errMsg  string
-	}{
+	tests := []tcpListenerCfgTest{
 		{
 			name: "Valid config with positive cost",
 			cfg: TCPListenerCfg{
@@ -779,12 +823,7 @@ func TestTCPListenerCfg_Prepare(t *testing.T) {
 }
 
 func TestTCPDialerCfg_Prepare(t *testing.T) {
-	tests := []struct {
-		name    string
-		cfg     TCPDialerCfg
-		wantErr bool
-		errMsg  string
-	}{
+	tests := []tcpDialerCfgTest{
 		{
 			name: "Valid config with positive cost",
 			cfg: TCPDialerCfg{
@@ -823,3 +862,187 @@ func TestTCPDialerCfg_Prepare(t *testing.T) {
 		})
 	}
 }
+
+func TestTCPDialerCfg_PreReload(t *testing.T) {
+	tests := []tcpDialerCfgTest{
+		{
+			name: "Valid config with positive cost",
+			cfg: TCPDialerCfg{
+				Cost: 1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid: zero cost",
+			cfg: TCPDialerCfg{
+				Cost: 0.0,
+			},
+			wantErr: true,
+			errMsg:  "connection cost must be positive",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.PreReload()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TCPDialerCfg.PreReload() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+			if tt.wantErr && err.Error() != tt.errMsg {
+				t.Errorf("TCPDialerCfg.PreReload() error message = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestTCPDialerCfg_Run(t *testing.T) {
+	t.Parallel()
+	tests := []tcpDialerCfgTest{
+		{
+			name: "Valid config",
+			cfg: TCPDialerCfg{
+				Address: "127.0.0.1:8080",
+				Redial:  true,
+				Cost:    1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid address format - missing port",
+			cfg: TCPDialerCfg{
+				Address: "127.0.0.1",
+				Redial:  true,
+				Cost:    1.0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "Invalid TLS config name",
+			cfg: TCPDialerCfg{
+				Address: "127.0.0.1:8080",
+				Redial:  true,
+				Cost:    1.0,
+				TLS:     "nonexistent-tls-config",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			netceptor.MainInstance = netceptor.New(context.Background(), "tcp_dialer_run_test")
+			err := tt.cfg.Run()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TCPDialerCfg.Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTCPDialerCfg_Reload(t *testing.T) {
+	t.Parallel()
+	cfg := TCPDialerCfg{
+		Address: "127.0.0.1:8080",
+		Redial:  true,
+		Cost:    1.0,
+	}
+	netceptor.MainInstance = netceptor.New(context.Background(), "tcp_dialer_reload_test")
+	err := cfg.Reload()
+	if err != nil {
+		t.Errorf("TCPDialerCfg.Reload() error = %v", err)
+	}
+}
+
+func TestTCPListenerCfg_PreReload(t *testing.T) {
+	tests := []tcpListenerCfgTest{
+		{
+			name: "Valid config with positive cost",
+			cfg: TCPListenerCfg{
+				Cost: 1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid: zero cost",
+			cfg: TCPListenerCfg{
+				Cost: 0.0,
+			},
+			wantErr: true,
+			errMsg:  "connection cost must be positive",
+		},
+		{
+			name: "Invalid: negative node cost",
+			cfg: TCPListenerCfg{
+				Cost: 1.0,
+				NodeCost: map[string]float64{
+					"node1": -1.0,
+				},
+			},
+			wantErr: true,
+			errMsg:  "connection cost must be positive for node1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.PreReload()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TCPListenerCfg.PreReload() error = %v, wantErr %v", err, tt.wantErr)
+
+				return
+			}
+			if tt.wantErr && err.Error() != tt.errMsg {
+				t.Errorf("TCPListenerCfg.PreReload() error message = %v, want %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestTCPListenerCfg_Run(t *testing.T) {
+	t.Parallel()
+	tests := []tcpListenerCfgTest{
+		{
+			name: "Valid config",
+			cfg: TCPListenerCfg{
+				BindAddr: "127.0.0.1",
+				Port:     0,
+				Cost:     1.0,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid TLS config name",
+			cfg: TCPListenerCfg{
+				BindAddr: "127.0.0.1",
+				Port:     0,
+				Cost:     1.0,
+				TLS:      "nonexistent-tls-config",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			netceptor.MainInstance = netceptor.New(context.Background(), "tcp_listener_run_test")
+			err := tt.cfg.Run()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("TCPListenerCfg.Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestTCPListenerCfg_Reload(t *testing.T) {
+	t.Parallel()
+	cfg := TCPListenerCfg{
+		BindAddr: "127.0.0.1",
+		Port:     0,
+		Cost:     1.0,
+	}
+	netceptor.MainInstance = netceptor.New(context.Background(), "tcp_listener_reload_test")
+	err := cfg.Reload()
+	if err != nil {
+		t.Errorf("TCPListenerCfg.Reload() error = %v", err)
+	}
+}
+
+

--- a/pkg/backends/tcp_test.go
+++ b/pkg/backends/tcp_test.go
@@ -94,7 +94,6 @@ func TestTCPDialer_GetTLS(t *testing.T) {
 }
 
 func TestTCPDialerStart(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name          string
 		address       string
@@ -115,7 +114,6 @@ func TestTCPDialerStart(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			testLogger := logger.NewReceptorLogger("TCPtest")
 
 			address := tt.address
@@ -162,7 +160,12 @@ func TestTCPDialerStart(t *testing.T) {
 			}
 
 			// Allow time for connection attempt to complete before context cancellation
-			time.Sleep(10 * time.Millisecond)
+			select {
+			case <-got:
+				// Connection received
+			case <-time.After(1 * time.Second):
+				t.Fatal("timeout waiting for connection")
+			}
 		})
 	}
 }
@@ -309,7 +312,6 @@ func TestTCPListener_GetTLS(t *testing.T) {
 }
 
 func TestTCPListenerStart(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name           string
 		address        string
@@ -330,7 +332,6 @@ func TestTCPListenerStart(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			b, err := NewTCPListener(tt.address, tt.tls, logger.NewReceptorLogger("TCPtest"))
 			if err != nil {
 				t.Errorf("NewTCPListener() error = %v", err)
@@ -363,9 +364,13 @@ func TestTCPListenerStart(t *testing.T) {
 				} else {
 					conn.Close()
 				}
+				select {
+				case <-got:
+					// Connection received
+				case <-time.After(10 * time.Millisecond):
+					t.Fatal("timeout waiting for connection")
+				}
 			}
-
-			time.Sleep(10 * time.Millisecond)
 		})
 	}
 }
@@ -899,7 +904,6 @@ func TestTCPDialerCfg_PreReload(t *testing.T) {
 }
 
 func TestTCPDialerCfg_Run(t *testing.T) {
-	t.Parallel()
 	tests := []tcpDialerCfgTest{
 		{
 			name: "Valid config",
@@ -932,7 +936,6 @@ func TestTCPDialerCfg_Run(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			netceptor.MainInstance = netceptor.New(context.Background(), "tcp_dialer_run_test")
 			err := tt.cfg.Run()
 			if (err != nil) != tt.wantErr {
@@ -943,7 +946,6 @@ func TestTCPDialerCfg_Run(t *testing.T) {
 }
 
 func TestTCPDialerCfg_Reload(t *testing.T) {
-	t.Parallel()
 	cfg := TCPDialerCfg{
 		Address: "127.0.0.1:8080",
 		Redial:  true,
@@ -1001,7 +1003,6 @@ func TestTCPListenerCfg_PreReload(t *testing.T) {
 }
 
 func TestTCPListenerCfg_Run(t *testing.T) {
-	t.Parallel()
 	tests := []tcpListenerCfgTest{
 		{
 			name: "Valid config",
@@ -1025,7 +1026,6 @@ func TestTCPListenerCfg_Run(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			netceptor.MainInstance = netceptor.New(context.Background(), "tcp_listener_run_test")
 			err := tt.cfg.Run()
 			if (err != nil) != tt.wantErr {
@@ -1036,7 +1036,6 @@ func TestTCPListenerCfg_Run(t *testing.T) {
 }
 
 func TestTCPListenerCfg_Reload(t *testing.T) {
-	t.Parallel()
 	cfg := TCPListenerCfg{
 		BindAddr: "127.0.0.1",
 		Port:     0,

--- a/pkg/backends/tcp_test.go
+++ b/pkg/backends/tcp_test.go
@@ -158,12 +158,13 @@ func TestTCPDialerStart(t *testing.T) {
 			if got == nil {
 				t.Errorf("TCPDialer.Start() returned nil channel")
 			}
-
-			// Allow time for connection attempt to complete before context cancellation
+			
+			// Wait for connection with 10ms timeout. This is sufficient for loopback
+			// connections (typical datacenter RTT is 0.5ms) while keeping tests fast.
 			select {
 			case <-got:
 				// Connection received
-			case <-time.After(1 * time.Second):
+			case <-time.After(10 * time.Millisecond):
 				t.Fatal("timeout waiting for connection")
 			}
 		})
@@ -364,6 +365,9 @@ func TestTCPListenerStart(t *testing.T) {
 				} else {
 					conn.Close()
 				}
+				
+				// Wait for connection with 10ms timeout. This is sufficient for loopback
+			    // connections (typical datacenter RTT is 0.5ms) while keeping tests fast.
 				select {
 				case <-got:
 					// Connection received


### PR DESCRIPTION
AAP - 60058

## Overview

Increases tcp.go unit test coverage from 63.6% to 90.4%

Adding unit tests for:

- TCPListenerCfg.Run
- TCPDialerCfg.Run
- TCPDialerCfg.PreReload
- TCPListenerCfg.PreReload
- TCPDialerCfg.Reload
- TCPListenerCfg.Reload

Improving unit tests for:

- TCPDialer.Start
- TCPListener.Start

## Changes
- TCPDialerCfg.PreReload & TCPDialerCfg.Reload 0% to 100% coverage
- TCPListenerCfg.PreReload & TCPListenerCfg.Reload 0% to 100% coverage
- TCPListenerCfg.Run 0% to 75% coverage
- TCPDialerCfg.Run 0% to 80% coverage
- TCPListener.Start 65.7% to 88.6% coverage
- TCPDialer.Start 84.6% to 100.0% coverage
- Added shared test structures tcpDialerCfgTest & tcpListenerCfgTest

Assisted by Claude