### PR TITLE
Enforce HTTPS protocol in curl commands for kind binary downloads

### DIFF
--- a/.github/workflows/coverage_reporting.yml
+++ b/.github/workflows/coverage_reporting.yml
@@ -33,7 +33,7 @@ jobs:
           sudo cp ./receptor /usr/local/bin/receptor
 
       - name: Download kind binary
-        run: curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 && chmod +x ./kind
+        run: curl --proto '=https' --tlsv1.2 -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 && chmod +x ./kind
 
       - name: Create k8s cluster
         run: ./kind create cluster --wait 60s

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,7 +52,7 @@ jobs:
           sudo cp ./receptor /usr/local/bin/receptor
 
       - name: Download kind binary
-        run: curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 && chmod +x ./kind
+        run: curl --proto '=https' --tlsv1.2 -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 && chmod +x ./kind
 
       - name: Create k8s cluster
         run: ./kind create cluster --wait 60s

--- a/.github/workflows/test-reporting.yml
+++ b/.github/workflows/test-reporting.yml
@@ -32,7 +32,7 @@ jobs:
           sudo cp ./receptor /usr/local/bin/receptor
 
       - name: Download kind binary
-        run: curl -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 && chmod +x ./kind
+        run: curl --proto '=https' --tlsv1.2 -Lo ./kind https://kind.sigs.k8s.io/dl/latest/kind-linux-amd64 && chmod +x ./kind
 
       - name: Create k8s cluster
         run: ./kind create cluster --wait 60s


### PR DESCRIPTION
To Address Sonarcube issues for not enforcing https

Add --proto '=https' --tlsv1.2 flags to curl commands downloading kind binary from kind.sigs.k8s.io to ensure HTTPS is enforced even on redirects. This addresses SonarQube security warnings about potential insecure redirects.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened CI/test workflow downloads to enforce HTTPS-only connections and require TLS 1.2+, improving security and reliability when fetching required tooling for PR and reporting jobs. No functional changes to the downloaded tool or post-download permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->