### PR TITLE
[AAP-63315] Move workflow permissions from workflow to job level 

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -4,9 +4,6 @@ on:  # yamllint disable-line rule:truthy
   release:
     types: [published]
 
-permissions:
-  contents: write
-
 jobs:
   promote:
     runs-on: ubuntu-latest
@@ -86,6 +83,8 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     env:
       VERSION: ${{github.event.release.tag_name}}
     steps:


### PR DESCRIPTION
## Summary
Moves workflow-level `contents: write` permission to job-level scope to improve security posture.

## Changes
- Removed `permissions: contents: write` from workflow level
- Added `permissions: contents: write` to `publish` job only
- The `promote` job now runs with default read-only permissions

## Rationale
The `publish` job requires write access to upload release artifacts to GitHub Releases via `softprops/action-gh-release@v2`. The `promote` job only interacts with external services (Quay.io and PyPI) and does not need GitHub repository permissions.

This change follows the principle of least privilege and resolves the SonarQube security issue flagged in [AAP-63315](https://issues.redhat.com/browse/AAP-63315).

## References
- JIRA: [AAP-63315](https://issues.redhat.com/browse/AAP-63315)
- SonarQube Issue: [githubactions:S7631](https://sonarcloud.io/project/issues?issues=AZuYoXPC5s2R-CmnIdZt&open=AZuYoXPC5s2R-CmnIdZt&id=ansible_receptor)
- [GitHub Permissions Documentation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)