### PR TITLE
fix: Limit Github Workflow Permissions

### DIFF
--- a/.github/workflows/sonar_checks.yml
+++ b/.github/workflows/sonar_checks.yml
@@ -7,9 +7,12 @@ on:
     types:
       - completed
 
-permissions: read-all
 jobs:
   sonarcloud:
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read
     name: SonarQube Static Scans (PR)
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
AAP-63317

Addressing the following Sonarcloud issue: 
https://sonarcloud.io/project/issues?issues=AZuYoXTi5s2R-CmnIdZx&open=AZuYoXTi5s2R-CmnIdZx&id=ansible_receptor&tab=code

My reasoning for these permissions:
* `contents: read`: needed by "Checkout Code", and "SonarQube Scan for receptor"
* `actions: read`: needed by "Fetch receptorctl coverage report" and "Fetch PR Number"
* `pull-requests: read`: needed by "Get Additional PR Information" and "Checkout Code for PR"

To be confirmed ^
