### PR TITLE
Add test coverage for pkg/services configuration Run() methods

### DIFF
--- a/pkg/services/command_test.go
+++ b/pkg/services/command_test.go
@@ -137,7 +137,14 @@ func TestCommandSvcCfgRun(t *testing.T) {
 		},
 	}
 
-	netceptor.MainInstance = netceptor.New(context.Background(), "test_command_svc_cfg_run")
+	// Save original instance and create cancellable context
+	originalInstance := netceptor.MainInstance
+	ctx, cancel := context.WithCancel(context.Background())
+	netceptor.MainInstance = netceptor.New(ctx, "test_command_svc_cfg_run")
+	defer func() {
+		cancel()
+		netceptor.MainInstance = originalInstance
+	}()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/services/command_test.go
+++ b/pkg/services/command_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"testing"
@@ -96,6 +97,60 @@ func TestCommandService(t *testing.T) {
 				}()
 			}
 			CommandService(mockNetceptor, tt.service, &tls.Config{}, tt.command, mockUtilsLib)
+		})
+	}
+}
+
+func TestCommandSvcCfgRun(t *testing.T) {
+	type testCase struct {
+		name                 string
+		expectError          bool
+		expectedErrorMessage string
+		configObj            CommandSvcCfg
+	}
+
+	testCases := []testCase{
+		{
+			name: "Valid command service configuration",
+			configObj: CommandSvcCfg{
+				Service: "cmd1",
+				Command: "echo hello",
+			},
+		},
+		{
+			name: "Valid command service with TLS",
+			configObj: CommandSvcCfg{
+				Service: "cmd2",
+				Command: "ls -la",
+				TLS:     "",
+			},
+		},
+		{
+			name:                 "Invalid TLS configuration",
+			expectError:          true,
+			expectedErrorMessage: "unknown TLS config invalid-tls",
+			configObj: CommandSvcCfg{
+				Service: "cmd3",
+				Command: "echo test",
+				TLS:     "invalid-tls",
+			},
+		},
+	}
+
+	netceptor.MainInstance = netceptor.New(context.Background(), "test_command_svc_cfg_run")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.configObj.Run()
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tc.expectedErrorMessage != "" && tc.expectedErrorMessage != err.Error() {
+					t.Errorf("expected error message '%s', but got '%s'", tc.expectedErrorMessage, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 		})
 	}
 }

--- a/pkg/services/udp_proxy_test.go
+++ b/pkg/services/udp_proxy_test.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"os"
+	"syscall"
 	"testing"
 
 	"github.com/ansible/receptor/pkg/logger"
@@ -539,6 +541,16 @@ func TestNetUDPWrapper_ListenUDP(t *testing.T) {
 		addr := &net.UDPAddr{IP: net.IPv6loopback, Port: 0}
 		conn, err := wrapper.ListenUDP("udp", addr)
 		if err != nil {
+			// Skip if IPv6 is not available (check for specific syscall errors)
+			if opErr, ok := err.(*net.OpError); ok {
+				if sysErr, ok := opErr.Err.(*os.SyscallError); ok {
+					if errno, ok := sysErr.Err.(syscall.Errno); ok {
+						if errno == syscall.EAFNOSUPPORT || errno == syscall.EADDRNOTAVAIL {
+							t.Skipf("IPv6 not available: %v", err)
+						}
+					}
+				}
+			}
 			t.Fatalf("expected no error, got %v", err)
 		}
 		if conn == nil {
@@ -593,7 +605,7 @@ func TestUDPProxyInboundCfgRun(t *testing.T) {
 		{
 			name: "Valid UDP proxy inbound configuration",
 			configObj: UDPProxyInboundCfg{
-				Port:          8080,
+				Port:          0, // Use ephemeral port
 				BindAddr:      "127.0.0.1",
 				RemoteNode:    "node1",
 				RemoteService: "service1",
@@ -602,7 +614,7 @@ func TestUDPProxyInboundCfgRun(t *testing.T) {
 		{
 			name: "Valid UDP proxy inbound with default bind address",
 			configObj: UDPProxyInboundCfg{
-				Port:          8081,
+				Port:          0, // Use ephemeral port
 				BindAddr:      "0.0.0.0",
 				RemoteNode:    "node2",
 				RemoteService: "service2",
@@ -610,7 +622,14 @@ func TestUDPProxyInboundCfgRun(t *testing.T) {
 		},
 	}
 
-	netceptor.MainInstance = netceptor.New(context.Background(), "test_udp_proxy_inbound_cfg_run")
+	// Save original instance and create cancellable context
+	originalInstance := netceptor.MainInstance
+	ctx, cancel := context.WithCancel(context.Background())
+	netceptor.MainInstance = netceptor.New(ctx, "test_udp_proxy_inbound_cfg_run")
+	defer func() {
+		cancel()
+		netceptor.MainInstance = originalInstance
+	}()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -650,7 +669,14 @@ func TestUDPProxyOutboundCfgRun(t *testing.T) {
 		},
 	}
 
-	netceptor.MainInstance = netceptor.New(context.Background(), "test_udp_proxy_outbound_cfg_run")
+	// Save original instance and create cancellable context
+	originalInstance := netceptor.MainInstance
+	ctx, cancel := context.WithCancel(context.Background())
+	netceptor.MainInstance = netceptor.New(ctx, "test_udp_proxy_outbound_cfg_run")
+	defer func() {
+		cancel()
+		netceptor.MainInstance = originalInstance
+	}()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/services/udp_proxy_test.go
+++ b/pkg/services/udp_proxy_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
@@ -472,6 +473,194 @@ func TestRunUDPProxyServiceOutbound(t *testing.T) {
 
 			if result != tt.expectContinue {
 				t.Errorf("Expected runUDPProxyServiceOutbound to return %v, but got %v", tt.expectContinue, result)
+			}
+		})
+	}
+}
+
+func TestNetUDPWrapper_ResolveUDPAddr(t *testing.T) {
+	wrapper := &NetUDPWrapper{}
+
+	t.Run("Valid address resolution", func(t *testing.T) {
+		addr, err := wrapper.ResolveUDPAddr("udp", "localhost:8080")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if addr == nil {
+			t.Fatal("expected non-nil address")
+		}
+		if addr.Port != 8080 {
+			t.Errorf("expected port 8080, got %d", addr.Port)
+		}
+	})
+
+	t.Run("Invalid address resolution", func(t *testing.T) {
+		_, err := wrapper.ResolveUDPAddr("udp", "invalid::address::format")
+		if err == nil {
+			t.Fatal("expected error for invalid address, got nil")
+		}
+	})
+
+	t.Run("IPv4 address resolution", func(t *testing.T) {
+		addr, err := wrapper.ResolveUDPAddr("udp", "127.0.0.1:9999")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if addr == nil {
+			t.Fatal("expected non-nil address")
+		}
+		if addr.IP.String() != "127.0.0.1" {
+			t.Errorf("expected IP 127.0.0.1, got %s", addr.IP.String())
+		}
+	})
+}
+
+func TestNetUDPWrapper_ListenUDP(t *testing.T) {
+	wrapper := &NetUDPWrapper{}
+
+	t.Run("Successful listen on random port", func(t *testing.T) {
+		addr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+		conn, err := wrapper.ListenUDP("udp", addr)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if conn == nil {
+			t.Fatal("expected non-nil connection")
+		}
+		defer conn.Close()
+
+		localAddr := conn.LocalAddr()
+		if localAddr == nil {
+			t.Fatal("expected non-nil local address")
+		}
+	})
+
+	t.Run("Listen on IPv6", func(t *testing.T) {
+		addr := &net.UDPAddr{IP: net.IPv6loopback, Port: 0}
+		conn, err := wrapper.ListenUDP("udp", addr)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if conn == nil {
+			t.Fatal("expected non-nil connection")
+		}
+		defer conn.Close()
+	})
+}
+
+func TestNetUDPWrapper_DialUDP(t *testing.T) {
+	wrapper := &NetUDPWrapper{}
+
+	t.Run("Successful dial", func(t *testing.T) {
+		raddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9999}
+		conn, err := wrapper.DialUDP("udp", nil, raddr)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if conn == nil {
+			t.Fatal("expected non-nil connection")
+		}
+		defer conn.Close()
+
+		remoteAddr := conn.RemoteAddr()
+		if remoteAddr == nil {
+			t.Fatal("expected non-nil remote address")
+		}
+	})
+
+	t.Run("Dial with local address", func(t *testing.T) {
+		laddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}
+		raddr := &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 9998}
+		conn, err := wrapper.DialUDP("udp", laddr, raddr)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if conn == nil {
+			t.Fatal("expected non-nil connection")
+		}
+		defer conn.Close()
+	})
+}
+
+func TestUDPProxyInboundCfgRun(t *testing.T) {
+	type testCase struct {
+		name        string
+		expectError bool
+		configObj   UDPProxyInboundCfg
+	}
+
+	testCases := []testCase{
+		{
+			name: "Valid UDP proxy inbound configuration",
+			configObj: UDPProxyInboundCfg{
+				Port:          8080,
+				BindAddr:      "127.0.0.1",
+				RemoteNode:    "node1",
+				RemoteService: "service1",
+			},
+		},
+		{
+			name: "Valid UDP proxy inbound with default bind address",
+			configObj: UDPProxyInboundCfg{
+				Port:          8081,
+				BindAddr:      "0.0.0.0",
+				RemoteNode:    "node2",
+				RemoteService: "service2",
+			},
+		},
+	}
+
+	netceptor.MainInstance = netceptor.New(context.Background(), "test_udp_proxy_inbound_cfg_run")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.configObj.Run()
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestUDPProxyOutboundCfgRun(t *testing.T) {
+	type testCase struct {
+		name        string
+		expectError bool
+		configObj   UDPProxyOutboundCfg
+	}
+
+	testCases := []testCase{
+		{
+			name: "Valid UDP proxy outbound configuration",
+			configObj: UDPProxyOutboundCfg{
+				Service: "udp1",
+				Address: "127.0.0.1:9090",
+			},
+		},
+		{
+			name: "Valid UDP proxy outbound with different address",
+			configObj: UDPProxyOutboundCfg{
+				Service: "udp2",
+				Address: "localhost:9091",
+			},
+		},
+	}
+
+	netceptor.MainInstance = netceptor.New(context.Background(), "test_udp_proxy_outbound_cfg_run")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.configObj.Run()
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
 			}
 		})
 	}

--- a/pkg/services/unix_proxy_test.go
+++ b/pkg/services/unix_proxy_test.go
@@ -77,3 +77,118 @@ func TestUnixProxyServiceOutbound(t *testing.T) {
 		})
 	}
 }
+
+func TestUnixProxyInboundCfgRun(t *testing.T) {
+	type testCase struct {
+		name                 string
+		expectError          bool
+		expectedErrorMessage string
+		configObj            UnixProxyInboundCfg
+	}
+
+	testCases := []testCase{
+		{
+			name: "Valid unix proxy inbound configuration",
+			configObj: UnixProxyInboundCfg{
+				Filename:      "/tmp/test-receptor-unix-inbound.sock",
+				Permissions:   0600,
+				RemoteNode:    "node1",
+				RemoteService: "service1",
+			},
+		},
+		{
+			name: "Valid unix proxy inbound with custom permissions",
+			configObj: UnixProxyInboundCfg{
+				Filename:      "/tmp/test-receptor-unix-inbound2.sock",
+				Permissions:   0660,
+				RemoteNode:    "node2",
+				RemoteService: "service2",
+			},
+		},
+		{
+			name:                 "Invalid TLS configuration",
+			expectError:          true,
+			expectedErrorMessage: "unknown TLS config invalid-tls",
+			configObj: UnixProxyInboundCfg{
+				Filename:      "/tmp/test-receptor-unix-inbound3.sock",
+				Permissions:   0600,
+				RemoteNode:    "node3",
+				RemoteService: "service3",
+				TLS:           "invalid-tls",
+			},
+		},
+	}
+
+	netceptor.MainInstance = netceptor.New(context.Background(), "test_unix_proxy_inbound_cfg_run")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clean up socket file if it exists
+			defer os.Remove(tc.configObj.Filename)
+
+			err := tc.configObj.Run()
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tc.expectedErrorMessage != "" && tc.expectedErrorMessage != err.Error() {
+					t.Errorf("expected error message '%s', but got '%s'", tc.expectedErrorMessage, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestUnixProxyOutboundCfgRun(t *testing.T) {
+	type testCase struct {
+		name                 string
+		expectError          bool
+		expectedErrorMessage string
+		configObj            UnixProxyOutboundCfg
+	}
+
+	testCases := []testCase{
+		{
+			name: "Valid unix proxy outbound configuration",
+			configObj: UnixProxyOutboundCfg{
+				Service:  "unix1",
+				Filename: "/tmp/test-receptor-unix-outbound.sock",
+			},
+		},
+		{
+			name: "Valid unix proxy outbound with different socket",
+			configObj: UnixProxyOutboundCfg{
+				Service:  "unix2",
+				Filename: "/tmp/test-receptor-unix-outbound2.sock",
+			},
+		},
+		{
+			name:                 "Invalid TLS configuration",
+			expectError:          true,
+			expectedErrorMessage: "unknown TLS config invalid-tls",
+			configObj: UnixProxyOutboundCfg{
+				Service:  "unix3",
+				Filename: "/tmp/test-receptor-unix-outbound3.sock",
+				TLS:      "invalid-tls",
+			},
+		},
+	}
+
+	netceptor.MainInstance = netceptor.New(context.Background(), "test_unix_proxy_outbound_cfg_run")
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.configObj.Run()
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected error but got nil")
+				} else if tc.expectedErrorMessage != "" && tc.expectedErrorMessage != err.Error() {
+					t.Errorf("expected error message '%s', but got '%s'", tc.expectedErrorMessage, err.Error())
+				}
+			} else if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/services/unix_proxy_test.go
+++ b/pkg/services/unix_proxy_test.go
@@ -83,50 +83,69 @@ func TestUnixProxyInboundCfgRun(t *testing.T) {
 		name                 string
 		expectError          bool
 		expectedErrorMessage string
-		configObj            UnixProxyInboundCfg
+		getConfigObj         func(sockPath string) UnixProxyInboundCfg
 	}
 
 	testCases := []testCase{
 		{
 			name: "Valid unix proxy inbound configuration",
-			configObj: UnixProxyInboundCfg{
-				Filename:      "/tmp/test-receptor-unix-inbound.sock",
-				Permissions:   0600,
-				RemoteNode:    "node1",
-				RemoteService: "service1",
+			getConfigObj: func(sockPath string) UnixProxyInboundCfg {
+				return UnixProxyInboundCfg{
+					Filename:      sockPath,
+					Permissions:   0o600,
+					RemoteNode:    "node1",
+					RemoteService: "service1",
+				}
 			},
 		},
 		{
 			name: "Valid unix proxy inbound with custom permissions",
-			configObj: UnixProxyInboundCfg{
-				Filename:      "/tmp/test-receptor-unix-inbound2.sock",
-				Permissions:   0660,
-				RemoteNode:    "node2",
-				RemoteService: "service2",
+			getConfigObj: func(sockPath string) UnixProxyInboundCfg {
+				return UnixProxyInboundCfg{
+					Filename:      sockPath,
+					Permissions:   0o660,
+					RemoteNode:    "node2",
+					RemoteService: "service2",
+				}
 			},
 		},
 		{
 			name:                 "Invalid TLS configuration",
 			expectError:          true,
 			expectedErrorMessage: "unknown TLS config invalid-tls",
-			configObj: UnixProxyInboundCfg{
-				Filename:      "/tmp/test-receptor-unix-inbound3.sock",
-				Permissions:   0600,
-				RemoteNode:    "node3",
-				RemoteService: "service3",
-				TLS:           "invalid-tls",
+			getConfigObj: func(sockPath string) UnixProxyInboundCfg {
+				return UnixProxyInboundCfg{
+					Filename:      sockPath,
+					Permissions:   0o600,
+					RemoteNode:    "node3",
+					RemoteService: "service3",
+					TLS:           "invalid-tls",
+				}
 			},
 		},
 	}
 
-	netceptor.MainInstance = netceptor.New(context.Background(), "test_unix_proxy_inbound_cfg_run")
+	// Save original instance and create cancellable context
+	originalInstance := netceptor.MainInstance
+	ctx, cancel := context.WithCancel(context.Background())
+	netceptor.MainInstance = netceptor.New(ctx, "test_unix_proxy_inbound_cfg_run")
+	defer func() {
+		cancel()
+		netceptor.MainInstance = originalInstance
+	}()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Clean up socket file if it exists
-			defer os.Remove(tc.configObj.Filename)
+			// Create unique socket path for this subtest
+			tmpDir := t.TempDir()
+			sockPath := tmpDir + "/test.sock"
+			configObj := tc.getConfigObj(sockPath)
 
-			err := tc.configObj.Run()
+			// Clean up socket file if it exists before and after
+			os.Remove(sockPath)
+			defer os.Remove(sockPath)
+
+			err := configObj.Run()
 			if tc.expectError {
 				if err == nil {
 					t.Error("expected error but got nil")
@@ -145,41 +164,59 @@ func TestUnixProxyOutboundCfgRun(t *testing.T) {
 		name                 string
 		expectError          bool
 		expectedErrorMessage string
-		configObj            UnixProxyOutboundCfg
+		getConfigObj         func(sockPath string) UnixProxyOutboundCfg
 	}
 
 	testCases := []testCase{
 		{
 			name: "Valid unix proxy outbound configuration",
-			configObj: UnixProxyOutboundCfg{
-				Service:  "unix1",
-				Filename: "/tmp/test-receptor-unix-outbound.sock",
+			getConfigObj: func(sockPath string) UnixProxyOutboundCfg {
+				return UnixProxyOutboundCfg{
+					Service:  "unix1",
+					Filename: sockPath,
+				}
 			},
 		},
 		{
 			name: "Valid unix proxy outbound with different socket",
-			configObj: UnixProxyOutboundCfg{
-				Service:  "unix2",
-				Filename: "/tmp/test-receptor-unix-outbound2.sock",
+			getConfigObj: func(sockPath string) UnixProxyOutboundCfg {
+				return UnixProxyOutboundCfg{
+					Service:  "unix2",
+					Filename: sockPath,
+				}
 			},
 		},
 		{
 			name:                 "Invalid TLS configuration",
 			expectError:          true,
 			expectedErrorMessage: "unknown TLS config invalid-tls",
-			configObj: UnixProxyOutboundCfg{
-				Service:  "unix3",
-				Filename: "/tmp/test-receptor-unix-outbound3.sock",
-				TLS:      "invalid-tls",
+			getConfigObj: func(sockPath string) UnixProxyOutboundCfg {
+				return UnixProxyOutboundCfg{
+					Service:  "unix3",
+					Filename: sockPath,
+					TLS:      "invalid-tls",
+				}
 			},
 		},
 	}
 
-	netceptor.MainInstance = netceptor.New(context.Background(), "test_unix_proxy_outbound_cfg_run")
+	// Save original instance and create cancellable context
+	originalInstance := netceptor.MainInstance
+	ctx, cancel := context.WithCancel(context.Background())
+	netceptor.MainInstance = netceptor.New(ctx, "test_unix_proxy_outbound_cfg_run")
+	defer func() {
+		cancel()
+		netceptor.MainInstance = originalInstance
+	}()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.configObj.Run()
+			// Create unique socket path for this subtest
+			tmpDir := t.TempDir()
+			sockPath := tmpDir + "/test.sock"
+			configObj := tc.getConfigObj(sockPath)
+
+			err := configObj.Run()
 			if tc.expectError {
 				if err == nil {
 					t.Error("expected error but got nil")


### PR DESCRIPTION
This commit adds comprehensive tests for previously untested configuration Run() methods in the services package.

Changes:
- Add tests for NetUDPWrapper methods (ResolveUDPAddr, ListenUDP, DialUDP)
- Add tests for UDPProxyInboundCfg.Run() and UDPProxyOutboundCfg.Run()
- Add tests for CommandSvcCfg.Run() with TLS validation
- Add tests for UnixProxyInboundCfg.Run() and UnixProxyOutboundCfg.Run()

Tests added:
- 8 new test functions with 20 sub-test cases
- All tests follow existing patterns and use table-driven approach
- Error cases validated with expected error messages

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for command service, UDP proxy, and Unix proxy configurations.
  * Added table-driven scenarios covering TLS validation with exact-error assertions, address resolution for localhost/IPv4/IPv6, UDP bind/dial behaviors, and Unix socket permission/target variations.
  * Tests run with isolated cancellable runtime instances and include per-test setup/cleanup for temporary sockets and conditional IPv6 skipping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->