### PR TITLE
Fix SonarQube issue: Refactor RunPhases to reduce cognitive complexity

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -142,35 +142,23 @@ func RunPhases(phase string, v reflect.Value) {
 	cmd := v.Interface()
 	var err error
 
-	if phase == "Init" {
-		switch c := cmd.(type) {
-		case Initer:
-			err = c.Init()
-			if err != nil {
-				PrintPhaseErrorMessage(v.Type().Name(), phase, err)
-			}
-		default:
+	switch phase {
+	case "Init":
+		if initer, ok := cmd.(Initer); ok {
+			err = initer.Init()
+		}
+	case "Prepare":
+		if preparer, ok := cmd.(Preparer); ok {
+			err = preparer.Prepare()
+		}
+	case "Run":
+		if runer, ok := cmd.(Runer); ok {
+			err = runer.Run()
 		}
 	}
-	if phase == "Prepare" {
-		switch c := cmd.(type) {
-		case Preparer:
-			err = c.Prepare()
-			if err != nil {
-				PrintPhaseErrorMessage(v.Type().Name(), phase, err)
-			}
-		default:
-		}
-	}
-	if phase == "Run" {
-		switch c := cmd.(type) {
-		case Runer:
-			err = c.Run()
-			if err != nil {
-				PrintPhaseErrorMessage(v.Type().Name(), phase, err)
-			}
-		default:
-		}
+
+	if err != nil {
+		PrintPhaseErrorMessage(v.Type().Name(), phase, err)
 	}
 }
 


### PR DESCRIPTION
https://sonarcloud.io/project/issues?open=AZEJzlOdr7OtURkdH9G8&id=ansible_receptor&tab=code

Simplified the RunPhases function to reduce SonarQube cognitive complexity from 18 to under 15 by:
- Replacing three separate if statements with a single switch on phase
- Consolidating error handling outside the switch statement
- Using type assertions with comma-ok idiom instead of type switches

This maintains identical functionality while improving code readability and reducing nesting levels.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved configuration phase handling and error reporting mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->