### PR TITLE
Use 'tr' instead of 'node' for string lowercase operation

### DIFF
--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -82,7 +82,7 @@ jobs:
 
       - name: Lowercase github owner
         run: |
-          echo "OWNER=$(echo 'console.log("${{ github.repository_owner }}".toLowerCase())' | node -)" >> $GITHUB_ENV
+          echo "OWNER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
 
       - name: Build container image
         run: |

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -80,6 +80,8 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
 
+      # Image repository names must be lowercase, so get lowercase repo owner for ghcr.io
+      # See https://github.com/orgs/community/discussions/27086.
       - name: Lowercase github owner
         run: |
           echo "OWNER=$(echo $GITHUB_REPOSITORY_OWNER | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV


### PR DESCRIPTION
Looked at this workflow a bit closer after #1512.

This step in the workflow was reading the GitHub Repository owner (e.g. 'ansible') from a variable, then executing JavaScript (via `node`) to lowercase the string so that the repo name we use later is guaranteed to be lowercase.

I find it overkill to launch a JavaScript virtual machine to lowercase a string (especially since it's already lowercase on this repo 🤔), when [coreutils `tr '[:upper:]' '[:lower:]'`](https://www.gnu.org/software/coreutils/manual/html_node/tr-invocation.html) is a simple, portable way to do this in Linux. I made this change because I believe in Linux and coreutils 🎸. 

AAP-63087