### PR TITLE
Add python 3.12 as sonar targeted version

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -50,3 +50,5 @@ sonar.sourceEncoding=UTF-8
 # =============================================================================
 
 sonar.go.coverage.reportPaths=coverage.txt
+
+sonar.python.version=3.12


### PR DESCRIPTION
Make Python 3.12 the targeted version in Sonarqube configuration to mitigate reported security issues about TLS versions.