### PR TITLE
receptorctl: switch to TLS 1.2 minimum version

### DIFF
--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -125,7 +125,7 @@ class ReceptorControl:
                                 purpose=ssl.Purpose.SERVER_AUTH,
                                 cafile=self._rootcas,
                             )
-                            context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1
+                            context.minimum_version = ssl.TLSVersion.TLSv1_2
 
                             if self._key and self._cert:
                                 context.load_cert_chain(certfile=self._cert, keyfile=self._key)

--- a/receptorctl/receptorctl/socket_interface.py
+++ b/receptorctl/receptorctl/socket_interface.py
@@ -38,6 +38,7 @@ class ReceptorControl:
         self._key = key
         self._cert = cert
         self._insecureskipverify = insecureskipverify
+        self._tls_minimum_version = ssl.TLSVersion.TLSv1_2
         if config and tlsclient:
             self.readconfig(config, tlsclient)
 
@@ -125,7 +126,7 @@ class ReceptorControl:
                                 purpose=ssl.Purpose.SERVER_AUTH,
                                 cafile=self._rootcas,
                             )
-                            context.minimum_version = ssl.TLSVersion.TLSv1_2
+                            context.minimum_version = self._tls_minimum_version
 
                             if self._key and self._cert:
                                 context.load_cert_chain(certfile=self._cert, keyfile=self._key)

--- a/receptorctl/tests/conftest.py
+++ b/receptorctl/tests/conftest.py
@@ -149,7 +149,8 @@ def receptor_bin_path():
 
 @pytest.fixture(scope="class")
 def default_socket_tcp():
-    return "tcp://localhost:11112"
+    #return "tcp://localhost:11112"
+    return "tls://localhost:11112"
 
 
 @pytest.fixture(scope="class")

--- a/receptorctl/tests/conftest.py
+++ b/receptorctl/tests/conftest.py
@@ -149,8 +149,12 @@ def receptor_bin_path():
 
 @pytest.fixture(scope="class")
 def default_socket_tcp():
-    # return "tcp://localhost:11112"
-    return "tls://localhost:11112"
+    return "tcp://localhost:11112"
+
+
+@pytest.fixture(scope="class")
+def default_socket_tcp_tls():
+    return "tls://localhost:11113"
 
 
 @pytest.fixture(scope="class")
@@ -169,14 +173,14 @@ def default_receptor_controller_tcp(default_socket_tcp):
 
 
 @pytest.fixture(scope="class")
-def default_receptor_controller_tcp_tls(default_socket_tcp, certificate_files):
+def default_receptor_controller_tcp_tls(default_socket_tcp_tls, certificate_files):
     rootcas = certificate_files["caCrtPath"]
     key = certificate_files["clientKeyPath"]
     cert = certificate_files["clientCrtPath"]
     insecureskipverify = True
 
     controller = receptorctl.ReceptorControl(
-        default_socket_tcp,
+        default_socket_tcp_tls,
         rootcas=rootcas,
         key=key,
         cert=cert,

--- a/receptorctl/tests/conftest.py
+++ b/receptorctl/tests/conftest.py
@@ -149,7 +149,7 @@ def receptor_bin_path():
 
 @pytest.fixture(scope="class")
 def default_socket_tcp():
-    #return "tcp://localhost:11112"
+    # return "tcp://localhost:11112"
     return "tls://localhost:11112"
 
 

--- a/receptorctl/tests/test_connection.py
+++ b/receptorctl/tests/test_connection.py
@@ -1,4 +1,5 @@
 import os
+import ssl
 import tempfile
 
 import pytest
@@ -73,6 +74,8 @@ class TestReceptorCtlConnection:
             )
             - status.keys()
         )
+
+        assert node1_controller._tls_minimum_version == ssl.TLSVersion.TLSv1_2
 
 
 class TestReceptorCtlConfig:


### PR DESCRIPTION
Previously, this code disallowed TLS 1.0 and 1.1. However, this may have allowed for older SSL versions to be used. This change switches to making TLS 1.2 the minimum allowed version.

Tests are also added to exercise the new code and make sure TLS/TCP connections are working as intended.

AAP-60418