### PR TITLE
fix(lint): pin ruff and lock the rule selection to stop CI drift

### DIFF
--- a/receptorctl/noxfile.py
+++ b/receptorctl/noxfile.py
@@ -1,4 +1,3 @@
-import subprocess
 from glob import iglob
 
 import nox.command

--- a/receptorctl/pyproject.toml
+++ b/receptorctl/pyproject.toml
@@ -32,7 +32,7 @@ test = [
   "coverage",
   "pytest",
   "pytest-cov",
-  "ruff",
+  "ruff==0.16.0",
 ]
 
 [project.scripts]
@@ -40,6 +40,11 @@ receptorctl = "receptorctl:run"
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
+# Pin the enabled rule set explicitly so an upgraded ruff cannot silently
+# expand it and flag pre-existing code. Matches ruff's historical default.
+select = ["E4", "E7", "E9", "F"]
 
 [tool.coverage.run]
 omit = ["tests/*"]


### PR DESCRIPTION
## What
- Pin `ruff==0.16.0` in receptorctl's test dependencies.
- Add explicit `[tool.ruff.lint] select = ["E4", "E7", "E9", "F"]` (ruff's historical default).
- Remove one unused `import subprocess` in noxfile.py (F401).

## Why
`Lint receptorctl / check_style` installs ruff unpinned and the config
declared no `select`, so it relied on ruff's built-in default rule set.
Newer ruff releases expand that default, so check_style began failing on
pre-existing code (54 findings: UP032, BLE001, I001, TRY/SIM/PLR/RUF, ...)
with no source change on any PR. This is the same unpinned-dependency
drift #1563 hardens the build workflows against, applied to the linter.

Pinning ruff and making the ruleset explicit stops the drift
deterministically. Adopting the broader rules (SIM/TRY/UP/etc.) can be a
separate, deliberate opt-in along with the code cleanup that entails.

## Verification
- `ruff check .` -> All checks passed
- `ruff format --check .` -> unchanged (14 files already formatted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed unused internal configuration code.
  * Pinned the code-quality tool version for more consistent development and validation environments.
  * Explicitly preserved the established linting rule set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->