### PR TITLE
Provide 'ref' as an env variable rather than direct user input

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -33,6 +33,8 @@ jobs:
     permissions:
       packages: write
       contents: write
+    env:
+      REF: ${{ github.event.inputs.ref }}
     steps:
       - name: Verify inputs
         run: |
@@ -53,7 +55,7 @@ jobs:
       - name: Checkout receptor
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.ref }}
+          ref: ${{ env.REF }}
 
       - name: Install python
         uses: actions/setup-python@v6


### PR DESCRIPTION
Updates the `stage.yml` GitHub action to provide the checkout ref as an environment variable rather than directly from user input. This change addresses a Sonarqube security recommendation where a user input could trigger code execution. By providing the value in an environment variable, we prevent that issue.

AAP-63087