### PR TITLE
Update to UBI 9.7 for Go 1.25.9

### DIFF
--- a/packaging/container/Dockerfile
+++ b/packaging/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5 AS builder
+FROM registry.access.redhat.com/ubi9/ubi:9.8 AS builder
 ARG VERSION
 
 RUN dnf -y update && \
@@ -9,7 +9,7 @@ ADD source.tar.gz /source
 WORKDIR /source
 RUN make VERSION=${VERSION}
 
-FROM registry.access.redhat.com/ubi9/ubi:9.5
+FROM registry.access.redhat.com/ubi9/ubi:9.8
 ARG VERSION
 
 LABEL license="ASL2"


### PR DESCRIPTION
[AAP-71324](https://redhat.atlassian.net/browse/AAP-71324), [AAP-71627](https://redhat.atlassian.net/browse/AAP-71627), [AAP-71640](https://redhat.atlassian.net/browse/AAP-71640)

Updates base image from ubi9:9.5 to ubi9:9.7 which includes golang-1.25.9-1.el9_7