### PR TITLE
Fix tests for Sonar security rating and flakiness

### DIFF
--- a/pkg/services/unix_proxy_test.go
+++ b/pkg/services/unix_proxy_test.go
@@ -136,16 +136,15 @@ func TestUnixProxyInboundCfgRun(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create unique socket path for this subtest
-			tmpDir := t.TempDir()
+			tmpDir, err := os.MkdirTemp("", "upi")
+			if err != nil {
+				t.Fatalf("failed to create temp dir: %v", err)
+			}
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
 			sockPath := tmpDir + "/test.sock"
 			configObj := tc.getConfigObj(sockPath)
 
-			// Clean up socket file if it exists before and after
-			os.Remove(sockPath)
-			defer os.Remove(sockPath)
-
-			err := configObj.Run()
+			err = configObj.Run()
 			if tc.expectError {
 				if err == nil {
 					t.Error("expected error but got nil")

--- a/pkg/utils/flock_test.go
+++ b/pkg/utils/flock_test.go
@@ -16,6 +16,13 @@ func TestTryFLock(t *testing.T) {
 	type args struct {
 		filename string
 	}
+
+	flockTemDir, err := os.MkdirTemp("", "flock-test-*")
+	if err != nil {
+		t.Fatalf("Error creating flock test temporary directory: %v", err)
+	}
+	defer os.RemoveAll(flockTemDir)
+
 	tests := []struct {
 		name    string
 		args    args
@@ -25,7 +32,7 @@ func TestTryFLock(t *testing.T) {
 		{
 			name: "Positive",
 			args: args{
-				filename: filepath.Join(os.TempDir(), "good_flock_listener"),
+				filename: filepath.Join(flockTemDir, "good_flock_listener"),
 			},
 			want:    &utils.FLock{Fd: 0},
 			wantErr: false,

--- a/pkg/utils/flock_test.go
+++ b/pkg/utils/flock_test.go
@@ -17,11 +17,11 @@ func TestTryFLock(t *testing.T) {
 		filename string
 	}
 
-	flockTemDir, err := os.MkdirTemp("", "flock-test-*")
+	flockTempDir, err := os.MkdirTemp("", "flock-test-*")
 	if err != nil {
 		t.Fatalf("Error creating flock test temporary directory: %v", err)
 	}
-	defer os.RemoveAll(flockTemDir)
+	defer os.RemoveAll(flockTempDir)
 
 	tests := []struct {
 		name    string
@@ -32,7 +32,7 @@ func TestTryFLock(t *testing.T) {
 		{
 			name: "Positive",
 			args: args{
-				filename: filepath.Join(flockTemDir, "good_flock_listener"),
+				filename: filepath.Join(flockTempDir, "good_flock_listener"),
 			},
 			want:    &utils.FLock{Fd: 0},
 			wantErr: false,

--- a/pkg/utils/unixsock_test.go
+++ b/pkg/utils/unixsock_test.go
@@ -22,6 +22,12 @@ func TestUnixSocketListen(t *testing.T) {
 
 	badFilename := ""
 
+	unixSockTempDir, err := os.MkdirTemp("", "unixsock-test-*")
+	if err != nil {
+		t.Fatalf("Error creating unix socket test temporary directory: %v", err)
+	}
+	defer os.RemoveAll(unixSockTempDir)
+
 	tests := []struct {
 		name    string
 		args    args
@@ -32,7 +38,7 @@ func TestUnixSocketListen(t *testing.T) {
 		{
 			name: "Positive",
 			args: args{
-				filename:    filepath.Join(os.TempDir(), "good_unixsock_listener"),
+				filename:    filepath.Join(unixSockTempDir, "good_unixsock_listener"),
 				permissions: 0x0400,
 			},
 			wantErr: false,

--- a/pkg/workceptor/python_test.go
+++ b/pkg/workceptor/python_test.go
@@ -66,7 +66,7 @@ func createReceptorPythonWorkerScript() error {
 		return fmt.Errorf("Error writing to %s: %v", filename, err)
 	}
 
-	err = os.Chmod(absoluteFilename, 0o755)
+	err = os.Chmod(absoluteFilename, 0o750)
 	if err != nil {
 		return fmt.Errorf("Error making %s executable: %v", absoluteFilename, err)
 	}


### PR DESCRIPTION
Fixes some tests with recommendations from Sonar security scan related to file permissions and TempDir usage. Also fixes a flakiness issue where unix socket paths could become too long (over 104 characters) causing EINVAL errors during some test runs.

AAP-71675

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test isolation by using dedicated temporary directories for individual test cases, avoiding cross-run interference
  * Ensured robust cleanup to reliably remove test artifacts after runs
  * Tightened file permissions on test fixtures to reduce execution privileges and improve security
<!-- end of auto-generated comment: release notes by coderabbit.ai -->