### PR TITLE
Fix intFromMap bug and add tests for map utility functions

### DIFF
--- a/pkg/workceptor/controlsvc.go
+++ b/pkg/workceptor/controlsvc.go
@@ -108,10 +108,7 @@ func intFromMap(config map[string]interface{}, name string) (int64, error) {
 	}
 	valueStr, ok := value.(string)
 	if ok {
-		valueInt, err := strconv.ParseInt(valueStr, 10, 64)
-		if err != nil {
-			return valueInt, err
-		}
+		return strconv.ParseInt(valueStr, 10, 64)
 	}
 
 	return 0, fmt.Errorf("field %s value %s is not convertible to an int", name, value)

--- a/pkg/workceptor/controlsvc_test.go
+++ b/pkg/workceptor/controlsvc_test.go
@@ -111,3 +111,219 @@ func Test_workceptorCommandTypeInitFromString(t *testing.T) {
 		})
 	}
 }
+
+func Test_strFromMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]interface{}
+		field   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Valid string field",
+			config: map[string]interface{}{
+				"name": "test-value",
+			},
+			field:   "name",
+			want:    "test-value",
+			wantErr: false,
+		},
+		{
+			name:    "Missing field",
+			config:  map[string]interface{}{},
+			field:   "name",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Field is not a string",
+			config: map[string]interface{}{
+				"name": 123,
+			},
+			field:   "name",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Field is bool not string",
+			config: map[string]interface{}{
+				"name": true,
+			},
+			field:   "name",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := strFromMap(tt.config, tt.field)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("strFromMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("strFromMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_intFromMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]interface{}
+		field   string
+		want    int64
+		wantErr bool
+	}{
+		{
+			name: "Valid int64 field",
+			config: map[string]interface{}{
+				"count": int64(42),
+			},
+			field:   "count",
+			want:    42,
+			wantErr: false,
+		},
+		{
+			name: "Valid float64 field",
+			config: map[string]interface{}{
+				"count": float64(100.0),
+			},
+			field:   "count",
+			want:    100,
+			wantErr: false,
+		},
+		{
+			name: "Valid string field",
+			config: map[string]interface{}{
+				"count": "256",
+			},
+			field:   "count",
+			want:    256,
+			wantErr: false,
+		},
+		{
+			name: "Float64 with decimals",
+			config: map[string]interface{}{
+				"count": float64(99.7),
+			},
+			field:   "count",
+			want:    99,
+			wantErr: false,
+		},
+		{
+			name:    "Missing field",
+			config:  map[string]interface{}{},
+			field:   "count",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "Invalid string value",
+			config: map[string]interface{}{
+				"count": "not-a-number",
+			},
+			field:   "count",
+			want:    0,
+			wantErr: true,
+		},
+		{
+			name: "Non-convertible type",
+			config: map[string]interface{}{
+				"count": true,
+			},
+			field:   "count",
+			want:    0,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := intFromMap(tt.config, tt.field)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("intFromMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("intFromMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_boolFromMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  map[string]interface{}
+		field   string
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "Valid true string",
+			config: map[string]interface{}{
+				"enabled": "true",
+			},
+			field:   "enabled",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Valid false string",
+			config: map[string]interface{}{
+				"enabled": "false",
+			},
+			field:   "enabled",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "Missing field",
+			config:  map[string]interface{}{},
+			field:   "enabled",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Field is not a string",
+			config: map[string]interface{}{
+				"enabled": true,
+			},
+			field:   "enabled",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Invalid bool string",
+			config: map[string]interface{}{
+				"enabled": "yes",
+			},
+			field:   "enabled",
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "Invalid bool string - numeric",
+			config: map[string]interface{}{
+				"enabled": "1",
+			},
+			field:   "enabled",
+			want:    false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := boolFromMap(tt.config, tt.field)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("boolFromMap() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("boolFromMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/workceptor/controlsvc_test.go
+++ b/pkg/workceptor/controlsvc_test.go
@@ -348,6 +348,7 @@ func Test_boolFromMap(t *testing.T) {
 			got, err := boolFromMap(tt.config, tt.field)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("boolFromMap() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if got != tt.want {

--- a/pkg/workceptor/controlsvc_test.go
+++ b/pkg/workceptor/controlsvc_test.go
@@ -154,15 +154,15 @@ func Test_strFromMap(t *testing.T) {
 			want:    "",
 			wantErr: true,
 		},
-      {
-      	name: "Empty string value",
-      	config: map[string]interface{}{
-      		"name": "",
-      	},
-      	field:   "name",
-      	want:    "",
-      	wantErr: false,
-      },
+		{
+			name: "Empty string value",
+			config: map[string]interface{}{
+				"name": "",
+			},
+			field:   "name",
+			want:    "",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -249,14 +249,14 @@ func Test_intFromMap(t *testing.T) {
 			wantErr: true,
 		},
 		{
-        	name: "Empty string value",
-        	config: map[string]interface{}{
-        		"count": "",
-        	},
-        	field:   "count",
-        	want:    0,
-        	wantErr: true,
-      },
+			name: "Empty string value",
+			config: map[string]interface{}{
+				"count": "",
+			},
+			field:   "count",
+			want:    0,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -333,15 +333,15 @@ func Test_boolFromMap(t *testing.T) {
 			want:    false,
 			wantErr: true,
 		},
-      {
-      	name: "Empty string value",
-      	config: map[string]interface{}{
-      		"enabled": "",
-      	},
-      	field:   "enabled",
-      	want:    false,
-      	wantErr: true,
-      },
+		{
+			name: "Empty string value",
+			config: map[string]interface{}{
+				"enabled": "",
+			},
+			field:   "enabled",
+			want:    false,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/workceptor/controlsvc_test.go
+++ b/pkg/workceptor/controlsvc_test.go
@@ -160,6 +160,7 @@ func Test_strFromMap(t *testing.T) {
 			got, err := strFromMap(tt.config, tt.field)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("strFromMap() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if got != tt.want {
@@ -244,6 +245,7 @@ func Test_intFromMap(t *testing.T) {
 			got, err := intFromMap(tt.config, tt.field)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("intFromMap() error = %v, wantErr %v", err, tt.wantErr)
+
 				return
 			}
 			if got != tt.want {
@@ -319,6 +321,7 @@ func Test_boolFromMap(t *testing.T) {
 			got, err := boolFromMap(tt.config, tt.field)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("boolFromMap() error = %v, wantErr %v", err, tt.wantErr)
+				
 				return
 			}
 			if got != tt.want {

--- a/pkg/workceptor/controlsvc_test.go
+++ b/pkg/workceptor/controlsvc_test.go
@@ -154,6 +154,15 @@ func Test_strFromMap(t *testing.T) {
 			want:    "",
 			wantErr: true,
 		},
+      {
+      	name: "Empty string value",
+      	config: map[string]interface{}{
+      		"name": "",
+      	},
+      	field:   "name",
+      	want:    "",
+      	wantErr: false,
+      },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -239,6 +248,15 @@ func Test_intFromMap(t *testing.T) {
 			want:    0,
 			wantErr: true,
 		},
+		{
+        	name: "Empty string value",
+        	config: map[string]interface{}{
+        		"count": "",
+        	},
+        	field:   "count",
+        	want:    0,
+        	wantErr: true,
+      },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -315,13 +333,21 @@ func Test_boolFromMap(t *testing.T) {
 			want:    false,
 			wantErr: true,
 		},
+      {
+      	name: "Empty string value",
+      	config: map[string]interface{}{
+      		"enabled": "",
+      	},
+      	field:   "enabled",
+      	want:    false,
+      	wantErr: true,
+      },
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := boolFromMap(tt.config, tt.field)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("boolFromMap() error = %v, wantErr %v", err, tt.wantErr)
-				
 				return
 			}
 			if got != tt.want {


### PR DESCRIPTION
Fixed bug in intFromMap where string values were incorrectly rejected. The function parsed strings successfully but didn't return the result, falling through to an error condition. Simplified by directly returning strconv.ParseInt result.

Overall pkg/workceptor coverage: 59.1% → 60.4%

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified integer parsing logic for clearer, more predictable behavior when converting string inputs to integers.

* **Tests**
  * Added comprehensive unit tests for string, integer, and boolean extraction helpers, covering valid inputs, missing fields, type mismatches, numeric truncation/formatting cases, and invalid formats to improve reliability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->