### PR TITLE
Fix cancelled work units being deleted prematurely on restart

### DIFF
--- a/pkg/workceptor/remote_work.go
+++ b/pkg/workceptor/remote_work.go
@@ -646,7 +646,7 @@ func (rw *remoteUnit) startOrRestart(start bool) error {
 
 		return rw.runAndMonitor(rw.topJC, false, rw.StartRemoteUnit)
 	} else if red.LocalReleased || red.LocalCancelled {
-		return rw.runAndMonitor(rw.topJC, true, func(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {
+		return rw.runAndMonitor(rw.topJC, red.LocalReleased, func(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {
 			return rw.cancelOrReleaseRemoteUnit(ctx, conn, reader, red.LocalReleased)
 		})
 	}

--- a/pkg/workceptor/remote_work_test.go
+++ b/pkg/workceptor/remote_work_test.go
@@ -307,6 +307,12 @@ func TestRemoteWorkLifecycleOperations(t *testing.T) {
 			errorContains: "remote work had not previously started",
 		},
 		{
+			name:          "restart_local_cancelled",
+			operation:     "restart",
+			remoteStarted: true,
+			expectError:   false,
+		},
+		{
 			name:          "restart_unknown_work_unit",
 			operation:     "restart",
 			remoteStarted: true,
@@ -407,6 +413,22 @@ func TestRemoteWorkLifecycleOperations(t *testing.T) {
 				err = wu.Restart()
 			case "restart_local_released":
 				remoteExtraData.LocalReleased = true
+				err = wu.Restart()
+			case "restart_local_cancelled":
+				// This test verifies that when LocalCancelled=true but LocalReleased=false,
+				// the work unit directory is NOT deleted (Release is not called).
+				// This was a bug fix: previously forRelease was hardcoded to true,
+				// causing premature deletion of cancelled-but-not-released work units.
+				remoteExtraData.LocalCancelled = true
+				remoteExtraData.LocalReleased = false
+				messages := []string{
+					"execution\n", // Hello message with remote node ID
+					"{\"State\": 4, \"Detail\": \"Cancelled\", \"StdoutSize\": 0}\n", // Response to cancel command
+				}
+				anyTimes := true
+				createRemoteWorkNetworkSetup(t, ctrl, contextWithCancel, messages, mockNetceptor, mockBaseWorkUnit, tmpDir, remoteExtraData, anyTimes)
+				// Note: We do NOT expect mockBaseWorkUnit.Release() to be called.
+				// If Release() were called, gomock would fail with an unexpected call error.
 				err = wu.Restart()
 			case "restart_unknown_work_unit":
 				messages := []string{


### PR DESCRIPTION
Fix premature deletion of cancelled work units on restart                                                                                 
                                                                                                                                            
When a work unit was cancelled but not released, Restart() incorrectly                                                                    
passed forRelease=true to runAndMonitor, causing the work unit directory                                                                  
to be deleted before Release() was explicitly called. This resulted in                                                                    
"unknown work unit" errors when attempting to release the unit.                                                                           
                                                                                                                                            
Changed to pass red.LocalReleased instead of hardcoded true,                                                                     
so deletion only occurs when the unit has actually been released.                                                                         
                                                                                                                                            
Added unit test for restart_local_cancelled scenario.

This fix replaces PR #1275                                                            